### PR TITLE
BUG: fixed issues with json validation (issue #98):

### DIFF
--- a/apps/sr/tid1500writer.cxx
+++ b/apps/sr/tid1500writer.cxx
@@ -50,14 +50,6 @@ DSRCodedEntryValue json2cev(Json::Value& j){
     j["CodeMeaning"].asCString());
 }
 
-template <typename T>
-string numberToString(T number)
-{
-  ostringstream sstream;
-  sstream << number;
-  return sstream.str();
-}
-
 void addFileToEvidence(DSRDocument &doc, string dirStr, string fileStr){
   DcmFileFormat ff;
   OFString fullPath;
@@ -179,9 +171,7 @@ int main(int argc, char** argv){
     for(int j=0;j<measurementGroup["measurementItems"].size();j++){
       Json::Value measurement = measurementGroup["measurementItems"][j];
       // TODO - add measurement method and derivation!
-      string value = numberToString(measurement["value"].isInt() ? measurement["value"].asInt() : measurement["value"].asFloat());
-      cout << value << endl;
-      const CMR_TID1411_in_TID1500::MeasurementValue numValue(value.c_str(), json2cev(measurement["units"]));
+      const CMR_TID1411_in_TID1500::MeasurementValue numValue(measurement["value"].asCString(), json2cev(measurement["units"]));
 
       if(measurement.isMember("derivationModifier")){
           measurements.addMeasurement(json2cev(measurement["quantity"]), numValue, DSRCodedEntryValue(), json2cev(measurement["derivationModifier"]));

--- a/apps/sr/tid1500writer.cxx
+++ b/apps/sr/tid1500writer.cxx
@@ -45,9 +45,17 @@ static OFLogger dcemfinfLogger = OFLog::getLogger("qiicr.apps");
 #define STATIC_ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
 
 DSRCodedEntryValue json2cev(Json::Value& j){
-  return DSRCodedEntryValue(j["codeValue"].asCString(),
-    j["codingSchemeDesignator"].asCString(),
-    j["codeMeaning"].asCString());
+  return DSRCodedEntryValue(j["CodeValue"].asCString(),
+    j["CodingSchemeDesignator"].asCString(),
+    j["CodeMeaning"].asCString());
+}
+
+template <typename T>
+string numberToString(T number)
+{
+  ostringstream sstream;
+  sstream << number;
+  return sstream.str();
 }
 
 void addFileToEvidence(DSRDocument &doc, string dirStr, string fileStr){
@@ -130,7 +138,7 @@ int main(int argc, char** argv){
   std::cout << "Total measurement groups: " << metaRoot["Measurements"].size() << std::endl;
 
   for(int i=0;i<metaRoot["Measurements"].size();i++){
-    Json::Value measurementGroup = metaRoot["Measurements"][i]["MeasurementGroup"];
+    Json::Value measurementGroup = metaRoot["Measurements"][i];
 
     CHECK_COND(report.addVolumetricROIMeasurements());
     /* fill volumetric ROI measurements with data */
@@ -171,8 +179,9 @@ int main(int argc, char** argv){
     for(int j=0;j<measurementGroup["measurementItems"].size();j++){
       Json::Value measurement = measurementGroup["measurementItems"][j];
       // TODO - add measurement method and derivation!
-      const CMR_TID1411_in_TID1500::MeasurementValue numValue(measurement["value"].asCString(),
-        json2cev(measurement["units"]));
+      string value = numberToString(measurement["value"].isInt() ? measurement["value"].asInt() : measurement["value"].asFloat());
+      cout << value << endl;
+      const CMR_TID1411_in_TID1500::MeasurementValue numValue(value.c_str(), json2cev(measurement["units"]));
 
       if(measurement.isMember("derivationModifier")){
           measurements.addMeasurement(json2cev(measurement["quantity"]), numValue, DSRCodedEntryValue(), json2cev(measurement["derivationModifier"]));

--- a/doc/bmmr-example.json
+++ b/doc/bmmr-example.json
@@ -1,13 +1,14 @@
 {
   "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/seg-schema.json#",
+
   "seriesAttributes": {
-    "ReaderID": "Reader1",
-    "SessionID": "Session1",
-    "TimePointID": "1",
+    "ContentCreatorName": "Reader1",
+    "ClinicalTrialSeriesID": "Session1",
+    "ClinicalTrialTimePointID": "1",
+    "ClinicalTrialCoordinatingCenterName": "UCSF",
     "SeriesDescription": "Segmentation",
     "SeriesNumber": "300",
-    "InstanceNumber": "1",
-    "ClinicalTrialCoordinatingCenterName": "UCSF"
+    "InstanceNumber": "1"
   },
   "segmentAttributes": [
     [
@@ -31,10 +32,10 @@
           "CodingSchemeDesignator": "SRT",
           "CodeMeaning": "Right and left"
         },
-        "RecommendedDisplayRGBValue": [
-          "252",
-          "226",
-          "234"
+        "recommendedDisplayRGBValue": [
+          252,
+          226,
+          234
         ]
       }
     ]

--- a/doc/common-schema.json
+++ b/doc/common-schema.json
@@ -52,6 +52,7 @@
     },
     "codeSequence" : {
       "type" : "object",
+      "additionalProperties": false,
       "required" : ["CodeValue","CodingSchemeDesignator","CodeMeaning"],
       "properties" : {
         "CodeValue" : { "$ref": "#/definitions/SH", "default" : "T-D0050"},
@@ -59,7 +60,6 @@
         "CodeMeaning" : { "$ref": "#/definitions/LO", "default" : "Tissue"}
       }
     },
-
     "dicomInstancesFileNameList" : {
       "type" : "array",
       "items" : {

--- a/doc/common-schema.json
+++ b/doc/common-schema.json
@@ -16,6 +16,11 @@
       "type" : "string",
       "maxLength" : 12
     },
+    "DS" : {
+      "type" : "string",
+      "maxLength" : 16,
+      "pattern": "^( )*(-|\\+)?[0-9]*(.[0-9]+)?((e|E)(-|\\+)?[0-9]+)?( )*$"
+    },
     "LO" : {
       "type" : "string",
       "maxLength" : 64

--- a/doc/pm-schema.json
+++ b/doc/pm-schema.json
@@ -7,7 +7,9 @@
     "AnatomicRegionCode",
     "FrameLaterality"
   ],
+  "additionalProperties": false,
   "properties": {
+    "@schema": {"type" : "string"},
     "SeriesDescription": {
       "allOf": [
         {

--- a/doc/seg-example.json
+++ b/doc/seg-example.json
@@ -1,5 +1,6 @@
 {
   "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/seg-schema.json#",
+
   "seriesAttributes": {
     "ContentCreatorName": "Reader1",
     "ClinicalTrialSeriesID": "Session1",

--- a/doc/seg-schema.json
+++ b/doc/seg-schema.json
@@ -2,9 +2,12 @@
   "@context": "http://qiicr.org/dcmqi/contexts/dcmqi.jsonld",
   "id": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/seg-schema.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "additionalProperties": false,
   "properties": {
+    "@schema": {"type" : "string"},
     "seriesAttributes": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "ContentCreatorName": {
           "allOf": [
@@ -94,6 +97,7 @@
         "type": "array",
         "items": {
           "type": "object",
+          "additionalProperties": false,
           "required": [
             "LabelID",
             "SegmentedPropertyCategoryCodeSequence",

--- a/doc/sr-common-schema.json
+++ b/doc/sr-common-schema.json
@@ -22,6 +22,7 @@
       "type": "object",
       "oneOf": [
         {
+          "additionalProperties": false,
           "properties": {
             "PersonObserverName": {
               "$ref": "#/definitions/PNAME"
@@ -39,6 +40,7 @@
           ]
         },
         {
+          "additionalProperties": false,
           "properties": {
             "DeviceObserverUID": {
               "$ref": "#/definitions/UIDREF"

--- a/doc/sr-tid1500-ct-liver-example.json
+++ b/doc/sr-tid1500-ct-liver-example.json
@@ -44,7 +44,7 @@
       },
       "measurementItems": [
         {
-          "value": 37.3289,
+          "value": "37.3289",
           "quantity": {
             "CodeValue": "122713",
             "CodingSchemeDesignator": "DCM",
@@ -62,7 +62,7 @@
           }
         },
         {
-          "value": -778,
+          "value": "-778",
           "quantity": {
             "CodeValue": "122713",
             "CodingSchemeDesignator": "DCM",
@@ -80,7 +80,7 @@
           }
         },
         {
-          "value": 221,
+          "value": "221",
           "quantity": {
             "CodeValue": "122713",
             "CodingSchemeDesignator": "DCM",
@@ -98,7 +98,7 @@
           }
         },
         {
-          "value": 59.1691,
+          "value": "59.1691",
           "quantity": {
             "CodeValue": "122713",
             "CodingSchemeDesignator": "DCM",
@@ -116,7 +116,7 @@
           }
         },
         {
-          "value": 70361.9,
+          "value": "70361.9",
           "quantity": {
             "CodeValue": "G-D705",
             "CodingSchemeDesignator": "SRT",
@@ -129,7 +129,7 @@
           }
         },
         {
-          "value": 70.3619,
+          "value": "70.3619",
           "quantity": {
             "CodeValue": "G-D705",
             "CodingSchemeDesignator": "SRT",

--- a/doc/sr-tid1500-ct-liver-example.json
+++ b/doc/sr-tid1500-ct-liver-example.json
@@ -1,5 +1,6 @@
 {
   "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/sr-tid1500-schema.json#",
+
   "SeriesDescription": "Measurements",
   "SeriesNumber": "1001",
   "InstanceNumber": "1",
@@ -27,122 +28,120 @@
 
   "Measurements": [
     {
-      "MeasurementGroup": {
-        "TrackingIdentifier": "Measurements group 1",
-        "ReferencedSegment": 1,
-        "SourceSeriesForImageSegmentation": "1.2.392.200103.20080913.113635.2.2009.6.22.21.43.10.23431.1",
-        "segmentationSOPInstanceUID": "1.2.276.0.7230010.3.1.4.0.42154.1458337731.665796",
-        "Finding": {
-          "codeValue": "T-D0060",
-          "codingSchemeDesignator": "SRT",
-          "codeMeaning": "Organ"
-        },
-        "FindingSite": {
-          "codeValue": "T-62000",
-          "codingSchemeDesignator": "SRT",
-          "codeMeaning": "Liver"
-        },
-        "measurementItems": [
-          {
-            "value": "37.3289",
-            "quantity": {
-              "codeValue": "122713",
-              "codingSchemeDesignator": "DCM",
-              "codeMeaning": "Attenuation Coefficient"
-            },
-            "units": {
-              "codeValue": "[hnsf'U]",
-              "codingSchemeDesignator": "UCUM",
-              "codeMeaning": "Hounsfield unit"
-            },
-            "derivationModifier": {
-              "codeValue": "R-00317",
-              "codingSchemeDesignator": "SRT",
-              "codeMeaning": "Mean"
-            }
+      "TrackingIdentifier": "Measurements group 1",
+      "ReferencedSegment": 1,
+      "SourceSeriesForImageSegmentation": "1.2.392.200103.20080913.113635.2.2009.6.22.21.43.10.23431.1",
+      "segmentationSOPInstanceUID": "1.2.276.0.7230010.3.1.4.0.42154.1458337731.665796",
+      "Finding": {
+        "CodeValue": "T-D0060",
+        "CodingSchemeDesignator": "SRT",
+        "CodeMeaning": "Organ"
+      },
+      "FindingSite": {
+        "CodeValue": "T-62000",
+        "CodingSchemeDesignator": "SRT",
+        "CodeMeaning": "Liver"
+      },
+      "measurementItems": [
+        {
+          "value": 37.3289,
+          "quantity": {
+            "CodeValue": "122713",
+            "CodingSchemeDesignator": "DCM",
+            "CodeMeaning": "Attenuation Coefficient"
           },
-          {
-            "value": "-778",
-            "quantity": {
-              "codeValue": "122713",
-              "codingSchemeDesignator": "DCM",
-              "codeMeaning": "Attenuation Coefficient"
-            },
-            "units": {
-              "codeValue": "[hnsf'U]",
-              "codingSchemeDesignator": "UCUM",
-              "codeMeaning": "Hounsfield unit"
-            },
-            "derivationModifier": {
-              "codeValue": "R-404FB",
-              "codingSchemeDesignator": "SRT",
-              "codeMeaning": "Minimum"
-            }
+          "units": {
+            "CodeValue": "[hnsf'U]",
+            "CodingSchemeDesignator": "UCUM",
+            "CodeMeaning": "Hounsfield unit"
           },
-          {
-            "value": "221",
-            "quantity": {
-              "codeValue": "122713",
-              "codingSchemeDesignator": "DCM",
-              "codeMeaning": "Attenuation Coefficient"
-            },
-            "units": {
-              "codeValue": "[hnsf'U]",
-              "codingSchemeDesignator": "UCUM",
-              "codeMeaning": "Hounsfield unit"
-            },
-            "derivationModifier": {
-              "codeValue": "G-A437",
-              "codingSchemeDesignator": "SRT",
-              "codeMeaning": "Maximum"
-            }
-          },
-          {
-            "value": "59.1691",
-            "quantity": {
-              "codeValue": "122713",
-              "codingSchemeDesignator": "DCM",
-              "codeMeaning": "Attenuation Coefficient"
-            },
-            "units": {
-              "codeValue": "[hnsf'U]",
-              "codingSchemeDesignator": "UCUM",
-              "codeMeaning": "Hounsfield unit"
-            },
-            "derivationModifier": {
-              "codeValue": "R-10047",
-              "codingSchemeDesignator": "SRT",
-              "codeMeaning": "Standard Deviation"
-            }
-          },
-          {
-            "value": "70361.9",
-            "quantity": {
-              "codeValue": "G-D705",
-              "codingSchemeDesignator": "SRT",
-              "codeMeaning": "Volume"
-            },
-            "units": {
-              "codeValue": "mm3",
-              "codingSchemeDesignator": "UCUM",
-              "codeMeaning": "cubic millimeter"
-            }
-          },
-          {
-            "value": "70.3619",
-            "quantity": {
-              "codeValue": "G-D705",
-              "codingSchemeDesignator": "SRT",
-              "codeMeaning": "Volume"
-            },
-            "units": {
-              "codeValue": "cm3",
-              "codingSchemeDesignator": "UCUM",
-              "codeMeaning": "cubic centimeter"
-            }
+          "derivationModifier": {
+            "CodeValue": "R-00317",
+            "CodingSchemeDesignator": "SRT",
+            "CodeMeaning": "Mean"
           }
-        ]
-      }
+        },
+        {
+          "value": -778,
+          "quantity": {
+            "CodeValue": "122713",
+            "CodingSchemeDesignator": "DCM",
+            "CodeMeaning": "Attenuation Coefficient"
+          },
+          "units": {
+            "CodeValue": "[hnsf'U]",
+            "CodingSchemeDesignator": "UCUM",
+            "CodeMeaning": "Hounsfield unit"
+          },
+          "derivationModifier": {
+            "CodeValue": "R-404FB",
+            "CodingSchemeDesignator": "SRT",
+            "CodeMeaning": "Minimum"
+          }
+        },
+        {
+          "value": 221,
+          "quantity": {
+            "CodeValue": "122713",
+            "CodingSchemeDesignator": "DCM",
+            "CodeMeaning": "Attenuation Coefficient"
+          },
+          "units": {
+            "CodeValue": "[hnsf'U]",
+            "CodingSchemeDesignator": "UCUM",
+            "CodeMeaning": "Hounsfield unit"
+          },
+          "derivationModifier": {
+            "CodeValue": "G-A437",
+            "CodingSchemeDesignator": "SRT",
+            "CodeMeaning": "Maximum"
+          }
+        },
+        {
+          "value": 59.1691,
+          "quantity": {
+            "CodeValue": "122713",
+            "CodingSchemeDesignator": "DCM",
+            "CodeMeaning": "Attenuation Coefficient"
+          },
+          "units": {
+            "CodeValue": "[hnsf'U]",
+            "CodingSchemeDesignator": "UCUM",
+            "CodeMeaning": "Hounsfield unit"
+          },
+          "derivationModifier": {
+            "CodeValue": "R-10047",
+            "CodingSchemeDesignator": "SRT",
+            "CodeMeaning": "Standard Deviation"
+          }
+        },
+        {
+          "value": 70361.9,
+          "quantity": {
+            "CodeValue": "G-D705",
+            "CodingSchemeDesignator": "SRT",
+            "CodeMeaning": "Volume"
+          },
+          "units": {
+            "CodeValue": "mm3",
+            "CodingSchemeDesignator": "UCUM",
+            "CodeMeaning": "cubic millimeter"
+          }
+        },
+        {
+          "value": 70.3619,
+          "quantity": {
+            "CodeValue": "G-D705",
+            "CodingSchemeDesignator": "SRT",
+            "CodeMeaning": "Volume"
+          },
+          "units": {
+            "CodeValue": "cm3",
+            "CodingSchemeDesignator": "UCUM",
+            "CodeMeaning": "cubic centimeter"
+          }
+        }
+      ]
     }
   ]
 }

--- a/doc/sr-tid1500-example.json
+++ b/doc/sr-tid1500-example.json
@@ -1,5 +1,6 @@
 {
   "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/sr-tid1500-schema.json#",
+
   "SeriesDescription": "Measurements",
   "SeriesNumber": "1001",
   "InstanceNumber": "1",
@@ -27,48 +28,46 @@
 
   "Measurements": [
     {
-      "MeasurementGroup": {
-        "TrackingIdentifier": "Measurements group 1",
-        "ReferencedSegment": 1,
-        "SourceSeriesForImageSegmentation": "1.3.6.1.4.1.14519.5.2.1.2744.7002.261560220703676715130542397405",
-        "segmentationSOPInstanceUID": "1.2.276.0.7230010.3.1.4.8323329.18591.1440001312.777033",
-        "rwvmMapUsedForMeasurement": "1.2.276.0.7230010.3.1.4.8323329.18215.1440001297.928457",
-        "MeasurementMethod": {
-          "codeValue": "126401",
-          "codingSchemeDesignator": "DCM",
-          "codeMeaning": "SUV body weight calculation method"
-        },
-        "Finding": {
-          "codeValue": "M-80003",
-          "codingSchemeDesignator": "SRT",
-          "codeMeaning": "Neoplasm, Primary"
-        },
-        "FindingSite": {
-          "codeValue": "T-00317",
-          "codingSchemeDesignator": "SRT",
-          "codeMeaning": "pharyngeal tonsil (adenoid)"
-        },
-        "measurementItems": [
-          {
-            "value": "1.96772",
-            "quantity": {
-              "codeValue": "126401",
-              "codingSchemeDesignator": "DCM",
-              "codeMeaning": "SUVbw"
-            },
-            "units": {
-              "codeValue": "{SUVbw}g/ml",
-              "codingSchemeDesignator": "UCUM",
-              "codeMeaning": "Standardized Uptake Value body weight"
-            },
-            "derivationModifier": {
-              "codeValue": "R-00317",
-              "codingSchemeDesignator": "SRT",
-              "codeMeaning": "Mean"
-            }
+      "TrackingIdentifier": "Measurements group 1",
+      "ReferencedSegment": 1,
+      "SourceSeriesForImageSegmentation": "1.3.6.1.4.1.14519.5.2.1.2744.7002.261560220703676715130542397405",
+      "segmentationSOPInstanceUID": "1.2.276.0.7230010.3.1.4.8323329.18591.1440001312.777033",
+      "rwvmMapUsedForMeasurement": "1.2.276.0.7230010.3.1.4.8323329.18215.1440001297.928457",
+      "MeasurementMethod": {
+        "CodeValue": "126401",
+        "CodingSchemeDesignator": "DCM",
+        "CodeMeaning": "SUV body weight calculation method"
+      },
+      "Finding": {
+        "CodeValue": "M-80003",
+        "CodingSchemeDesignator": "SRT",
+        "CodeMeaning": "Neoplasm, Primary"
+      },
+      "FindingSite": {
+        "CodeValue": "T-00317",
+        "CodingSchemeDesignator": "SRT",
+        "CodeMeaning": "pharyngeal tonsil (adenoid)"
+      },
+      "measurementItems": [
+        {
+          "value": 1.96772,
+          "quantity": {
+            "CodeValue": "126401",
+            "CodingSchemeDesignator": "DCM",
+            "CodeMeaning": "SUVbw"
+          },
+          "units": {
+            "CodeValue": "{SUVbw}g/ml",
+            "CodingSchemeDesignator": "UCUM",
+            "CodeMeaning": "Standardized Uptake Value body weight"
+          },
+          "derivationModifier": {
+            "CodeValue": "R-00317",
+            "CodingSchemeDesignator": "SRT",
+            "CodeMeaning": "Mean"
           }
-        ]
-      }
+        }
+      ]
     }
   ]
 }

--- a/doc/sr-tid1500-example.json
+++ b/doc/sr-tid1500-example.json
@@ -50,7 +50,7 @@
       },
       "measurementItems": [
         {
-          "value": 1.96772,
+          "value": "1.96772",
           "quantity": {
             "CodeValue": "126401",
             "CodingSchemeDesignator": "DCM",

--- a/doc/sr-tid1500-schema.json
+++ b/doc/sr-tid1500-schema.json
@@ -8,7 +8,7 @@
       "additionalProperties": false,
       "properties": {
         "value": {
-          "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/sr-common-schema.json#/definitions/NUM"
+          "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/DS"
         },
         "quantity": {
           "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/codeSequence"

--- a/doc/sr-tid1500-schema.json
+++ b/doc/sr-tid1500-schema.json
@@ -5,6 +5,7 @@
   "definitions": {
     "measurementItem": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "value": {
           "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/sr-common-schema.json#/definitions/NUM"
@@ -22,6 +23,7 @@
     },
     "MeasurementGroup": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "TrackingIdentifier": {
           "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/sr-common-schema.json#/definitions/TEXT"
@@ -44,6 +46,9 @@
         "MeasurementMethod": {
           "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/codeSequence"
         },
+        "Finding": {
+          "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/codeSequence"
+        },
         "FindingSite": {
           "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/codeSequence"
         },
@@ -63,12 +68,17 @@
       }
     }
   },
+  "additionalProperties": false,
   "properties": {
+    "@schema": {"type" : "string"},
     "compositeContext": {
       "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/dicomInstancesFileNameList"
     },
     "imageLibrary": {
       "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/dicomInstancesFileNameList"
+    },
+    "observerContext": {
+      "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/sr-common-schema.json#/definitions/observerContext"
     },
     "activitySession": {
       "type": "string",


### PR DESCRIPTION
fixes #98 
- prohibiting  additional properties
- needed to define @schema which is usually not used in json data files
- removed MeasurementGroup keyword since this name is used within definitions. Measurements already defines an array of objects which hold those values.
- corrected some typos regarding CodeSequences
- using number instead of string for measurement values how it was defined in the schema