### PR TITLE
BUG: enable parametric maps component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ option(DCMQI_BUILD_APPS "Build ${PROJECT_NAME} applications." ON)
 mark_as_superbuild(DCMQI_BUILD_APPS)
 
 cmake_dependent_option(
-  DCMQI_BUILD_PARAMETRIC_MAPS "Build parametric maps for ${PROJECT_NAME}." OFF
+  DCMQI_BUILD_PARAMETRIC_MAPS "Build parametric maps for ${PROJECT_NAME}." ON
   "DCMQI_BUILD_APPS" OFF
   )
 mark_as_superbuild(DCMQI_BUILD_PARAMETRIC_MAPS)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5.0)
 
-if(BUILD_PARAMETRIC_MAPS)
+if(DCMQI_BUILD_PARAMETRIC_MAPS)
   add_subdirectory(paramaps)
 endif()
 add_subdirectory(seg)

--- a/apps/paramaps/CMakeLists.txt
+++ b/apps/paramaps/CMakeLists.txt
@@ -32,23 +32,35 @@ set(COMMON_SOURCE_FILES
 #-----------------------------------------------------------------------------
 set(MODULE_NAME itkimage2paramap)
 
+
 #-----------------------------------------------------------------------------
 set(${MODULE_NAME}_TARGET_LIBRARIES
   ${COMMON_TARGET_LIBRARIES}
   )
 
 #-----------------------------------------------------------------------------
+set(MODULE_SRCS
+  ${MODULE_NAME}.cxx
+  )
+
+#-----------------------------------------------------------------------------
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   INCLUDE_DIRECTORIES ${COMMON_INCLUDE_DIRECTORIES}
-  ADDITIONAL_SRCS ${COMMON_SOURCE_FILES} ${MODULE_NAME}.cxx
+  ADDITIONAL_SRCS ${MODULE_SRCS} ${COMMON_DCMQI_LIB_SOURCES}
   TARGET_LIBRARIES ${${MODULE_NAME}_TARGET_LIBRARIES}
+  EXECUTABLE_ONLY
   )
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME paramap2itkimage)
 
 #-----------------------------------------------------------------------------
+set(MODULE_SRCS
+  ${MODULE_NAME}.cxx
+  )
+  
+#-----------------------------------------------------------------------------
 set(${MODULE_NAME}_TARGET_LIBRARIES
   ${COMMON_TARGET_LIBRARIES}
   )
@@ -57,8 +69,9 @@ set(${MODULE_NAME}_TARGET_LIBRARIES
 SEMMacroBuildCLI(
   NAME ${MODULE_NAME}
   INCLUDE_DIRECTORIES ${COMMON_INCLUDE_DIRECTORIES}
-  ADDITIONAL_SRCS ${COMMON_SOURCE_FILES} ${MODULE_NAME}.cxx
+  ADDITIONAL_SRCS ${MODULE_SRCS} ${COMMON_DCMQI_LIB_SOURCES}
   TARGET_LIBRARIES ${${MODULE_NAME}_TARGET_LIBRARIES}
+  EXECUTABLE_ONLY
   )
 
 #-----------------------------------------------------------------------------

--- a/include/dcmqi/ParaMapConverter.h
+++ b/include/dcmqi/ParaMapConverter.h
@@ -2,6 +2,12 @@
 #define DCMQI_PARAMAP_CONVERTER_H
 
 // DCMTK includes
+#include <dcmtk/dcmfg/fgderimg.h>
+#include <dcmtk/dcmfg/fgseg.h>
+#include <dcmtk/dcmseg/segdoc.h>
+#include <dcmtk/dcmseg/segment.h>
+#include <dcmtk/dcmseg/segutils.h>
+#include <dcmtk/dcmdata/dcrledrg.h>
 #include <dcmtk/dcmpmap/dpmparametricmapiod.h>
 
 // STD includes

--- a/libsrc/CMakeLists.txt
+++ b/libsrc/CMakeLists.txt
@@ -16,7 +16,7 @@ source_group("Generated" FILES
 #-----------------------------------------------------------------------------
 set(ADDITIONAL_SRCS)
 
-if(BUILD_PARAMETRIC_MAPS)
+if(DCMQI_BUILD_PARAMETRIC_MAPS)
   list(APPEND ADDITIONAL_SRCS
     JSONParametricMapMetaInformationHandler.cpp
     ParaMapConverter.cpp


### PR DESCRIPTION
Fix consistency of the cmake flag, update paramap CLI macro parameters, make
parametric maps enabled by default.

It will make sense to remove parametric map flag completely. The reason we had
it because that component of dcmqi was being developed while parametric map API
was not yet integrated into DCMTK. Now that it is part of the stable DCMTK API,
there is no real need to make parametric map optional.