### PR TITLE
ENH: add support for multiple source instances per seg frame

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ os:
 clone_depth: 1
 skip_tags: true
 clone_folder: c:\dcmqi
-install:
-  - cinst cmake
 configuration:
   - Release
 platform:

--- a/doc/seg-example.json
+++ b/doc/seg-example.json
@@ -12,12 +12,12 @@
   "segmentAttributes": [{
     "LabelID": 216,
     "SegmentDescription": "Liver Segmentation",
-    "SegmentedPropertyCategoryCode": {
+    "SegmentedPropertyCategoryCodeSequence": {
       "codeValue": "T-D0050",
       "codingSchemeDesignator": "SRT",
       "codeMeaning": "Tissue"
     },
-    "SegmentedPropertyType": {
+    "SegmentedPropertyTypeCodeSequence": {
       "codeValue": "T-62000",
       "codingSchemeDesignator": "SRT",
       "codeMeaning": "Liver"

--- a/lib/ImageSEGConverter.h
+++ b/lib/ImageSEGConverter.h
@@ -73,7 +73,7 @@ namespace dcmqi {
     private:
         static IODGeneralEquipmentModule::EquipmentInfo getEquipmentInfo();
         static ContentIdentificationMacro createContentIdentificationInformation();
-        static vector<int> getSliceMapForSegmentation2DerivationImage(const vector<string> &dicomImageFileNames,
+        static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<string> &dicomImageFileNames,
                                                                       const itk::Image<short, 3>::Pointer &labelImage);
 
         static int getImageDirections(FGInterface &fgInterface, ImageType::DirectionType &dir);

--- a/lib/JSONMetaInformationHandler.cpp
+++ b/lib/JSONMetaInformationHandler.cpp
@@ -68,14 +68,16 @@ namespace dcmqi {
             if ((*it)->getSegmentAlgorithmName().length() > 0)
                 segment["SegmentAlgorithmName"] = (*it)->getSegmentAlgorithmName();
 
-            if ((*it)->getSegmentedPropertyCategoryCode())
-                segment["SegmentedPropertyCategoryCode"] = codeSequence2Json((*it)->getSegmentedPropertyCategoryCode());
+            if ((*it)->getSegmentedPropertyCategoryCode()){
+                segment["SegmentedPropertyCategoryCodeSequence"] = codeSequence2Json((*it)->getSegmentedPropertyCategoryCode());
+                cout << (*it)->getSegmentedPropertyCategoryCode() << endl;
+              }
 
             if ((*it)->getSegmentedPropertyType())
-                segment["SegmentedPropertyType"] = codeSequence2Json((*it)->getSegmentedPropertyType());
+                segment["SegmentedPropertyTypeCodeSequence"] = codeSequence2Json((*it)->getSegmentedPropertyType());
 
             if ((*it)->getSegmentedPropertyTypeModifier())
-                segment["SegmentedPropertyTypeModifier"] = codeSequence2Json((*it)->getSegmentedPropertyTypeModifier());
+                segment["SegmentedPropertyTypeModifierCodeSequence"] = codeSequence2Json((*it)->getSegmentedPropertyTypeModifier());
 
             if ((*it)->getAnatomicRegion())
                 segment["AnatomicRegion"] = codeSequence2Json((*it)->getAnatomicRegion());
@@ -134,13 +136,13 @@ namespace dcmqi {
             if (!segmentDescription.isNull()) {
                 segmentAttribute->setSegmentDescription(segmentDescription.asString());
             }
-            Json::Value elem = segment["SegmentedPropertyCategoryCode"];
+            Json::Value elem = segment["SegmentedPropertyCategoryCodeSequence"];
             if (!elem.isNull()) {
                 segmentAttribute->setSegmentedPropertyCategoryCode(elem.get("codeValue", "T-D0050").asString(),
                                                                    elem.get("codingSchemeDesignator", "SRT").asString(),
                                                                    elem.get("codeMeaning", "Tissue").asString());
             }
-            elem = segment["SegmentedPropertyType"];
+            elem = segment["SegmentedPropertyTypeCodeSequence"];
             if (!elem.isNull()) {
                 segmentAttribute->setSegmentedPropertyType(elem.get("codeValue", "T-D0050").asString(),
                                                            elem.get("codingSchemeDesignator", "SRT").asString(),
@@ -194,5 +196,3 @@ namespace dcmqi {
     }
 
 }
-
-


### PR DESCRIPTION
 - lists of image instances from the input DICOM file list that match origin
 of the segmentation slice are maintained
 - instances that are not matchin are skipped

fixes #47 (at least, for the BMMR use case)