### PR TITLE
Support of most popular itk file formats for conversion output from dcm to itk

### DIFF
--- a/apps/paramaps/itkimage2paramap.xml
+++ b/apps/paramaps/itkimage2paramap.xml
@@ -7,9 +7,9 @@
   <documentation-url></documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-<acknowledgements></acknowledgements>
+  <acknowledgements></acknowledgements>
 
-<parameters>
+  <parameters>
     <file>
       <name>inputFileName</name>
       <label>Parametric Map file name</label>
@@ -19,12 +19,12 @@
     </file>
 
     <file>
-        <name>dicomImageFileName</name>
-        <label>DICOM images file name</label>
-        <channel>input</channel>
-        <longflag>dicomImageFileName</longflag>
-        <default></default>
-        <description>File name of the DICOM image file which has been used </description>
+      <name>dicomImageFileName</name>
+      <label>DICOM images file name</label>
+      <channel>input</channel>
+      <longflag>dicomImageFileName</longflag>
+      <default></default>
+      <description>File name of the DICOM image file which has been used </description>
     </file>
 
     <file>

--- a/apps/paramaps/itkimage2paramap.xml
+++ b/apps/paramaps/itkimage2paramap.xml
@@ -7,7 +7,9 @@
   <documentation-url></documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements></acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
+    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
+    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
     <file>

--- a/apps/paramaps/itkimage2paramap.xml
+++ b/apps/paramaps/itkimage2paramap.xml
@@ -2,14 +2,12 @@
 <executable>
   <category>Informatics.Converters</category>
   <title>Encode DICOM Parametric Map</title>
-  <description>Create DICOM Parametric Map Image object from non-DICOM images</description>
-  <version></version>
-  <documentation-url></documentation-url>
+  <description>Convert a parametric map provided in any of the formats supported by ITK, such as NRRD or NIFTI, as a DICOM Parametric Map image object.</description>
+  <version>1.0</version>
+  <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
-    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
-    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
     <file>

--- a/apps/paramaps/paramap2itkimage.cxx
+++ b/apps/paramaps/paramap2itkimage.cxx
@@ -5,6 +5,7 @@
 #undef HAVE_SSTREAM // Avoid redefinition warning
 #include "dcmqi/ParaMapConverter.h"
 
+
 int main(int argc, char *argv[])
 {
   PARSE_ARGS;
@@ -16,10 +17,12 @@ int main(int argc, char *argv[])
 
   pair <ImageType::Pointer, string> result =  dcmqi::ParaMapConverter::paramap2itkimage(dataset);
 
+  string fileExtension = dcmqi::Helper::getFileExtensionFromType(outputType);
+
   typedef itk::ImageFileWriter<ImageType> WriterType;
   WriterType::Pointer writer = WriterType::New();
   stringstream imageFileNameSStream;
-  imageFileNameSStream << outputDirName << "/" << "pmap.nrrd";
+  imageFileNameSStream << outputDirName << "/" << "pmap" << fileExtension;
   writer->SetFileName(imageFileNameSStream.str().c_str());
   writer->SetInput(result.first);
   writer->SetUseCompression(1);

--- a/apps/paramaps/paramap2itkimage.xml
+++ b/apps/paramaps/paramap2itkimage.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Informatics.Converters</category>
-  <title>Encode DICOM Parametric Map</title>
-  <description>Create itk image from DICOM Parametric Map Image object.</description>
-  <version></version>
-  <documentation-url></documentation-url>
+  <title>Convert DICOM Parametric Map into ITK image</title>
+  <description>Convert a DICOM Parametric Map Image object into ITK image format including the generation of a json file holding meta information.</description>
+  <version>1.0</version>
+  <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
-    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
-    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
     <file>

--- a/apps/paramaps/paramap2itkimage.xml
+++ b/apps/paramaps/paramap2itkimage.xml
@@ -7,7 +7,9 @@
   <documentation-url></documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements></acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
+    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
+    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
     <file>

--- a/apps/paramaps/paramap2itkimage.xml
+++ b/apps/paramaps/paramap2itkimage.xml
@@ -7,9 +7,9 @@
   <documentation-url></documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-<acknowledgements></acknowledgements>
+  <acknowledgements></acknowledgements>
 
-<parameters>
+  <parameters>
     <file>
       <name>inputFileName</name>
       <label>Parametric Map DICOM file name</label>
@@ -19,12 +19,28 @@
     </file>
 
     <directory>
-        <name>outputDirName</name>
-        <label>Output directory name</label>
-        <channel>output</channel>
-        <longflag>outputDirName</longflag>
-        <description>Directory to store parametric map as NRRD file.</description>
+      <name>outputDirName</name>
+      <label>Output directory name</label>
+      <channel>output</channel>
+      <longflag>outputDirName</longflag>
+      <description>Directory to store parametric map as NRRD file.</description>
     </directory>
+
+    <string-enumeration>
+      <name>outputType</name>
+      <label>Output type</label>
+      <flag>-t</flag>
+      <longflag>--outputType</longflag>
+      <description>Output type of the resulting image data.</description>
+      <default>nrrd</default>
+      <element>mhd</element>
+      <element>mha</element>
+      <element>nii</element>
+      <element>nifti</element>
+      <element>hdr</element>
+      <element>img</element>
+    </string-enumeration>
+
   </parameters>
 
 </executable>

--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
   ifstream metainfoStream(metaDataFileName.c_str(), ios_base::binary);
   std::string metadata( (std::istreambuf_iterator<char>(metainfoStream) ),
                        (std::istreambuf_iterator<char>()));
-  DcmDataset* result = dcmqi::ImageSEGConverter::itkimage2dcmSegmentation(dcmDatasets, segmentations, metadata);
+  DcmDataset* result = dcmqi::ImageSEGConverter::itkimage2dcmSegmentation(dcmDatasets, segmentations, metadata, !noSkipEmptySlices);
 
   if (result == NULL){
     return EXIT_FAILURE;

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -2,14 +2,12 @@
 <executable>
   <category>Informatics.Converters</category>
   <title>Encode DICOM SEG</title>
-  <description>Create DICOM Segmentation Image object from non-DICOM segmentations</description>
-  <version></version>
-  <documentation-url></documentation-url>
+  <description>Convert the volumetric segmentation(s) stored as labeled pixels using any of the formats supported by ITK, such as NRRD or NIFTI, into a DICOM Segmentation Object (further referred to as SEG).</description>
+  <version>1.0</version>
+  <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
-    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
-    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
     <string-vector>

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -7,7 +7,9 @@
   <documentation-url></documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements></acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
+    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
+    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
     <string-vector>

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -42,13 +42,13 @@
       <description>File name of the SEG object that will keep the result.</description>
     </file>
 
-    <!--<boolean>-->
-      <!--<name>skipEmptySlices</name>-->
-      <!--<label>Skip empty slices</label>-->
-      <!--<channel>input</channel>-->
-      <!--<longflag>skip</longflag>-->
-      <!--<description>Skip empty slices while encoding segmentation image.</description>-->
-    <!--</boolean>-->
+    <boolean>
+      <name>noSkipEmptySlices</name>
+      <label>Skip empty slices</label>
+      <channel>input</channel>
+      <longflag>noskip</longflag>
+      <description>Don't skip empty slices while encoding segmentation image.</description>-->
+    </boolean>
 
     <!--<boolean>-->
       <!--<name>compress</name>-->

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -6,10 +6,10 @@
   <version></version>
   <documentation-url></documentation-url>
   <license></license>
-  <contributor>Andrey Fedorov, BWH</contributor>
-<acknowledgements></acknowledgements>
+  <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
+  <acknowledgements></acknowledgements>
 
-<parameters>
+  <parameters>
     <string-vector>
       <name>dicomImageFiles</name>
       <label>DICOM images file names</label>

--- a/apps/seg/segimage2itkimage.cxx
+++ b/apps/seg/segimage2itkimage.cxx
@@ -5,6 +5,7 @@
 #undef HAVE_SSTREAM // Avoid redefinition warning
 #include "dcmqi/ImageSEGConverter.h"
 
+
 int main(int argc, char *argv[])
 {
   PARSE_ARGS;
@@ -17,15 +18,13 @@ int main(int argc, char *argv[])
 
   string outputPrefix = prefix.empty() ? "" : prefix + "-";
 
+  string fileExtension = dcmqi::Helper::getFileExtensionFromType(outputType);
+
   for(map<unsigned,ImageType::Pointer>::const_iterator sI=result.first.begin();sI!=result.first.end();++sI){
     typedef itk::ImageFileWriter<ImageType> WriterType;
     stringstream imageFileNameSStream;
 
-    if (niftiOutput) {
-      imageFileNameSStream << outputDirName << "/" << outputPrefix << sI->first << ".nii.gz";
-    } else {
-      imageFileNameSStream << outputDirName << "/" << outputPrefix << sI->first << ".nrrd";
-    }
+    imageFileNameSStream << outputDirName << "/" << outputPrefix << sI->first << fileExtension;
 
     WriterType::Pointer writer = WriterType::New();
     writer->SetFileName(imageFileNameSStream.str().c_str());

--- a/apps/seg/segimage2itkimage.cxx
+++ b/apps/seg/segimage2itkimage.cxx
@@ -20,7 +20,12 @@ int main(int argc, char *argv[])
   for(map<unsigned,ImageType::Pointer>::const_iterator sI=result.first.begin();sI!=result.first.end();++sI){
     typedef itk::ImageFileWriter<ImageType> WriterType;
     stringstream imageFileNameSStream;
-    imageFileNameSStream << outputDirName << "/" << outputPrefix << sI->first << ".nrrd";
+
+    if (niftiOutput) {
+      imageFileNameSStream << outputDirName << "/" << outputPrefix << sI->first << ".nii.gz";
+    } else {
+      imageFileNameSStream << outputDirName << "/" << outputPrefix << sI->first << ".nrrd";
+    }
 
     WriterType::Pointer writer = WriterType::New();
     writer->SetFileName(imageFileNameSStream.str().c_str());

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Informatics</category>
-  <title>Convert DICOM SEG into ITK image file format + json</title>
-  <description></description>
-  <version></version>
-  <documentation-url></documentation-url>
+  <title>Convert DICOM SEG into ITK image</title>
+  <description>Convert a DICOM Segmentation Object into volumetric segmentation(s) stored as labeled pixels as NRRD file format + meta information stored in the JSON file format.</description>
+  <version>1.0</version>
+  <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
-    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
-    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
     <file>

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Informatics</category>
-  <title>Convert DICOM SEG into NRRD</title>
+  <title>Convert DICOM SEG into ITK image file format + json</title>
   <description></description>
   <version></version>
   <documentation-url></documentation-url>
   <license></license>
-  <contributor>Andrey Fedorov, BWH</contributor>
-<acknowledgements></acknowledgements>
+  <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
+  <acknowledgements></acknowledgements>
 
-<parameters>
+  <parameters>
     <file>
       <name>inputSEGFileName</name>
       <label>SEG file name</label>
@@ -21,38 +21,34 @@
     <string>
       <name>prefix</name>
       <label>Output prefix</label>
-      <flag>-n</flag>
+      <flag>-p</flag>
       <longflag>--prefix</longflag>
       <description>Prefix for output files</description>
       <default></default>
     </string>
-
-    <!--<boolean>-->
-      <!--<name>combineSegments</name>-->
-      <!--<flag>c</flag>-->
-      <!--<longflag>combine</longflag>-->
-      <!--<label>Combine segments</label>-->
-      <!--<channel>input</channel>-->
-      <!--<default>0</default>-->
-      <!--<description>Combine segments into one output file. This option will cause warnings to be printed on the console in case segments overlap and are overwritten. For now, always split into separate files.</description>-->
-    <!--</boolean>-->
 
     <file>
       <name>outputDirName</name>
       <label>Output directory name</label>
       <channel>input</channel>
       <index>1</index>
-      <description>Directory to store individual segments as NRRD files. File names will correspond to the segment numbers.</description>
+      <description>Directory to store individual segments as itk files. File names will correspond to the segment numbers.</description>
     </file>
 
-    <boolean>
-      <name>niftiOutput</name>
-      <longflag>nii</longflag>
-      <label>Output a nifti file (.nii.gz) instead of a .nrrd file</label>
-      <channel>input</channel>
-      <default>0</default>
-      <description>Output a nifti file (.nii.gz) instead of a .nrrd file</description>
-    </boolean>
+    <string-enumeration>
+      <name>outputType</name>
+      <flag>-t</flag>
+      <longflag>--outputType</longflag>
+      <description>Output type of the resulting image data.</description>
+      <label>Output type</label>
+      <default>nrrd</default>
+      <element>mhd</element>
+      <element>mha</element>
+      <element>nii</element>
+      <element>nifti</element>
+      <element>hdr</element>
+      <element>img</element>
+    </string-enumeration>
 
   </parameters>
 

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -45,6 +45,15 @@
       <description>Directory to store individual segments as NRRD files. File names will correspond to the segment numbers.</description>
     </file>
 
+    <boolean>
+      <name>niftiOutput</name>
+      <longflag>nii</longflag>
+      <label>Output a nifti file (.nii.gz) instead of a .nrrd file</label>
+      <channel>input</channel>
+      <default>0</default>
+      <description>Output a nifti file (.nii.gz) instead of a .nrrd file</description>
+    </boolean>
+
   </parameters>
 
 </executable>

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -7,7 +7,9 @@
   <documentation-url></documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements></acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
+    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
+    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
     <file>

--- a/apps/sr/tid1500reader.xml
+++ b/apps/sr/tid1500reader.xml
@@ -6,27 +6,27 @@
   <version></version>
   <documentation-url></documentation-url>
   <license></license>
-  <contributor>Andrey Fedorov, BWH</contributor>
-<acknowledgements></acknowledgements>
+  <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
+  <acknowledgements></acknowledgements>
 
-<parameters>
+  <parameters>
 
     <file>
-        <name>inputSRFileName</name>
-        <label>SR file name</label>
-        <channel>input</channel>
-        <longflag>inputSRFileName</longflag>
-        <description>File name of the SR object.</description>
+      <name>inputSRFileName</name>
+      <label>SR file name</label>
+      <channel>input</channel>
+      <longflag>inputSRFileName</longflag>
+      <description>File name of the SR object.</description>
     </file>
 
     <file>
-        <name>metaDataFileName</name>
-        <label>JSON file name</label>
-        <channel>output</channel>
-        <longflag>metaDataFileName</longflag>
-        <description>JSON file name that will keep the metadata and measurements information.</description>
+      <name>metaDataFileName</name>
+      <label>JSON file name</label>
+      <channel>output</channel>
+      <longflag>metaDataFileName</longflag>
+      <description>JSON file name that will keep the metadata and measurements information.</description>
     </file>
 
-</parameters>
+  </parameters>
 
 </executable>

--- a/apps/sr/tid1500reader.xml
+++ b/apps/sr/tid1500reader.xml
@@ -7,7 +7,9 @@
   <documentation-url></documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements></acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
+    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
+    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
 

--- a/apps/sr/tid1500reader.xml
+++ b/apps/sr/tid1500reader.xml
@@ -2,14 +2,12 @@
 <executable>
   <category>Informatics</category>
   <title>DICOM Measurements reporting</title>
-  <description></description>
-  <version></version>
-  <documentation-url></documentation-url>
+  <description>Save measurements calculated from the image over a volume defined by image segmentation into a DICOM Structured Report that follows template TID1500.</description>
+  <version>1.0</version>
+  <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
-    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
-    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
 

--- a/apps/sr/tid1500writer.xml
+++ b/apps/sr/tid1500writer.xml
@@ -6,41 +6,41 @@
   <version></version>
   <documentation-url></documentation-url>
   <license></license>
-  <contributor>Andrey Fedorov, BWH</contributor>
-<acknowledgements></acknowledgements>
+  <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
+  <acknowledgements></acknowledgements>
 
-<parameters>
+  <parameters>
 
-  <file>
-    <name>metaDataFileName</name>
-    <label>JSON metadata file</label>
-    <channel>input</channel>
-    <longflag>metaDataFileName</longflag>
-  </file>
+    <file>
+      <name>metaDataFileName</name>
+      <label>JSON metadata file</label>
+      <channel>input</channel>
+      <longflag>metaDataFileName</longflag>
+    </file>
 
-  <file>
-    <name>compositeContextDataDir</name>
-    <label>Composite context DICOM data dir</label>
-    <channel>input</channel>
-    <longflag>compositeContextDataDir</longflag>
-    <description>Location of input DICOM Data to be used for populating composite context</description>
-  </file>
+    <file>
+      <name>compositeContextDataDir</name>
+      <label>Composite context DICOM data dir</label>
+      <channel>input</channel>
+      <longflag>compositeContextDataDir</longflag>
+      <description>Location of input DICOM Data to be used for populating composite context</description>
+    </file>
 
-  <file>
-    <name>imageLibraryDataDir</name>
-    <label>Image library DICOM data dir</label>
-    <channel>input</channel>
-    <longflag>imageLibraryDataDir</longflag>
-    <description>Location of input DICOM Data to be used for populating image library</description>
-  </file>
+    <file>
+      <name>imageLibraryDataDir</name>
+      <label>Image library DICOM data dir</label>
+      <channel>input</channel>
+      <longflag>imageLibraryDataDir</longflag>
+      <description>Location of input DICOM Data to be used for populating image library</description>
+    </file>
 
-  <file>
-    <name>outputFileName</name>
-    <label>Output DICOM SR file name</label>
-    <channel>output</channel>
-    <longflag>outputFileName</longflag>
-  </file>
+    <file>
+      <name>outputFileName</name>
+      <label>Output DICOM SR file name</label>
+      <channel>output</channel>
+      <longflag>outputFileName</longflag>
+    </file>
 
-</parameters>
+  </parameters>
 
 </executable>

--- a/apps/sr/tid1500writer.xml
+++ b/apps/sr/tid1500writer.xml
@@ -2,14 +2,12 @@
 <executable>
   <category>Informatics</category>
   <title>DICOM Measurements reporting</title>
-  <description></description>
-  <version></version>
-  <documentation-url></documentation-url>
+  <description>convert a DICOM Structured Report (template TID1500) into a human readable representation by means of the JSON file format.</description>
+  <version>1.0</version>
+  <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
-    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
-    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
 

--- a/apps/sr/tid1500writer.xml
+++ b/apps/sr/tid1500writer.xml
@@ -7,7 +7,9 @@
   <documentation-url></documentation-url>
   <license></license>
   <contributor>Andrey Fedorov(BWH), Christian Herz(BWH)</contributor>
-  <acknowledgements></acknowledgements>
+  <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute,
+    Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research
+    (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
 

--- a/include/dcmqi/Helper.h
+++ b/include/dcmqi/Helper.h
@@ -26,6 +26,8 @@ namespace dcmqi {
 
   public:
 
+    static string getFileExtensionFromType(const string& type);
+
     static string floatToStrScientific(float f);
     static void tokenizeString(string str, vector<string> &tokens, string delimiter);
     static void splitString(string str, string &head, string &tail, string delimiter);

--- a/include/dcmqi/ImageSEGConverter.h
+++ b/include/dcmqi/ImageSEGConverter.h
@@ -41,7 +41,9 @@ namespace dcmqi {
   public:
     static DcmDataset* itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
                                                 vector<ImageType::Pointer> segmentations,
-                                                const string &metaData);
+                                                const string &metaData,
+												bool skipEmptySlices=true);
+
 
     static pair <map<unsigned,ImageType::Pointer>, string> dcmSegmentation2itkimage(DcmDataset *segDataset);
 

--- a/include/dcmqi/ImageSEGConverter.h
+++ b/include/dcmqi/ImageSEGConverter.h
@@ -42,7 +42,7 @@ namespace dcmqi {
     static DcmDataset* itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
                                                 vector<ImageType::Pointer> segmentations,
                                                 const string &metaData,
-												bool skipEmptySlices=true);
+                                                bool skipEmptySlices=true);
 
 
     static pair <map<unsigned,ImageType::Pointer>, string> dcmSegmentation2itkimage(DcmDataset *segDataset);

--- a/libsrc/Helper.cpp
+++ b/libsrc/Helper.cpp
@@ -4,6 +4,23 @@
 
 namespace dcmqi {
 
+  string Helper::getFileExtensionFromType(const string& type) {
+    string extension = ".nrrd";
+    if (type == "nii" || type == "nifti")
+      extension = ".nii.gz";
+    else if (type == "mhd")
+      extension = ".mhd";
+    else if (type == "mha")
+      extension = ".mha";
+    else if (type == "img")
+      extension = ".img";
+    else if (type == "hdr")
+      extension = ".hdr";
+    else if (type == "nrrd")
+      extension = ".nrrd";
+    return extension;
+  }
+
   string Helper::floatToStrScientific(float f) {
     ostringstream sstream;
     sstream << scientific << f;

--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -7,7 +7,8 @@ namespace dcmqi {
 
   DcmDataset* ImageSEGConverter::itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
                                                           vector<ImageType::Pointer> segmentations,
-                                                          const string &metaData) {
+                                                          const string &metaData,
+                                                          bool skipEmptySlices) {
 
     ImageType::SizeType inputSize = segmentations[0]->GetBufferedRegion().GetSize();
     cout << "Input image size: " << inputSize << endl;
@@ -167,7 +168,8 @@ namespace dcmqi {
 
         LabelStatisticsType::BoundingBoxType bbox = labelStats->GetBoundingBox(label);
         unsigned firstSlice, lastSlice;
-        bool skipEmptySlices = true; // TODO: what to do with that line?
+        //bool skipEmptySlices = true; // TODO: what to do with that line?
+        //bool skipEmptySlices = false; // TODO: what to do with that line?
         if(skipEmptySlices){
           firstSlice = bbox[4];
           lastSlice = bbox[5]+1;


### PR DESCRIPTION
supported itk output formats: mhd|mha|nii|nifti|hdr|img

fixes #175
related to https://github.com/QIICR/dcmqi/pull/123

@fedorov let me know if I should add other file formats