### PR TITLE
STYLE: remove warning about inconsistent frame spacing

### DIFF
--- a/include/dcmqi/ConverterBase.h
+++ b/include/dcmqi/ConverterBase.h
@@ -216,10 +216,6 @@ namespace dcmqi {
         for(size_t i=1;i<originDistances.size(); i++){
           float dist1 = fabs(originDistances[i-1]-originDistances[i]);
           float delta = sliceSpacing-dist1;
-          if(delta > 0.001){
-            cerr << "WARNING: Inter-slice distance " << originDistances[i] <<
-            " difference exceeded threshold: " << delta << endl;
-          }
         }
 
         sliceExtent = fabs(originDistances[0]-originDistances[originDistances.size()-1]);


### PR DESCRIPTION
as discussed in the comment in ConverterBase.h, this warning is irrelevant and misleading,
since spacing between frames is not calculated on a per-segment basis. Spacing
is not expected to be consistent, even for individual segments, since segments can
have gaps.