### PR TITLE
ENH: add more common tid1500 example

### DIFF
--- a/apps/sr/Testing/CMakeLists.txt
+++ b/apps/sr/Testing/CMakeLists.txt
@@ -10,3 +10,11 @@ COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${MODULE_NAME}
   --imageLibraryDataDir ${CMAKE_SOURCE_DIR}/data/ct-3slice
   --compositeContextDataDir ${CMAKE_SOURCE_DIR}/data/sr-example
   )
+
+add_test(NAME ${MODULE_NAME}_ct-liver
+COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${MODULE_NAME}
+  --metaDataFileName ${CMAKE_SOURCE_DIR}/doc/sr-tid1500-ct-liver-example.json
+  --outputFileName ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.dcm
+  --imageLibraryDataDir ${CMAKE_SOURCE_DIR}/data/ct-3slice
+  --compositeContextDataDir ${CMAKE_SOURCE_DIR}/data/ct-3slice
+  )

--- a/apps/sr/tid1500writer.cxx
+++ b/apps/sr/tid1500writer.cxx
@@ -155,7 +155,9 @@ int main(int argc, char** argv){
 
     OFCHECK(measurements.setSourceSeriesForSegmentation(measurementGroup["SourceSeriesForImageSegmentation"].asString().c_str()).good());
 
-    OFCHECK(measurements.setRealWorldValueMap(DSRCompositeReferenceValue(UID_RealWorldValueMappingStorage, measurementGroup["rwvmMapUsedForMeasurement"].asCString())).good());
+    if(measurementGroup.isMember("rwvmMapUsedForMeasurement")){
+      OFCHECK(measurements.setRealWorldValueMap(DSRCompositeReferenceValue(UID_RealWorldValueMappingStorage, measurementGroup["rwvmMapUsedForMeasurement"].asCString())).good());
+    }
 
     DSRImageReferenceValue segment(UID_SegmentationStorage, measurementGroup["segmentationSOPInstanceUID"].asString().c_str());
     segment.getSegmentList().addItem(measurementGroup["ReferencedSegment"].asInt());
@@ -172,10 +174,12 @@ int main(int argc, char** argv){
       measurementGroup["FindingSite"]["codeMeaning"].asCString());
     OFCHECK(measurements.setFindingSite(findingSiteCode).good());
 
-    DSRCodedEntryValue measurementMethodCode(measurementGroup["MeasurementMethod"]["codeValue"].asCString(),
-      measurementGroup["MeasurementMethod"]["codingSchemeDesignator"].asCString(),
-      measurementGroup["MeasurementMethod"]["codeMeaning"].asCString());
-    OFCHECK(measurements.setMeasurementMethod(measurementMethodCode).good());
+    if(measurementGroup.isMember("MeasurementMethod")){
+      DSRCodedEntryValue measurementMethodCode(measurementGroup["MeasurementMethod"]["codeValue"].asCString(),
+        measurementGroup["MeasurementMethod"]["codingSchemeDesignator"].asCString(),
+        measurementGroup["MeasurementMethod"]["codeMeaning"].asCString());
+      OFCHECK(measurements.setMeasurementMethod(measurementMethodCode).good());
+    }
 
     // TODO - handle conditional items!
     for(int j=0;j<measurementGroup["measurementItems"].size();j++){

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -69,10 +69,9 @@ foreach(pm_example_name ${PM_EXAMPLES})
   createExampleDataTest(${pm_example_name} ${PM_SCHEMA})
 endforeach()
 
-set(SRTID1500_EXAMPLES sr-tid1500)
+set(SRTID1500_EXAMPLES sr-tid1500 sr-tid1500-ct-liver)
 set(SRTID1500_SCHEMA ${CMAKE_SOURCE_DIR}/doc/sr-tid1500-schema.json)
 
 foreach(srtid1500_example_name ${SRTID1500_EXAMPLES})
   createExampleDataTest(${srtid1500_example_name} ${SRTID1500_SCHEMA})
 endforeach()
-

--- a/doc/sr-tid1500-ct-liver-example.json
+++ b/doc/sr-tid1500-ct-liver-example.json
@@ -1,0 +1,148 @@
+{
+  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/sr-tid1500-schema.json#",
+  "SeriesDescription": "Measurements",
+  "SeriesNumber": "1001",
+  "InstanceNumber": "1",
+
+  "compositeContext": [
+    "liver.dcm"
+  ],
+
+  "imageLibrary": [
+    "01.dcm",
+    "02.dcm",
+    "03.dcm"
+  ],
+
+  "observerContext": {
+    "ObserverType": "PERSON",
+    "PersonObserverName": "Reader1"
+  },
+
+  "VerificationFlag": "VERIFIED",
+  "CompletionFlag": "COMPLETE",
+
+  "activitySession": "1",
+  "timePoint": "1",
+
+  "Measurements": [
+    {
+      "MeasurementGroup": {
+        "TrackingIdentifier": "Measurements group 1",
+        "ReferencedSegment": 1,
+        "SourceSeriesForImageSegmentation": "1.2.392.200103.20080913.113635.2.2009.6.22.21.43.10.23431.1",
+        "segmentationSOPInstanceUID": "1.2.276.0.7230010.3.1.4.0.42154.1458337731.665796",
+        "Finding": {
+          "codeValue": "T-D0060",
+          "codingSchemeDesignator": "SRT",
+          "codeMeaning": "Organ"
+        },
+        "FindingSite": {
+          "codeValue": "T-62000",
+          "codingSchemeDesignator": "SRT",
+          "codeMeaning": "Liver"
+        },
+        "measurementItems": [
+          {
+            "value": "37.3289",
+            "quantity": {
+              "codeValue": "122713",
+              "codingSchemeDesignator": "DCM",
+              "codeMeaning": "Attenuation Coefficient"
+            },
+            "units": {
+              "codeValue": "[hnsf'U]",
+              "codingSchemeDesignator": "UCUM",
+              "codeMeaning": "Hounsfield unit"
+            },
+            "derivationModifier": {
+              "codeValue": "R-00317",
+              "codingSchemeDesignator": "SRT",
+              "codeMeaning": "Mean"
+            }
+          },
+          {
+            "value": "-778",
+            "quantity": {
+              "codeValue": "122713",
+              "codingSchemeDesignator": "DCM",
+              "codeMeaning": "Attenuation Coefficient"
+            },
+            "units": {
+              "codeValue": "[hnsf'U]",
+              "codingSchemeDesignator": "UCUM",
+              "codeMeaning": "Hounsfield unit"
+            },
+            "derivationModifier": {
+              "codeValue": "R-404FB",
+              "codingSchemeDesignator": "SRT",
+              "codeMeaning": "Minimum"
+            }
+          },
+          {
+            "value": "221",
+            "quantity": {
+              "codeValue": "122713",
+              "codingSchemeDesignator": "DCM",
+              "codeMeaning": "Attenuation Coefficient"
+            },
+            "units": {
+              "codeValue": "[hnsf'U]",
+              "codingSchemeDesignator": "UCUM",
+              "codeMeaning": "Hounsfield unit"
+            },
+            "derivationModifier": {
+              "codeValue": "G-A437",
+              "codingSchemeDesignator": "SRT",
+              "codeMeaning": "Maximum"
+            }
+          },
+          {
+            "value": "59.1691",
+            "quantity": {
+              "codeValue": "122713",
+              "codingSchemeDesignator": "DCM",
+              "codeMeaning": "Attenuation Coefficient"
+            },
+            "units": {
+              "codeValue": "[hnsf'U]",
+              "codingSchemeDesignator": "UCUM",
+              "codeMeaning": "Hounsfield unit"
+            },
+            "derivationModifier": {
+              "codeValue": "R-10047",
+              "codingSchemeDesignator": "SRT",
+              "codeMeaning": "Standard Deviation"
+            }
+          },
+          {
+            "value": "70361.9",
+            "quantity": {
+              "codeValue": "G-D705",
+              "codingSchemeDesignator": "SRT",
+              "codeMeaning": "Volume"
+            },
+            "units": {
+              "codeValue": "mm3",
+              "codingSchemeDesignator": "UCUM",
+              "codeMeaning": "cubic millimeter"
+            }
+          },
+          {
+            "value": "70.3619",
+            "quantity": {
+              "codeValue": "G-D705",
+              "codingSchemeDesignator": "SRT",
+              "codeMeaning": "Volume"
+            },
+            "units": {
+              "codeValue": "cm3",
+              "codingSchemeDesignator": "UCUM",
+              "codeMeaning": "cubic centimeter"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This example encodes all measurements done by Slicer LabelStatistics, except
voxel count.