### PR TITLE
Add support for build apps option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,10 @@ cmake_dependent_option(
 mark_as_advanced(BUILD_PARAMETRIC_MAPS)
 mark_as_superbuild(BUILD_PARAMETRIC_MAPS)
 
+option(BUILD_DOC "Build ${PROJECT_NAME} documentation." ON)
+mark_as_advanced(BUILD_DOC)
+mark_as_superbuild(BUILD_DOC)
+
 #-----------------------------------------------------------------------------
 # Superbuild Option - Enabled by default
 #
@@ -234,4 +238,6 @@ if(BUILD_APPS)
   add_subdirectory("apps")
 endif()
 
-add_subdirectory("doc")
+if(BUILD_DOC)
+  add_subdirectory("doc")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,16 @@ mark_as_superbuild(
 #-----------------------------------------------------------------------------
 # Options
 
-option(BUILD_PARAMETRIC_MAPS "Build parametric maps for ${PROJECT_NAME}." OFF)
+include(CMakeDependentOption)
+
+option(BUILD_APPS "Build ${PROJECT_NAME} applications." ON)
+mark_as_advanced(BUILD_APPS)
+mark_as_superbuild(BUILD_APPS)
+
+cmake_dependent_option(
+  BUILD_PARAMETRIC_MAPS "Build parametric maps for ${PROJECT_NAME}." OFF
+  "BUILD_APPS" OFF
+  )
 mark_as_advanced(BUILD_PARAMETRIC_MAPS)
 mark_as_superbuild(BUILD_PARAMETRIC_MAPS)
 
@@ -223,6 +232,8 @@ set(JSONCPP_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp/jsoncpp.cpp)
 
 add_subdirectory("libsrc")
 
-add_subdirectory("apps")
+if(BUILD_APPS)
+  add_subdirectory("apps")
+endif()
 
 add_subdirectory("doc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,12 +204,10 @@ if(DCMQI_SUPERBUILD)
   return()
 endif()
 
+#-----------------------------------------------------------------------------
 find_package(DCMTK NO_MODULE REQUIRED)
-find_package(SlicerExecutionModel NO_MODULE REQUIRED GenerateCLP)
 find_package(ITK NO_MODULE REQUIRED)
 include(${ITK_USE_FILE})
-
-include(${SlicerExecutionModel_USE_FILE})
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/FindGit.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/dcmqiMacroExtractRepositoryInfo.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ mark_as_superbuild(
 
 option(BUILD_PARAMETRIC_MAPS "Build parametric maps for ${PROJECT_NAME}." OFF)
 mark_as_advanced(BUILD_PARAMETRIC_MAPS)
+mark_as_superbuild(BUILD_PARAMETRIC_MAPS)
 
 #-----------------------------------------------------------------------------
 # Superbuild Option - Enabled by default

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -25,8 +25,12 @@ set(DCMQI_DEPENDENCIES
   zlib
   DCMTK
   ITK
-  SlicerExecutionModel
   )
+if(BUILD_APPS)
+  list(APPEND DCMQI_DEPENDENCIES
+    SlicerExecutionModel
+    )
+endif()
 
 #-----------------------------------------------------------------------------
 # WARNING - No change should be required after this comment

--- a/apps/paramaps/CMakeLists.txt
+++ b/apps/paramaps/CMakeLists.txt
@@ -1,5 +1,13 @@
 
 #-----------------------------------------------------------------------------
+
+#
+# SlicerExecutionModel
+#
+find_package(SlicerExecutionModel REQUIRED)
+include(${SlicerExecutionModel_USE_FILE})
+
+#-----------------------------------------------------------------------------
 set(COMMON_INCLUDE_DIRECTORIES
   )
 

--- a/apps/seg/CMakeLists.txt
+++ b/apps/seg/CMakeLists.txt
@@ -1,5 +1,13 @@
 
 #-----------------------------------------------------------------------------
+
+#
+# SlicerExecutionModel
+#
+find_package(SlicerExecutionModel REQUIRED)
+include(${SlicerExecutionModel_USE_FILE})
+
+#-----------------------------------------------------------------------------
 set(COMMON_INCLUDE_DIRECTORIES
   )
 

--- a/apps/sr/CMakeLists.txt
+++ b/apps/sr/CMakeLists.txt
@@ -1,5 +1,13 @@
 
 #-----------------------------------------------------------------------------
+
+#
+# SlicerExecutionModel
+#
+find_package(SlicerExecutionModel REQUIRED)
+include(${SlicerExecutionModel_USE_FILE})
+
+#-----------------------------------------------------------------------------
 set(COMMON_INCLUDE_DIRECTORIES
   )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ before_build:
   - cmd: 7z x C:\SlicerExecutionModel-dcmqi.zip -oC:\SlicerExecutionModel\SlicerExecutionModel-build
   - cmd: mkdir c:\dcmqi\dcmqi-build
   - cmd: cd c:\dcmqi\dcmqi-build
-  - cmd: cmake -G "Visual Studio 12 2013 Win64" -DCMAKE_BUILD_TYPE:STRING=Release -DITK_DIR:PATH=C:\ITK-install -DSlicerExecutionModel_DIR:PATH=C:\SlicerExecutionModel\SlicerExecutionModel-build -DDCMTK_DIR:PATH=C:\DCMTK-install\cmake -DZLIB_ROOT:PATH=c:\zlib-install -DZLIB_INCLUDE_DIR:PATH=c:\zlib-install\include -DZLIB_LIBRARY:FILEPATH=c:\zlib-install\lib\zlib.lib c:\dcmqi
+  - cmd: cmake -G "Visual Studio 12 2013 Win64" -DCMAKE_BUILD_TYPE:STRING=Release -DITK_DIR:PATH=C:\ITK-install\lib\cmake\ITK-4.10 -DSlicerExecutionModel_DIR:PATH=C:\SlicerExecutionModel\SlicerExecutionModel-build -DDCMTK_DIR:PATH=C:\DCMTK-install\cmake -DZLIB_ROOT:PATH=c:\zlib-install -DZLIB_INCLUDE_DIR:PATH=c:\zlib-install\include -DZLIB_LIBRARY:FILEPATH=c:\zlib-install\lib\zlib.lib c:\dcmqi
   - cmd: dir
 build_script:
   - cmd: type DCMQI.sln

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -52,7 +52,7 @@ foreach(json_schema_file ${json_schema_files})
   createSchemaValidationTest(${json_schema_file})
 endforeach()
 
-# function to simpify creation of example validation tests
+# function to simplify creation of example validation tests
 function(createExampleDataTest example_name schema)
   set(json_example_file ${CMAKE_SOURCE_DIR}/doc/${example_name}-example.json)
   add_test(NAME ajv_${example_name}-example


### PR DESCRIPTION
Per our discussion, this topic adds option `BUILD_APPS`

It also:
* ensure that the `BUILD_PARAMETRIC_MAPS` is passed to the inner build
* add `SlicerExecutionModel` as a dependency only if `BUILD_APPS` is `ON`