### PR TITLE
add jsonlint testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ compiler:
 - clang
 before_script:
 - clang --version
+- npm install jsonlint -g
 - pwd && mkdir -p /Users/travis/build/QIICR/dcmqi-build
 - cd /Users/travis/build/QIICR
 - wget --no-check-certificate https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,3 +257,5 @@ set(JSONCPP_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/jsoncpp.cpp)
 add_subdirectory("libsrc")
 
 add_subdirectory("apps")
+
+add_subdirectory("doc")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ configuration:
 platform:
   - x64
 before_build:
+  - npm install jsonlint -g
   - cmd: cmake --version
   - ps: $client = new-object System.Net.WebClient;$client.DownloadFile("https://github.com/fedorov/zlib/releases/download/zlib-dcmqi-1.2.3-VS12-Win64-Release/zlib-dcmqi.zip", "C:\zlib-dcmqi.zip")
   - cmd: 7z x C:\zlib-dcmqi.zip -oC:\zlib-install

--- a/circle.yml
+++ b/circle.yml
@@ -15,6 +15,7 @@ dependencies:
     - sudo apt-get update
     - cd ~
     - wget --no-check-certificate https://cmake.org/files/v3.6/cmake-3.6.0-rc4-Linux-x86_64.tar.gz
+    - npm install jsonlint -g
     - tar zxf cmake-3.6.0-rc4-Linux-x86_64.tar.gz
   post:
     - export PATH=${CMAKE_BIN}:${PATH} && mkdir -p ~/dcmqi-build && cd ~/dcmqi-build && cmake ../dcmqi && make

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,12 @@
+file(GLOB json_files
+  *.json
+  )
+
+message(${json_files})
+
+foreach(json_file ${json_files})
+  get_filename_component(json_name ${json_file} NAME_WE)
+  add_test(NAME jsonlint_${json_name}
+    COMMAND jsonlint ${json_file})
+endforeach()
+


### PR DESCRIPTION
All json files will be tested with jsonlint. npm install of jsonlint added to
all CI platforms configs. Related to #27, but just basic JSON validity checks.