### PR TITLE
Mprage test

### DIFF
--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
   ifstream metainfoStream(metaDataFileName.c_str(), ios_base::binary);
   std::string metadata( (std::istreambuf_iterator<char>(metainfoStream) ),
                        (std::istreambuf_iterator<char>()));
-  DcmDataset* result = dcmqi::ImageSEGConverter::itkimage2dcmSegmentation(dcmDatasets, segmentations, metadata);
+  DcmDataset* result = dcmqi::ImageSEGConverter::itkimage2dcmSegmentation(dcmDatasets, segmentations, metadata, !noSkipEmptySlices);
 
   if (result == NULL){
     return EXIT_FAILURE;

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -42,13 +42,13 @@
       <description>File name of the SEG object that will keep the result.</description>
     </file>
 
-    <!--<boolean>-->
-      <!--<name>skipEmptySlices</name>-->
-      <!--<label>Skip empty slices</label>-->
-      <!--<channel>input</channel>-->
-      <!--<longflag>skip</longflag>-->
-      <!--<description>Skip empty slices while encoding segmentation image.</description>-->
-    <!--</boolean>-->
+    <boolean>
+      <name>noSkipEmptySlices</name>
+      <label>Skip empty slices</label>
+      <channel>input</channel>
+      <longflag>noskip</longflag>
+      <description>Don't skip empty slices while encoding segmentation image.</description>-->
+    </boolean>
 
     <!--<boolean>-->
       <!--<name>compress</name>-->

--- a/apps/seg/segimage2itkimage.cxx
+++ b/apps/seg/segimage2itkimage.cxx
@@ -16,11 +16,17 @@ int main(int argc, char *argv[])
   for(map<unsigned,ImageType::Pointer>::const_iterator sI=result.first.begin();sI!=result.first.end();++sI){
     typedef itk::ImageFileWriter<ImageType> WriterType;
     stringstream imageFileNameSStream;
-    imageFileNameSStream << outputDirName << "/" << sI->first << ".nrrd";
-
+    
+    if (niftiOutput) {
+      imageFileNameSStream << outputDirName << "/" << sI->first << ".nii.gz";  
+    } else {
+      imageFileNameSStream << outputDirName << "/" << sI->first << ".nrrd";
+    }
+    
     WriterType::Pointer writer = WriterType::New();
     writer->SetFileName(imageFileNameSStream.str().c_str());
     writer->SetInput(sI->second);
+    //PW
     writer->SetUseCompression(1);
     writer->Update();
   }

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -36,6 +36,15 @@
       <description>Directory to store individual segments as NRRD files. File names will correspond to the segment numbers.</description>
     </file>
 
+    <boolean>
+      <name>niftiOutput</name>
+      <longflag>nii</longflag>
+      <label>Output a nifti file (.nii.gz) instead of a .nrrd file</label>
+      <channel>input</channel>
+      <default>0</default>
+      <description>Output a nifti file (.nii.gz) instead of a .nrrd file</description>
+    </boolean>
+
   </parameters>
 
 </executable>

--- a/include/ImageSEGConverter.h
+++ b/include/ImageSEGConverter.h
@@ -42,7 +42,9 @@ namespace dcmqi {
   public:
     static DcmDataset* itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
                                                 vector<ImageType::Pointer> segmentations,
-                                                const string &metaData);
+                                                const string &metaData,
+												bool skipEmptySlices=true);
+
 
     static pair <map<unsigned,ImageType::Pointer>, string> dcmSegmentation2itkimage(DcmDataset *segDataset);
 

--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -5,7 +5,8 @@ namespace dcmqi {
 
   DcmDataset* ImageSEGConverter::itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
                                                           vector<ImageType::Pointer> segmentations,
-                                                          const string &metaData) {
+                                                          const string &metaData,
+                                                          bool skipEmptySlices) {
 
     ImageType::SizeType inputSize = segmentations[0]->GetBufferedRegion().GetSize();
     cout << "Input image size: " << inputSize << endl;
@@ -168,7 +169,8 @@ namespace dcmqi {
 
         LabelStatisticsType::BoundingBoxType bbox = labelStats->GetBoundingBox(label);
         unsigned firstSlice, lastSlice;
-        bool skipEmptySlices = true; // TODO: what to do with that line?
+        //bool skipEmptySlices = true; // TODO: what to do with that line?
+        //bool skipEmptySlices = false; // TODO: what to do with that line?
         if(skipEmptySlices){
           firstSlice = bbox[4];
           lastSlice = bbox[5]+1;


### PR DESCRIPTION
Hi dcmqi team,

Here are a couple of modest enhancements that have helped me with development/debugging. One is a flag to allow segimage2itkimage to output niftis, the other is a flag force itkimage2segimage to not skip empty slices.  It looks like there already was a similar flag that has been removed, so I'll understand if you're not keen on putting it back in.

-Paul