### PR TITLE
WIP: clean up CLI XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,13 @@ Specifically, the current focus of development for dcmqi is to support conversio
 
 As an introduction to the motivation, capabilities and advantages of using the DICOM standard, and the objects mentioned above, you might want to read this open access paper:
 
-Fedorov A, Clunie D, Ulrich E, Bauer C, Wahle A, Brown B, Onken M, Riesmeier J, Pieper S, Kikinis R, Buatti J, Beichel RR. (2016) DICOM for quantitative imaging biomarker development: a standards based approach to sharing clinical data and structured PET/CT analysis results in head and neck cancer research. *PeerJ* 4:e2057 https://doi.org/10.7717/peerj.2057
-
-dcmqi is under active development. The functionality available is being refined, may (and most likely, will) change in the future, and may not work as expected. The organization of the documentation will also change in the future.
+> Fedorov A, Clunie D, Ulrich E, Bauer C, Wahle A, Brown B, Onken M, Riesmeier J, Pieper S, Kikinis R, Buatti J, Beichel RR. (2016) DICOM for quantitative imaging biomarker development: a standards based approach to sharing clinical data and structured PET/CT analysis results in head and neck cancer research. *PeerJ* 4:e2057 https://doi.org/10.7717/peerj.2057
 
 dcmqi is developed and maintained by the [QIICR](http://qiicr.org) project.
 
 # Getting started
 
-At the moment, we do not provide pre-built packages for dcmqi. If you want to give it a try, you will need to check out the source code and build it yourself. 
-
-dcmqi is not platform specific. Our goal is to support its use on Windows, Mac and Linux.
-
-In the future (pending resolution of issues on the gitbooks platform), instructions on how to build dcmqi and how to use it will be provided in the [dcmqi gitbook manual](https://fedorov.gitbooks.io/dcmqi/content/v/gitbook/).
-
-For now, please check out [dcmqi faq](https://github.com/QIICR/dcmqi-faq/issues) to find instructions on how to build dcmqi, and how to use certain components.
+Installation and usage instructions are available in [dcmqi gitbook manual](https://fedorov.gitbooks.io/dcmqi/content/v/gitbook/).
 
 # License
 
@@ -44,14 +36,6 @@ You can communicate you feedback, feature requests, comments or problem reports 
   group](https://groups.google.com/forum/#!forum/dcmqi)
 * send email to [Andrey Fedorov](http://fedorov.github.io)
 * leave comments in the [dcmqi gitbook manual](https://fedorov.gitbooks.io/dcmqi/content/v/gitbook/)
-
-# dcmqi health monitors
-
-Indicators below can be used to check whether current version of dcmqi source code has any build or testing issues on our continuous integration platforms (green means good).
-
-* Linux: [![Circle CI](https://circleci.com/gh/QIICR/dcmqi.svg?style=svg)](https://circleci.com/gh/QIICR/dcmqi)
-* Windows: [![Build status](https://ci.appveyor.com/api/projects/status/04l87y2j6prboap7?svg=true)](https://ci.appveyor.com/project/fedorov/dcmqi)
-* Mac OS X: [![TravisCI](https://travis-ci.org/QIICR/dcmqi.svg?branch=master)](https://travis-ci.org/QIICR/dcmqi)
 
 # Acknowledgments
 

--- a/apps/paramaps/Testing/CMakeLists.txt
+++ b/apps/paramaps/Testing/CMakeLists.txt
@@ -26,8 +26,8 @@ dcmqi_add_test(
   COMMAND $<TARGET_FILE:${MODULE_NAME}>
     --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/pm-example.json
     --inputImage ${BASELINE}/pm-example.nrrd
-    --outputDICOM ${TEMP_DIR}/paramap.dcm
     --inputDICOM ${BASELINE}/pm-example-slice.dcm
+    --outputDICOM ${TEMP_DIR}/paramap.dcm
   )
 
 dcmqi_add_test(
@@ -36,8 +36,8 @@ dcmqi_add_test(
   COMMAND $<TARGET_FILE:${MODULE_NAME}>
     --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/pm-example-float.json
     --inputImage ${BASELINE}/pm-example-float.nrrd
-    --outputDICOM ${TEMP_DIR}/paramap-float.dcm
     --inputDICOM ${BASELINE}/pm-example-slice.dcm
+    --outputDICOM ${TEMP_DIR}/paramap-float.dcm
   )
 
 #-----------------------------------------------------------------------------

--- a/apps/paramaps/Testing/CMakeLists.txt
+++ b/apps/paramaps/Testing/CMakeLists.txt
@@ -24,20 +24,20 @@ dcmqi_add_test(
   NAME ${MODULE_NAME}_makeParametricMap
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${MODULE_NAME}>
-    --metaDataFileName ${CMAKE_SOURCE_DIR}/doc/examples/pm-example.json
-    --inputFileName ${BASELINE}/pm-example.nrrd
-    --outputParaMapFileName ${TEMP_DIR}/paramap.dcm
-    --dicomImageFileName ${BASELINE}/pm-example-slice.dcm
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/pm-example.json
+    --inputImage ${BASELINE}/pm-example.nrrd
+    --outputDICOM ${TEMP_DIR}/paramap.dcm
+    --inputDICOM ${BASELINE}/pm-example-slice.dcm
   )
 
 dcmqi_add_test(
   NAME ${MODULE_NAME}_makeParametricMapFP
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${MODULE_NAME}>
-    --metaDataFileName ${CMAKE_SOURCE_DIR}/doc/examples/pm-example-float.json
-    --inputFileName ${BASELINE}/pm-example-float.nrrd
-    --outputParaMapFileName ${TEMP_DIR}/paramap-float.dcm
-    --dicomImageFileName ${BASELINE}/pm-example-slice.dcm
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/pm-example-float.json
+    --inputImage ${BASELINE}/pm-example-float.nrrd
+    --outputDICOM ${TEMP_DIR}/paramap-float.dcm
+    --inputDICOM ${BASELINE}/pm-example-slice.dcm
   )
 
 #-----------------------------------------------------------------------------
@@ -61,8 +61,8 @@ dcmqi_add_test(
   COMMAND $<TARGET_FILE:${MODULE_NAME}Test>
     --compare ${BASELINE}/pm-example.nrrd ${TEMP_DIR}/pmap.nrrd
     ${MODULE_NAME}Test
-      --inputFileName ${TEMP_DIR}/paramap.dcm
-      --outputDirName ${TEMP_DIR}
+      --inputDICOM ${TEMP_DIR}/paramap.dcm
+      --outputDirectory ${TEMP_DIR}
   TEST_DEPENDS
     itkimage2paramap_makeParametricMap
   )
@@ -74,8 +74,8 @@ dcmqi_add_test(
   COMMAND $<TARGET_FILE:${MODULE_NAME}Test>
     --compare ${BASELINE}/pm-example-float.nrrd ${TEMP_DIR}/pmap.nrrd
     ${MODULE_NAME}Test
-      --inputFileName ${TEMP_DIR}/paramap-float.dcm
-      --outputDirName ${TEMP_DIR}
+      --inputDICOM ${TEMP_DIR}/paramap-float.dcm
+      --outputDirectory ${TEMP_DIR}
   TEST_DEPENDS
     itkimage2paramap_makeParametricMapFP
   )

--- a/apps/paramaps/itkimage2paramap.xml
+++ b/apps/paramaps/itkimage2paramap.xml
@@ -2,7 +2,7 @@
 <executable>
   <category>Informatics.Converters</category>
   <title>Encode DICOM Parametric Map</title>
-  <description>Convert a parametric map provided in any of the formats supported by ITK, such as NRRD or NIFTI, as a DICOM Parametric Map image object.</description>
+  <description>Convert a parametric map provided in any of the formats supported by ITK, such as NRRD or NIFTI, into a DICOM Parametric Map image object.</description>
   <version>1.0</version>
   <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
@@ -10,12 +10,29 @@
   <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
+
+    <file>
+      <name>metaDataFileName</name>
+      <label>JSON metadata file</label>
+      <channel>input</channel>
+      <index>0</index>
+      <description>File name of the JSON files containing metadata attributes.</description>
+    </file>
+
     <file>
       <name>inputFileName</name>
       <label>Parametric Map file name</label>
       <channel>input</channel>
-      <longflag>inputFileName</longflag>
+      <index>1</index>
       <description>File name of the parametric map image in a format readable by ITK (NRRD, NIfTI, MHD, etc.).</description>
+    </file>
+
+    <file>
+      <name>outputParaMapFileName</name>
+      <label>Parametric map file name</label>
+      <channel>output</channel>
+      <index>2</index>
+      <description>File name of the DICOM Parametric map object with the result of the conversion.</description>
     </file>
 
     <file>
@@ -24,24 +41,9 @@
       <channel>input</channel>
       <longflag>dicomImageFileName</longflag>
       <default></default>
-      <description>File name of the DICOM image file which has been used </description>
+      <description>File name of the DICOM image file that should be used to populate the composite context (attributes related to the patient and imaging study).</description>
     </file>
 
-    <file>
-      <name>metaDataFileName</name>
-      <label>JSON metadata file</label>
-      <channel>input</channel>
-      <longflag>metaDataFileName</longflag>
-      <description>File names of the text files containing metadata attributes.</description>
-    </file>
-
-    <file>
-      <name>outputParaMapFileName</name>
-      <label>Parametric map file name</label>
-      <channel>output</channel>
-      <longflag>outputParaMapFileName</longflag>
-      <description>File name of the parametric map object that will keep the result.</description>
-    </file>
   </parameters>
 
 </executable>

--- a/apps/paramaps/itkimage2paramap.xml
+++ b/apps/paramaps/itkimage2paramap.xml
@@ -12,26 +12,26 @@
   <parameters>
 
     <file>
-      <name>metaDataFileName</name>
-      <label>JSON metadata file</label>
-      <channel>input</channel>
-      <index>0</index>
-      <description>File name of the JSON files containing metadata attributes.</description>
-    </file>
-
-    <file>
       <name>inputFileName</name>
       <label>Parametric Map file name</label>
       <channel>input</channel>
-      <index>1</index>
+      <longflag>inputImage</longflag>
       <description>File name of the parametric map image in a format readable by ITK (NRRD, NIfTI, MHD, etc.).</description>
+    </file>
+
+    <file>
+      <name>metaDataFileName</name>
+      <label>JSON metadata file</label>
+      <channel>input</channel>
+      <longflag>inputMetadata</longflag>
+      <description>File name of the JSON files containing metadata attributes.</description>
     </file>
 
     <file>
       <name>outputParaMapFileName</name>
       <label>Parametric map file name</label>
       <channel>output</channel>
-      <index>2</index>
+      <longflag>outputDICOM</longflag>
       <description>File name of the DICOM Parametric map object with the result of the conversion.</description>
     </file>
 
@@ -39,7 +39,7 @@
       <name>dicomImageFileName</name>
       <label>DICOM images file name</label>
       <channel>input</channel>
-      <longflag>dicomImageFileName</longflag>
+      <longflag>inputDICOM</longflag>
       <default></default>
       <description>File name of the DICOM image file that should be used to populate the composite context (attributes related to the patient and imaging study).</description>
     </file>

--- a/apps/paramaps/paramap2itkimage.xml
+++ b/apps/paramaps/paramap2itkimage.xml
@@ -14,7 +14,7 @@
       <name>inputFileName</name>
       <label>Parametric Map DICOM file name</label>
       <channel>input</channel>
-      <index>0</index>
+      <longflag>inputDICOM</longflag>
       <description>File name of the DICOM Parametric map image.</description>
     </file>
 
@@ -22,7 +22,7 @@
       <name>outputDirName</name>
       <label>Output directory name</label>
       <channel>output</channel>
-      <index>1</index>
+      <longflag>outputDirectory</longflag>
       <description>Directory to store parametric map in an ITK format, and the JSON metadata file.</description>
     </directory>
 

--- a/apps/paramaps/paramap2itkimage.xml
+++ b/apps/paramaps/paramap2itkimage.xml
@@ -2,7 +2,7 @@
 <executable>
   <category>Informatics.Converters</category>
   <title>Convert DICOM Parametric Map into ITK image</title>
-  <description>Convert a DICOM Parametric Map Image object into ITK image format including the generation of a json file holding meta information.</description>
+  <description>This tool can be used to convert a DICOM Parametric Map Image object into ITK image format, and generate a JSON file holding meta information.</description>
   <version>1.0</version>
   <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
@@ -14,16 +14,16 @@
       <name>inputFileName</name>
       <label>Parametric Map DICOM file name</label>
       <channel>input</channel>
-      <longflag>inputFileName</longflag>
-      <description>File name of the parametric map image in a format readable by ITK (NRRD, NIfTI, MHD, etc.).</description>
+      <index>0</index>
+      <description>File name of the DICOM Parametric map image.</description>
     </file>
 
     <directory>
       <name>outputDirName</name>
       <label>Output directory name</label>
       <channel>output</channel>
-      <longflag>outputDirName</longflag>
-      <description>Directory to store parametric map as NRRD file.</description>
+      <index>1</index>
+      <description>Directory to store parametric map in an ITK format, and the JSON metadata file.</description>
     </directory>
 
     <string-enumeration>
@@ -31,7 +31,7 @@
       <label>Output type</label>
       <flag>-t</flag>
       <longflag>--outputType</longflag>
-      <description>Output type of the resulting image data.</description>
+      <description>Output ITK format for the output image.</description>
       <default>nrrd</default>
       <element>nrrd</element>
       <element>mhd</element>

--- a/apps/seg/Testing/CMakeLists.txt
+++ b/apps/seg/Testing/CMakeLists.txt
@@ -23,20 +23,20 @@ dcmqi_add_test(
   NAME ${itk2dcm}_makeSEG
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${itk2dcm}>
-    --metaDataFileName ${CMAKE_SOURCE_DIR}/doc/examples/seg-example.json
-    --segImageFiles ${BASELINE}/liver_seg.nrrd
-    --dicomImageFiles ${BASELINE}/01.dcm,${BASELINE}/02.dcm,${BASELINE}/03.dcm
-    --segDICOMFile ${MODULE_TEMP_DIR}/liver.dcm
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/seg-example.json
+    --inputImageList ${BASELINE}/liver_seg.nrrd
+    --inputDICOMList ${BASELINE}/01.dcm,${BASELINE}/02.dcm,${BASELINE}/03.dcm
+    --outputDICOM ${MODULE_TEMP_DIR}/liver.dcm
   )
 
 dcmqi_add_test(
   NAME ${itk2dcm}_makeSEG_multiple_segment_files
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${itk2dcm}>
-    --metaDataFileName ${CMAKE_SOURCE_DIR}/doc/examples/seg-example_multiple_segments.json
-    --segImageFiles ${BASELINE}/liver_seg.nrrd,${BASELINE}/spine_seg.nrrd,${BASELINE}/heart_seg.nrrd
-    --dicomImageFiles ${BASELINE}/01.dcm,${BASELINE}/02.dcm,${BASELINE}/03.dcm
-    --segDICOMFile ${MODULE_TEMP_DIR}/liver_heart_seg.dcm
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/seg-example_multiple_segments.json
+    --inputImageList ${BASELINE}/liver_seg.nrrd,${BASELINE}/spine_seg.nrrd,${BASELINE}/heart_seg.nrrd
+    --inputDICOMList ${BASELINE}/01.dcm,${BASELINE}/02.dcm,${BASELINE}/03.dcm
+    --outputDICOM ${MODULE_TEMP_DIR}/liver_heart_seg.dcm
   )
 
 find_program(DCIODVFY_EXECUTABLE dciodvfy)
@@ -78,8 +78,8 @@ dcmqi_add_test(
     --compare ${BASELINE}/liver_seg.nrrd
     ${MODULE_TEMP_DIR}/makeNRRD-1.nrrd
     ${dcm2itk}Test
-    ${MODULE_TEMP_DIR}/liver.dcm
-    ${MODULE_TEMP_DIR}
+    --inputDICOM ${MODULE_TEMP_DIR}/liver.dcm
+    --outputDirectory ${MODULE_TEMP_DIR}
     --outputType nrrd
     --prefix makeNRRD
   TEST_DEPENDS
@@ -94,8 +94,8 @@ dcmqi_add_test(
     --compare ${BASELINE}spine_seg.nrrd ${MODULE_TEMP_DIR}/makeNRRD_multiple_segments-2.nrrd
     --compare ${BASELINE}heart_seg.nrrd ${MODULE_TEMP_DIR}/makeNRRD_multiple_segments-3.nrrd
     ${dcm2itk}Test
-    ${MODULE_TEMP_DIR}/liver_heart_seg.dcm
-    ${MODULE_TEMP_DIR}
+    --inputDICOM ${MODULE_TEMP_DIR}/liver_heart_seg.dcm
+    --outputDirectory ${MODULE_TEMP_DIR}
     --prefix makeNRRD_multiple_segments
   TEST_DEPENDS
     ${itk2dcm}_makeSEG_multiple_segment_files

--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
   ifstream metainfoStream(metaDataFileName.c_str(), ios_base::binary);
   std::string metadata( (std::istreambuf_iterator<char>(metainfoStream) ),
                        (std::istreambuf_iterator<char>()));
-  DcmDataset* result = dcmqi::ImageSEGConverter::itkimage2dcmSegmentation(dcmDatasets, segmentations, metadata, !noSkipEmptySlices);
+  DcmDataset* result = dcmqi::ImageSEGConverter::itkimage2dcmSegmentation(dcmDatasets, segmentations, metadata, skipEmptySlices);
 
   if (result == NULL){
     return EXIT_FAILURE;

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -15,7 +15,7 @@
       <name>metaDataFileName</name>
       <label>JSON metadata file</label>
       <channel>input</channel>
-      <index>0</index>
+      <longflag>inputMetadata</longflag>
       <description>JSON file containing the meta-information that describes the measurements to be encoded. See documentation for details.</description>
     </file>
 
@@ -23,7 +23,7 @@
       <name>outputSEGFileName</name>
       <label>SEG file name</label>
       <channel>output</channel>
-      <index>1</index>
+      <longflag>outputDICOM</longflag>
       <description>File name of the DICOM SEG object that will store the result of conversion.</description>
     </file>
 
@@ -31,7 +31,7 @@
       <name>dicomImageFiles</name>
       <label>DICOM images file names</label>
       <channel>input</channel>
-      <longflag>dicomImageFiles</longflag>
+      <longflag>inputDICOMList</longflag>
       <description>Comma-separated list of DICOM images that correspond to the original image that was segmented. This means you must have access to the original data in DICOM in order to use the converter (at least for now).</description>
     </string-vector>
 
@@ -39,17 +39,17 @@
       <name>segImageFiles</name>
       <label>Segmentation file names</label>
       <channel>input</channel>
-      <longflag>segImageFiles</longflag>
+      <longflag>inputImageList</longflag>
       <description>Comma-separated list of file names of the segmentation images in a format readable by ITK (NRRD, NIfTI, MHD, etc.). Each of the individual files can contain one or more labels (segments). Segments from different files are allowed to overlap. See documentation for details.</description>
     </string-vector>
 
     <boolean>
-      <name>noSkipEmptySlices</name>
-      <label>Do not skip empty slices</label>
+      <name>skipEmptySlices</name>
+      <label>Skip empty slices</label>
       <channel>input</channel>
-      <longflag>noskip</longflag>
-      <default>false</default>
-      <description>Don't skip empty slices while encoding segmentation image. By default, empty slices will not be encoded, resulting in a smaller output file size.</description>-->
+      <longflag>skip</longflag>
+      <default>true</default>
+      <description>Skip empty slices while encoding segmentation image. By default, empty slices will not be encoded, resulting in a smaller output file size.</description>-->
     </boolean>
 
     <!--<boolean>-->

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -10,12 +10,29 @@
   <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
+
+    <file>
+      <name>metaDataFileName</name>
+      <label>JSON metadata file</label>
+      <channel>input</channel>
+      <index>0</index>
+      <description>JSON file containing the meta-information that describes the measurements to be encoded. See documentation for details.</description>
+    </file>
+
+    <file>
+      <name>outputSEGFileName</name>
+      <label>SEG file name</label>
+      <channel>output</channel>
+      <index>1</index>
+      <description>File name of the DICOM SEG object that will store the result of conversion.</description>
+    </file>
+
     <string-vector>
       <name>dicomImageFiles</name>
       <label>DICOM images file names</label>
       <channel>input</channel>
       <longflag>dicomImageFiles</longflag>
-      <description>List of DICOM images that correspond to the image that was segmented.</description>
+      <description>Comma-separated list of DICOM images that correspond to the original image that was segmented. This means you must have access to the original data in DICOM in order to use the converter (at least for now).</description>
     </string-vector>
 
     <string-vector>
@@ -23,31 +40,16 @@
       <label>Segmentation file names</label>
       <channel>input</channel>
       <longflag>segImageFiles</longflag>
-      <description>File names of the segmentation images in a format readable by ITK (NRRD, NIfTI, MHD, etc.).</description>
+      <description>Comma-separated list of file names of the segmentation images in a format readable by ITK (NRRD, NIfTI, MHD, etc.). Each of the individual files can contain one or more labels (segments). Segments from different files are allowed to overlap. See documentation for details.</description>
     </string-vector>
-
-    <file>
-      <name>metaDataFileName</name>
-      <label>JSON metadata file</label>
-      <channel>input</channel>
-      <longflag>metaDataFileName</longflag>
-      <description>File names of the text files containing metadata attributes for each of the segments in the input segmentation file. The number of attribute files should match the number of the input segmentation files. The number of lines in each attribute file must match the number of segments in the corresponding segmentation file. Attributes should be separated by semicolon. For each segment label the attribute file should contain the following items separated by semicolon:\nLabelID - integer number of the segment label within the segmentation file (required);\nSegmentedPropertyCategory:code_tuple - code describing segmented property category of the segment. code_tuple consists of the code itself, coding scheme designator and code meaning. For example, T-D0050,SRT,Tissue. Required.\nSegmentedPropertyType:code_tuple - code further describing the segment. Required.\nSegmentedPropertyTypeModifier:code_tuple - code describing the modifier of the segmented property type (e.g., left vs right). Optional.\nSegmentAlgorithmType:type - code designation for the algorithm type, where type can be AUTOMATIC, MANUAL, or SEMIAUTOMATIC. Required.\nSegmentAlgorithmName:name - name of the algorithm, free text. Required if the algorithm usd is not MANUAL.\nRecommendedDisplayRGBValue:rgb - comma-separated recommended color for displaying the segment. Optional.</description>
-    </file>
-
-    <file>
-      <name>outputSEGFileName</name>
-      <label>SEG file name</label>
-      <channel>output</channel>
-      <longflag>segDICOMFile</longflag>
-      <description>File name of the SEG object that will keep the result.</description>
-    </file>
 
     <boolean>
       <name>noSkipEmptySlices</name>
-      <label>Skip empty slices</label>
+      <label>Do not skip empty slices</label>
       <channel>input</channel>
       <longflag>noskip</longflag>
-      <description>Don't skip empty slices while encoding segmentation image.</description>-->
+      <default>false</default>
+      <description>Don't skip empty slices while encoding segmentation image. By default, empty slices will not be encoded, resulting in a smaller output file size.</description>-->
     </boolean>
 
     <!--<boolean>-->

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -2,7 +2,7 @@
 <executable>
   <category>Informatics</category>
   <title>Convert DICOM SEG into ITK image</title>
-  <description>Convert a DICOM Segmentation Object into volumetric segmentation(s) stored as labeled pixels as NRRD file format + meta information stored in the JSON file format.</description>
+  <description>This tool can be used to convert DICOM Segmentation into volumetric segmentations stored as labeled pixels using research format, such as NRRD or NIfTI, and meta information stored in the JSON file format.</description>
   <version>1.0</version>
   <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
@@ -15,7 +15,15 @@
       <label>SEG file name</label>
       <channel>input</channel>
       <index>0</index>
-      <description>File name of the SEG object.</description>
+      <description>File name of the input DICOM Segmentation image object.</description>
+    </file>
+
+    <file>
+      <name>outputDirName</name>
+      <label>Output directory name</label>
+      <channel>input</channel>
+      <index>1</index>
+      <description>Directory to store individual segments saved using the output format specified files. When specified, file names will contain prefix, followed by the segment number.</description>
     </file>
 
     <string>
@@ -23,23 +31,15 @@
       <label>Output prefix</label>
       <flag>-p</flag>
       <longflag>--prefix</longflag>
-      <description>Prefix for output files</description>
+      <description>Prefix for output file.</description>
       <default></default>
     </string>
-
-    <file>
-      <name>outputDirName</name>
-      <label>Output directory name</label>
-      <channel>input</channel>
-      <index>1</index>
-      <description>Directory to store individual segments as itk files. File names will correspond to the segment numbers.</description>
-    </file>
 
     <string-enumeration>
       <name>outputType</name>
       <flag>-t</flag>
       <longflag>--outputType</longflag>
-      <description>Output type of the resulting image data.</description>
+      <description>Output file format for the resulting image data.</description>
       <label>Output type</label>
       <default>nrrd</default>
       <element>nrrd</element>

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -14,7 +14,7 @@
       <name>inputSEGFileName</name>
       <label>SEG file name</label>
       <channel>input</channel>
-      <index>0</index>
+      <longflag>inputDICOM</longflag>
       <description>File name of the input DICOM Segmentation image object.</description>
     </file>
 
@@ -22,23 +22,23 @@
       <name>outputDirName</name>
       <label>Output directory name</label>
       <channel>input</channel>
-      <index>1</index>
+      <longflag>outputDirectory</longflag>
       <description>Directory to store individual segments saved using the output format specified files. When specified, file names will contain prefix, followed by the segment number.</description>
     </file>
 
     <string>
       <name>prefix</name>
       <label>Output prefix</label>
-      <flag>-p</flag>
-      <longflag>--prefix</longflag>
+      <flag>p</flag>
+      <longflag>prefix</longflag>
       <description>Prefix for output file.</description>
       <default></default>
     </string>
 
     <string-enumeration>
       <name>outputType</name>
-      <flag>-t</flag>
-      <longflag>--outputType</longflag>
+      <flag>t</flag>
+      <longflag>outputType</longflag>
       <description>Output file format for the resulting image data.</description>
       <label>Output type</label>
       <default>nrrd</default>

--- a/apps/sr/Testing/CMakeLists.txt
+++ b/apps/sr/Testing/CMakeLists.txt
@@ -18,20 +18,20 @@ dcmqi_add_test(
   NAME ${WRITER_MODULE_NAME}_example
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${WRITER_MODULE_NAME}>
-    --metaDataFileName ${CMAKE_SOURCE_DIR}/doc/examples/sr-tid1500-example.json
-    --outputFileName ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-example.dcm
-    --imageLibraryDataDir ${CMAKE_SOURCE_DIR}/data/ct-3slice
-    --compositeContextDataDir ${CMAKE_SOURCE_DIR}/data/sr-example
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/sr-tid1500-example.json
+    --outputDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-example.dcm
+    --imageLibraryDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
+    --compositeContextDirectory ${CMAKE_SOURCE_DIR}/data/sr-example
   )
 
 dcmqi_add_test(
   NAME ${WRITER_MODULE_NAME}_ct-liver
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${WRITER_MODULE_NAME}>
-    --metaDataFileName ${CMAKE_SOURCE_DIR}/doc/examples/sr-tid1500-ct-liver-example.json
-    --outputFileName ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.dcm
-    --imageLibraryDataDir ${CMAKE_SOURCE_DIR}/data/ct-3slice
-    --compositeContextDataDir ${CMAKE_SOURCE_DIR}/data/ct-3slice
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/sr-tid1500-ct-liver-example.json
+    --outputDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.dcm
+    --imageLibraryDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
+    --compositeContextDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
   )
 
 
@@ -58,8 +58,8 @@ dcmqi_add_test(
   NAME ${READER_MODULE_NAME}_ct-liver
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${READER_MODULE_NAME}>
-    --inputSRFileName ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.dcm
-    --metaDataFileName ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.json
+    --inputDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.dcm
+    --outputMetadata ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.json
   TEST_DEPENDS
     ${WRITER_MODULE_NAME}_ct-liver
   )

--- a/apps/sr/Testing/CMakeLists.txt
+++ b/apps/sr/Testing/CMakeLists.txt
@@ -19,9 +19,9 @@ dcmqi_add_test(
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${WRITER_MODULE_NAME}>
     --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/sr-tid1500-example.json
-    --outputDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-example.dcm
     --imageLibraryDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
     --compositeContextDirectory ${CMAKE_SOURCE_DIR}/data/sr-example
+    --outputDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-example.dcm
   )
 
 dcmqi_add_test(
@@ -29,9 +29,9 @@ dcmqi_add_test(
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${WRITER_MODULE_NAME}>
     --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/sr-tid1500-ct-liver-example.json
-    --outputDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.dcm
     --imageLibraryDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
     --compositeContextDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
+    --outputDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.dcm
   )
 
 

--- a/apps/sr/Testing/CMakeLists.txt
+++ b/apps/sr/Testing/CMakeLists.txt
@@ -19,8 +19,8 @@ dcmqi_add_test(
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${WRITER_MODULE_NAME}>
     --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/sr-tid1500-example.json
-    --imageLibraryDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
-    --compositeContextDirectory ${CMAKE_SOURCE_DIR}/data/sr-example
+    --inputImageLibraryDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
+    --inputCompositeContextDirectory ${CMAKE_SOURCE_DIR}/data/sr-example
     --outputDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-example.dcm
   )
 
@@ -29,8 +29,8 @@ dcmqi_add_test(
   MODULE_NAME ${MODULE_NAME}
   COMMAND $<TARGET_FILE:${WRITER_MODULE_NAME}>
     --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/sr-tid1500-ct-liver-example.json
-    --imageLibraryDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
-    --compositeContextDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
+    --inputImageLibraryDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
+    --inputCompositeContextDirectory ${CMAKE_SOURCE_DIR}/data/ct-3slice
     --outputDICOM ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/sr-tid1500-ct-liver-example.dcm
   )
 

--- a/apps/sr/tid1500reader.xml
+++ b/apps/sr/tid1500reader.xml
@@ -15,7 +15,7 @@
       <name>inputSRFileName</name>
       <label>SR file name</label>
       <channel>input</channel>
-      <index>0</index>
+      <longflag>inputDICOM</longflag>
       <description>File name of the DICOM SR TID1500 object.</description>
     </file>
 
@@ -23,7 +23,7 @@
       <name>metaDataFileName</name>
       <label>JSON file name</label>
       <channel>output</channel>
-      <index>1</index>
+      <longflag>outputMetadata</longflag>
       <description>File name of the JSON file that will keep the metadata and measurements information.</description>
     </file>
 

--- a/apps/sr/tid1500reader.xml
+++ b/apps/sr/tid1500reader.xml
@@ -15,16 +15,16 @@
       <name>inputSRFileName</name>
       <label>SR file name</label>
       <channel>input</channel>
-      <longflag>inputSRFileName</longflag>
-      <description>File name of the SR object.</description>
+      <index>0</index>
+      <description>File name of the DICOM SR TID1500 object.</description>
     </file>
 
     <file>
       <name>metaDataFileName</name>
       <label>JSON file name</label>
       <channel>output</channel>
-      <longflag>metaDataFileName</longflag>
-      <description>JSON file name that will keep the metadata and measurements information.</description>
+      <index>1</index>
+      <description>File name of the JSON file that will keep the metadata and measurements information.</description>
     </file>
 
   </parameters>

--- a/apps/sr/tid1500writer.xml
+++ b/apps/sr/tid1500writer.xml
@@ -31,7 +31,7 @@
       <name>compositeContextDataDir</name>
       <label>Composite context DICOM data dir</label>
       <channel>input</channel>
-      <longflag>compositeContextDirectory</longflag>
+      <longflag>inputCompositeContextDirectory</longflag>
       <description>Location of input DICOM Data to be used for populating composite context. See documentation.</description>
     </file>
 
@@ -39,7 +39,7 @@
       <name>imageLibraryDataDir</name>
       <label>Image library DICOM data dir</label>
       <channel>input</channel>
-      <longflag>imageLibraryDirectory</longflag>
+      <longflag>inputImageLibraryDirectory</longflag>
       <description>Location of input DICOM Data to be used for populating image library. See documentation.</description>
     </file>
 

--- a/apps/sr/tid1500writer.xml
+++ b/apps/sr/tid1500writer.xml
@@ -15,7 +15,7 @@
       <name>metaDataFileName</name>
       <label>JSON metadata file</label>
       <channel>input</channel>
-      <index>0</index>
+      <longflag>inputMetadata</longflag>
       <description>JSON file that contains the list of mesurements and other meta data items that can be specified by the user. See documentation for details.</description>
     </file>
 
@@ -23,7 +23,7 @@
       <name>outputFileName</name>
       <label>Output DICOM SR file name</label>
       <channel>output</channel>
-      <index>1</index>
+      <longflag>outputDICOM</longflag>
       <description>File name of the DICOM SR object that will store the result of the conversion.</description>
     </file>
 
@@ -31,7 +31,7 @@
       <name>compositeContextDataDir</name>
       <label>Composite context DICOM data dir</label>
       <channel>input</channel>
-      <longflag>compositeContextDataDir</longflag>
+      <longflag>compositeContextDirectory</longflag>
       <description>Location of input DICOM Data to be used for populating composite context. See documentation.</description>
     </file>
 
@@ -39,7 +39,7 @@
       <name>imageLibraryDataDir</name>
       <label>Image library DICOM data dir</label>
       <channel>input</channel>
-      <longflag>imageLibraryDataDir</longflag>
+      <longflag>imageLibraryDirectory</longflag>
       <description>Location of input DICOM Data to be used for populating image library. See documentation.</description>
     </file>
 

--- a/apps/sr/tid1500writer.xml
+++ b/apps/sr/tid1500writer.xml
@@ -2,7 +2,7 @@
 <executable>
   <category>Informatics</category>
   <title>DICOM Measurements reporting</title>
-  <description>convert a DICOM Structured Report (template TID1500) into a human readable representation by means of the JSON file format.</description>
+  <description>This tool can be used to save measurements calculated from the image over a volume defined by image segmentation into a DICOM Structured Report that follows [template TID1500](http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1500).</description>
   <version>1.0</version>
   <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>
   <license></license>
@@ -15,7 +15,16 @@
       <name>metaDataFileName</name>
       <label>JSON metadata file</label>
       <channel>input</channel>
-      <longflag>metaDataFileName</longflag>
+      <index>0</index>
+      <description>JSON file that contains the list of mesurements and other meta data items that can be specified by the user. See documentation for details.</description>
+    </file>
+
+    <file>
+      <name>outputFileName</name>
+      <label>Output DICOM SR file name</label>
+      <channel>output</channel>
+      <index>1</index>
+      <description>File name of the DICOM SR object that will store the result of the conversion.</description>
     </file>
 
     <file>
@@ -23,7 +32,7 @@
       <label>Composite context DICOM data dir</label>
       <channel>input</channel>
       <longflag>compositeContextDataDir</longflag>
-      <description>Location of input DICOM Data to be used for populating composite context</description>
+      <description>Location of input DICOM Data to be used for populating composite context. See documentation.</description>
     </file>
 
     <file>
@@ -31,14 +40,7 @@
       <label>Image library DICOM data dir</label>
       <channel>input</channel>
       <longflag>imageLibraryDataDir</longflag>
-      <description>Location of input DICOM Data to be used for populating image library</description>
-    </file>
-
-    <file>
-      <name>outputFileName</name>
-      <label>Output DICOM SR file name</label>
-      <channel>output</channel>
-      <longflag>outputFileName</longflag>
+      <description>Location of input DICOM Data to be used for populating image library. See documentation.</description>
     </file>
 
   </parameters>


### PR DESCRIPTION
* removed some invalid legacy descriptions
* refined some definitions
* redefined some of the arguments that are mandatory as positional arguments
 (no flags)

The idea is that we should be able to include output of -h for each of these commands
directly into the documentation to make maintenance and ensuring consistency
of the documentation more manageable.

This is WIP - tests are expected to fail, and the changes will need to propagate to Slicer.

@che85 @pieper what do you think about how command line arguments are organized and named right now? Is it worth the effort changing those from how it used to be?

TODO:
- [x] once finalized, update documentation