### PR TITLE
19 ipfs testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,4 +250,11 @@ set(TEMP_DIR ${CMAKE_BINARY_DIR}/Testing/Temporary)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp)
 set(JSONCPP_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/jsoncpp.cpp)
 
+# utilities
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/cliwrap.py
+  ${DCMQI_INSTALL_BIN_DIR}
+  COPYONLY
+  )
+
 add_subdirectory("apps")

--- a/apps/seg/Testing/CMakeLists.txt
+++ b/apps/seg/Testing/CMakeLists.txt
@@ -31,3 +31,11 @@ add_test(NAME ${MODULE_NAME}_makeSEG
         --dicomImageFiles ${BASELINE}/01.dcm,${BASELINE}/02.dcm,${BASELINE}/03.dcm
         --segDICOMFile ${TEMP_DIR}/liver.dcm
        )
+
+add_test(NAME ${MODULE_NAME}_BrainlabExampleSEG1
+         COMMAND
+         ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/cliwrap.py
+           ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/segimage2itkimage
+           http://ipfs.io/ipfs/QmTftaDyQCNFsceFwR2kkRMdz5VBbCzzD64VVEWiKRA2Go/BLSEGTest1/SEG/brainlab.dcm
+           ${TEMP_DIR}
+       )

--- a/util/cliwrap.py
+++ b/util/cliwrap.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Allows traditional file-system based command line interface (cli)
+programs to work on data pulled from urls
+
+ cliwrap.py seg2itk http://ipfs.io/ipfs/QmTftaDyQCNFsceFwR2kkRMdz5VBbCzzD64VVEWiKRA2Go/BLSEGTest1/SEG/brainlab.dcm /tmp/out.nrrd
+
+"""
+
+import json
+import os
+import sys
+import subprocess
+import tempfile
+import urllib
+
+# directory to stage files to and from
+workDirectory = tempfile.mkdtemp()
+
+def stageFromHTTP(arg):
+  fileName = os.path.split(arg)[1]
+  filePath = tempfile.mktemp(suffix=fileName, dir=workDirectory)
+  urllib.urlretrieve(arg, filePath)
+  return filePath
+
+def transformArg(arg):
+  if arg.startswith('http://'):
+    return stageFromHTTP(arg)
+  return arg
+
+transformedArgs = [sys.argv[1]]
+for arg in sys.argv[2:]:
+  transformedArgs.append(transformArg(arg))
+
+cliProcess = subprocess.check_call(transformedArgs)


### PR DESCRIPTION
WIP: do not merge.  This is for discussion.

This adds a cliwrap python utility to support running the programs with url inputs.

The utility is used to run a test where the data is pulled from a url.

The url comes from ipfs.  If ipfs proves useful, cliwrap can be extended to directly use ipfs to copy and serve test data, but this part requires more testing and discussion.