### PR TITLE
BUG: remove explicit mentions of 'Iowa' and more

### DIFF
--- a/doc/seg-schema.json
+++ b/doc/seg-schema.json
@@ -19,6 +19,24 @@
         {"properties" : {"default" : "Session1"}}]
       },
 
+      "ContentLabel":
+      { "allOf" :
+        [{"$ref" : "http://qiicr.org/schema/dcmqi/common-schema.json#/definitions/CS"},
+        {"properties" : {"default" : "SEGMENTATION"}}]
+      },
+
+      "ContentDescription":
+      { "allOf" :
+        [{"$ref" : "http://qiicr.org/schema/dcmqi/common-schema.json#/definitions/LO"},
+        {"properties" : {"default" : "Image segmentation"}}]
+      },
+
+      "ClinicalTrialCoordinatingCenterName":
+      { "allOf" :
+        [{"$ref" : "http://qiicr.org/schema/dcmqi/common-schema.json#/definitions/LO"},
+        {"properties" : {"default" : "dcmqi"}}]
+      },
+
       "ClinicalTrialTimePointID":
       { "allOf" :
         [{"$ref" : "http://qiicr.org/schema/dcmqi/common-schema.json#/definitions/LO"},

--- a/lib/Exceptions.h
+++ b/lib/Exceptions.h
@@ -4,6 +4,14 @@
 #include <vector>
 #include <map>
 
+#define CHECK_COND(condition) \
+  do { \
+    if (condition.bad()) { \
+      std::cerr << "Condition failed: " << condition.text() << " in " __FILE__ << ":" << __LINE__ << std::endl; \
+      throw -1; \
+    } \
+} while (0);
+
 using namespace std;
 
 namespace dcmqi {

--- a/lib/ImageSEGConverter.h
+++ b/lib/ImageSEGConverter.h
@@ -68,11 +68,10 @@ namespace dcmqi {
                                              const std::string &metaDataFileName, const std::string &outputFileName);
 
         static int dcmSegmentation2itkimage(const string &inputSEGFileName, const string &outputDirName);
-        static int CHECK_COND(const OFCondition& condition);
 
     private:
         static IODGeneralEquipmentModule::EquipmentInfo getEquipmentInfo();
-        static ContentIdentificationMacro createContentIdentificationInformation();
+        static ContentIdentificationMacro createContentIdentificationInformation(JSONMetaInformationHandler&);
         static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<string> &dicomImageFileNames,
                                                                       const itk::Image<short, 3>::Pointer &labelImage);
 

--- a/lib/JSONMetaInformationHandler.cpp
+++ b/lib/JSONMetaInformationHandler.cpp
@@ -26,12 +26,11 @@ namespace dcmqi {
             try {
                 ifstream metainfoStream(this->filename, ifstream::binary);
 
-                Json::Value root;
-                metainfoStream >> root;
-                this->readSeriesAttributes(root);
-                this->readSegmentAttributes(root);
+                metainfoStream >> this->metaInfoRoot;
+                this->readSeriesAttributes(this->metaInfoRoot);
+                this->readSegmentAttributes(this->metaInfoRoot);
             } catch (exception& e) {
-                cout << e.what() << '\n';
+                cout << e.what() << endl;
                 return false;
             }
             return true;

--- a/lib/JSONMetaInformationHandler.h
+++ b/lib/JSONMetaInformationHandler.h
@@ -41,6 +41,9 @@ namespace dcmqi {
         string instanceNumber;
         string bodyPartExamined;
 
+        // need to revisit
+        Json::Value metaInfoRoot;
+
     protected:
         bool isValid(const char *filename);
 


### PR DESCRIPTION
- parameterize attributes in the schema
- add access to metaInfoRoot directly in the JSON class - that class will need to be revisited
- move CHECK_COND out of the class into a macro (otherwise it is not helpful, as its main purpose is to help with the speicific location of the exception)