### PR TITLE
WIP: support definition of the private schemes

### DIFF
--- a/doc/common-schema.json
+++ b/doc/common-schema.json
@@ -37,6 +37,15 @@
       "minimum" : 0,
       "maximum": 2E+16
     },
+    "UI": {
+      "type": "string",
+      "pattern": "[0-9.]+",
+      "maxLength": 64
+    },
+    "ST": {
+      "type": "string",
+      "maxLength": 1024
+    },
     "RGB": {
       "type": "array",
       "items": {
@@ -69,6 +78,26 @@
       "type" : "array",
       "items" : {
         "type": "string"
+      }
+    },
+    "codingSchemeIdentificationSequenceItem": {
+      "type": "object",
+      "properties": {
+        "CodingSchemeDesignator": {
+          "$ref": "#/definitions/SH"
+        },
+        "CodingSchemeUID": {
+          "$ref": "#/definitions/UI"
+        },
+        "CodingSchemeName": {
+          "$ref": "#/definitions/ST"
+        },
+        "CodingSchemeVersion": {
+          "$ref": "#/definitions/SH"
+        },
+        "CodingSchemeResponsibleOrganization": {
+          "$ref": "#/definitions/LO"
+        }
       }
     }
   }

--- a/doc/dcmqi.jsonld
+++ b/doc/dcmqi.jsonld
@@ -16,6 +16,7 @@
     "PN" : "http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html#para_33c3c135-889d-43ab-bd7c-33e8baf2cf4e",
     "SH" : "http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html#para_86e7840f-09d0-4a50-964a-bfa24df6c5c4",
     "FD" : "http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html#para_ecc3ceda-4b8b-4531-9323-af7767dadf23",
+    "UI" : "http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html#para_76ccbac7-54a5-4657-bef8-c2356ebb2dd6",
     "DerivedPixelContrast" : "http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.32.2.html#para_9a99a024-eb07-4ce0-ad9a-50dd0514e14d",
     "recommendedDisplayRGBValue" : "TBD - will be converted to CIELab by the converter",
     "RecommendedDisplayCIELabValue" : "http://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.20.2.html#para_fea81a93-95f6-4da5-988a-84358398da66"

--- a/doc/pm-schema.json
+++ b/doc/pm-schema.json
@@ -118,6 +118,12 @@
     "FrameLaterality": {
       "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/CS",
       "default": "U"
+    },
+    "CodingSchemeIdentificationSequence": {
+      "type": "array",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/codingSchemeIdentificationSequenceItem"
+      }
     }
   }
 }

--- a/doc/seg-schema.json
+++ b/doc/seg-schema.json
@@ -85,6 +85,13 @@
       ],
       "default": ""
     },
+    "CodingSchemeIdentificationSequence": {
+      "type": "array",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/codingSchemeIdentificationSequenceItem"
+      }
+    },
+    
     "segmentAttributes": {
       "type": "array",
       "items": {

--- a/doc/sr-tid1500-schema.json
+++ b/doc/sr-tid1500-schema.json
@@ -138,6 +138,12 @@
       "items": {
         "$ref": "#/definitions/MeasurementGroup"
       }
+    },
+    "CodingSchemeIdentificationSequence": {
+      "type": "array",
+      "items": {
+        "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/common-schema.json#/definitions/codingSchemeIdentificationSequenceItem"
+      }
     }
   }
 }


### PR DESCRIPTION
Re #90

* added definitions for the missing VRs
* added scheme identification item to the common scheme
* added an option to specify identification item in individual schemes

WIP - need to add support of reading and writing these items to the converters