### PR TITLE
Add derivation images to parametric map

### DIFF
--- a/apps/paramaps/Testing/CMakeLists.txt
+++ b/apps/paramaps/Testing/CMakeLists.txt
@@ -26,7 +26,7 @@ dcmqi_add_test(
   COMMAND $<TARGET_FILE:${MODULE_NAME}>
     --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/pm-example.json
     --inputImage ${BASELINE}/pm-example.nrrd
-    --inputDICOM ${BASELINE}/pm-example-slice.dcm
+    --inputDICOMList ${BASELINE}/pm-example-slice.dcm
     --outputDICOM ${TEMP_DIR}/paramap.dcm
   )
 
@@ -36,7 +36,7 @@ dcmqi_add_test(
   COMMAND $<TARGET_FILE:${MODULE_NAME}>
     --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/pm-example-float.json
     --inputImage ${BASELINE}/pm-example-float.nrrd
-    --inputDICOM ${BASELINE}/pm-example-slice.dcm
+    --inputDICOMList ${BASELINE}/pm-example-slice.dcm
     --outputDICOM ${TEMP_DIR}/paramap-float.dcm
   )
 

--- a/apps/paramaps/itkimage2paramap.cxx
+++ b/apps/paramaps/itkimage2paramap.cxx
@@ -5,6 +5,13 @@
 #undef HAVE_SSTREAM // Avoid redefinition warning
 #include "dcmqi/ParaMapConverter.h"
 
+#ifdef _WIN32
+#include "dirent_win.h"
+#else
+#include <dirent.h>
+#endif
+
+
 int main(int argc, char *argv[])
 {
   PARSE_ARGS;
@@ -19,18 +26,37 @@ int main(int argc, char *argv[])
   reader->Update();
   ImageType::Pointer parametricMapImage = reader->GetOutput();
 
-  DcmDataset* dcmDataset = NULL;
-  if (!dicomImageFileName.empty()) {
-    DcmFileFormat *sliceFF = new DcmFileFormat();
-    CHECK_COND(sliceFF->loadFile(dicomImageFileName.c_str()));
-    dcmDataset = sliceFF->getDataset();
+  vector<DcmDataset*> dcmDatasets;
+
+  DcmFileFormat* sliceFF = new DcmFileFormat();
+  for(size_t dcmFileNumber=0; dcmFileNumber<dicomImageFileList.size(); dcmFileNumber++){
+    if(sliceFF->loadFile(dicomImageFileList[dcmFileNumber].c_str()).good()){
+      dcmDatasets.push_back(sliceFF->getAndRemoveDataset());
+    }
+  }
+
+  // solution from
+  //  http://stackoverflow.com/questions/612097/how-can-i-get-the-list-of-files-in-a-directory-using-c-or-c
+  if(dicomDirectory.size()){
+    DIR *dir;
+    struct dirent *ent;
+    if ((dir = opendir (dicomDirectory.c_str())) != NULL) {
+      while ((ent = readdir (dir)) != NULL) {
+        if(sliceFF->loadFile((dicomDirectory+"/"+ent->d_name).c_str()).good()){
+          dcmDatasets.push_back(sliceFF->getAndRemoveDataset());
+        }
+      }
+      closedir (dir);
+    } else {
+      cerr << "Cannot open input DICOM directory!" << endl;
+    }
   }
 
   ifstream metainfoStream(metaDataFileName.c_str(), ios_base::binary);
   std::string metadata( (std::istreambuf_iterator<char>(metainfoStream) ),
                         (std::istreambuf_iterator<char>()));
 
-  DcmDataset* result = dcmqi::ParaMapConverter::itkimage2paramap(parametricMapImage, dcmDataset, metadata);
+  DcmDataset* result = dcmqi::ParaMapConverter::itkimage2paramap(parametricMapImage, dcmDatasets, metadata);
 
   if (result == NULL) {
     return EXIT_FAILURE;

--- a/apps/paramaps/itkimage2paramap.cxx
+++ b/apps/paramaps/itkimage2paramap.cxx
@@ -21,10 +21,10 @@ int main(int argc, char *argv[])
     return EXIT_FAILURE;
   }
 
-  ReaderType::Pointer reader = ReaderType::New();
+  FloatReaderType::Pointer reader = FloatReaderType::New();
   reader->SetFileName(inputFileName.c_str());
   reader->Update();
-  ImageType::Pointer parametricMapImage = reader->GetOutput();
+  FloatImageType::Pointer parametricMapImage = reader->GetOutput();
 
   vector<DcmDataset*> dcmDatasets;
 

--- a/apps/paramaps/itkimage2paramap.xml
+++ b/apps/paramaps/itkimage2paramap.xml
@@ -35,13 +35,22 @@
       <description>File name of the DICOM Parametric map object with the result of the conversion.</description>
     </file>
 
-    <file>
-      <name>dicomImageFileName</name>
+    <string-vector>
+      <name>dicomImageFileList</name>
       <label>DICOM images file name</label>
       <channel>input</channel>
-      <longflag>inputDICOM</longflag>
+      <longflag>inputDICOMList</longflag>
       <default></default>
       <description>File name of the DICOM image file that should be used to populate the composite context (attributes related to the patient and imaging study).</description>
+    </string-vector>
+
+    <file>
+      <name>dicomDirectory</name>
+      <label>Source DICOM directory</label>
+      <channel>input</channel>
+      <longflag>inputDICOMDirectory</longflag>
+      <default></default>
+      <description>Directory with the source DICOM images that were used to generate the parametric map.</description>
     </file>
 
   </parameters>

--- a/apps/paramaps/paramap2itkimage.cxx
+++ b/apps/paramaps/paramap2itkimage.cxx
@@ -15,11 +15,11 @@ int main(int argc, char *argv[])
   CHECK_COND(sliceFF.loadFile(inputFileName.c_str()));
   DcmDataset* dataset = sliceFF.getDataset();
 
-  pair <ImageType::Pointer, string> result =  dcmqi::ParaMapConverter::paramap2itkimage(dataset);
+  pair <FloatImageType::Pointer, string> result =  dcmqi::ParaMapConverter::paramap2itkimage(dataset);
 
   string fileExtension = dcmqi::Helper::getFileExtensionFromType(outputType);
 
-  typedef itk::ImageFileWriter<ImageType> WriterType;
+  typedef itk::ImageFileWriter<FloatImageType> WriterType;
   WriterType::Pointer writer = WriterType::New();
   stringstream imageFileNameSStream;
   imageFileNameSStream << outputDirName << "/" << "pmap" << fileExtension;

--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -35,13 +35,13 @@ int main(int argc, char *argv[])
     return EXIT_FAILURE;
   }
 
-  vector<ImageType::Pointer> segmentations;
+  vector<ShortImageType::Pointer> segmentations;
 
   for(size_t segFileNumber=0; segFileNumber<segImageFiles.size(); segFileNumber++){
-    ReaderType::Pointer reader = ReaderType::New();
+    ShortReaderType::Pointer reader = ShortReaderType::New();
     reader->SetFileName(segImageFiles[segFileNumber]);
     reader->Update();
-    ImageType::Pointer labelImage = reader->GetOutput();
+    ShortImageType::Pointer labelImage = reader->GetOutput();
     segmentations.push_back(labelImage);
   }
 

--- a/apps/seg/segimage2itkimage.cxx
+++ b/apps/seg/segimage2itkimage.cxx
@@ -14,14 +14,14 @@ int main(int argc, char *argv[])
   CHECK_COND(sliceFF.loadFile(inputSEGFileName.c_str()));
   DcmDataset* dataset = sliceFF.getDataset();
 
-  pair <map<unsigned,ImageType::Pointer>, string> result =  dcmqi::ImageSEGConverter::dcmSegmentation2itkimage(dataset);
+  pair <map<unsigned,ShortImageType::Pointer>, string> result =  dcmqi::ImageSEGConverter::dcmSegmentation2itkimage(dataset);
 
   string outputPrefix = prefix.empty() ? "" : prefix + "-";
 
   string fileExtension = dcmqi::Helper::getFileExtensionFromType(outputType);
 
-  for(map<unsigned,ImageType::Pointer>::const_iterator sI=result.first.begin();sI!=result.first.end();++sI){
-    typedef itk::ImageFileWriter<ImageType> WriterType;
+  for(map<unsigned,ShortImageType::Pointer>::const_iterator sI=result.first.begin();sI!=result.first.end();++sI){
+    typedef itk::ImageFileWriter<ShortImageType> WriterType;
     stringstream imageFileNameSStream;
 
     imageFileNameSStream << outputDirName << "/" << outputPrefix << sI->first << fileExtension;

--- a/doc/examples/pm-example-float.json
+++ b/doc/examples/pm-example-float.json
@@ -11,6 +11,11 @@
     "CodingSchemeDesignator": "DCM",
     "CodeMeaning": "Apparent Diffusion Coefficient"
   },
+  "DerivationCode": {
+    "CodeValue": "113041",
+    "CodingSchemeDesignator": "DCM",
+    "CodeMeaning": "Apparent Diffusion Coefficient"
+  },
   "MeasurementUnitsCode": {
     "CodeValue": "m2/s",
     "CodingSchemeDesignator": "UCUM",

--- a/doc/examples/pm-example.json
+++ b/doc/examples/pm-example.json
@@ -11,6 +11,11 @@
     "CodingSchemeDesignator": "DCM",
     "CodeMeaning": "Apparent Diffusion Coefficient"
   },
+  "DerivationCode": {
+    "CodeValue": "113041",
+    "CodingSchemeDesignator": "DCM",
+    "CodeMeaning": "Apparent Diffusion Coefficient"
+  },
   "MeasurementUnitsCode": {
     "CodeValue": "um2/s",
     "CodingSchemeDesignator": "UCUM",

--- a/doc/schemas/pm-schema.json
+++ b/doc/schemas/pm-schema.json
@@ -5,7 +5,10 @@
   "required": [
     "DerivedPixelContrast",
     "AnatomicRegionSequence",
-    "FrameLaterality"
+    "FrameLaterality",
+    "QuantityValueCode",
+    "MeasurementUnitsCode",
+    "DerivationCode"
   ],
   "additionalProperties": false,
   "properties": {
@@ -53,6 +56,13 @@
     },
     "ModelFittingMethodCode": {
       "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"
+    },
+    "DerivationCode": {
+      "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"
+    },
+    "DerivationDescription": {
+      "type": "string",
+      "default": ""
     },
     "SourceImageDiffusionBValues": {
       "type": "array",

--- a/include/dcmqi/ImageSEGConverter.h
+++ b/include/dcmqi/ImageSEGConverter.h
@@ -27,9 +27,7 @@
 
 using namespace std;
 
-typedef short ShortPixelType;
-typedef itk::Image<ShortPixelType, 3> ShortImageType;
-typedef itk::ImageFileReader<ShortImageType> ShortReaderType;
+
 typedef itk::LabelImageToLabelMapFilter<ShortImageType> LabelToLabelMapFilterType;
 
 namespace dcmqi {
@@ -44,9 +42,6 @@ namespace dcmqi {
 
 
     static pair <map<unsigned,ShortImageType::Pointer>, string> dcmSegmentation2itkimage(DcmDataset *segDataset);
-
-    static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<DcmDataset*> dcmDatasets,
-                                                                           const ShortImageType::Pointer &labelImage);
 
  private:
 

--- a/include/dcmqi/ImageSEGConverter.h
+++ b/include/dcmqi/ImageSEGConverter.h
@@ -27,12 +27,10 @@
 
 using namespace std;
 
-typedef short PixelType;
-typedef itk::Image<PixelType, 3> ImageType;
-typedef itk::ImageFileReader<ImageType> ReaderType;
-typedef itk::LabelImageToLabelMapFilter<ImageType> LabelToLabelMapFilterType;
-
-static OFLogger dcemfinfLogger = OFLog::getLogger("qiicr.apps");
+typedef short ShortPixelType;
+typedef itk::Image<ShortPixelType, 3> ShortImageType;
+typedef itk::ImageFileReader<ShortImageType> ShortReaderType;
+typedef itk::LabelImageToLabelMapFilter<ShortImageType> LabelToLabelMapFilterType;
 
 namespace dcmqi {
 
@@ -40,16 +38,17 @@ namespace dcmqi {
 
   public:
     static DcmDataset* itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
-                                                vector<ImageType::Pointer> segmentations,
+                                                vector<ShortImageType::Pointer> segmentations,
                                                 const string &metaData,
                                                 bool skipEmptySlices=true);
 
 
-    static pair <map<unsigned,ImageType::Pointer>, string> dcmSegmentation2itkimage(DcmDataset *segDataset);
+    static pair <map<unsigned,ShortImageType::Pointer>, string> dcmSegmentation2itkimage(DcmDataset *segDataset);
 
-  private:
     static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<DcmDataset*> dcmDatasets,
-                                                                           const itk::Image<short, 3>::Pointer &labelImage);
+                                                                           const ShortImageType::Pointer &labelImage);
+
+ private:
 
     static void populateMetaInformationFromDICOM(DcmDataset *segDataset, DcmSegmentation *segdoc,
                                                  JSONSegmentationMetaInformationHandler &metaInfo);

--- a/include/dcmqi/ParaMapConverter.h
+++ b/include/dcmqi/ParaMapConverter.h
@@ -21,26 +21,25 @@
 #include "dcmqi/ConverterBase.h"
 #include "dcmqi/JSONParametricMapMetaInformationHandler.h"
 
-typedef IODFloatingPointImagePixelModule::value_type PixelType;
-typedef itk::Image<PixelType, 3> ImageType;
-typedef itk::ImageFileReader<ImageType> ReaderType;
-typedef itk::MinimumMaximumImageCalculator<ImageType> MinMaxCalculatorType;
+typedef IODFloatingPointImagePixelModule::value_type FloatPixelType;
+typedef itk::Image<FloatPixelType, 3> FloatImageType;
+typedef itk::ImageFileReader<FloatImageType> FloatReaderType;
+typedef itk::MinimumMaximumImageCalculator<FloatImageType> MinMaxCalculatorType;
 
 using namespace std;
 
-static OFLogger dcemfinfLogger = OFLog::getLogger("qiicr.apps");
 
 namespace dcmqi {
 
   class ParaMapConverter : public ConverterBase {
 
   public:
-    static DcmDataset* itkimage2paramap(const ImageType::Pointer &parametricMapImage, vector<DcmDataset*> dcmDatasets,
+    static DcmDataset* itkimage2paramap(const FloatImageType::Pointer &parametricMapImage, vector<DcmDataset*> dcmDatasets,
                                         const string &metaData);
 
-    static pair <ImageType::Pointer, string> paramap2itkimage(DcmDataset *pmapDataset);
+    static pair <FloatImageType::Pointer, string> paramap2itkimage(DcmDataset *pmapDataset);
   protected:
-    static OFCondition addFrame(DPMParametricMapIOD &map, const ImageType::Pointer &parametricMapImage,
+    static OFCondition addFrame(DPMParametricMapIOD &map, const FloatImageType::Pointer &parametricMapImage,
                                 const JSONParametricMapMetaInformationHandler &metaInfo, const unsigned long frameNo);
 
     static void populateMetaInformationFromDICOM(DcmDataset *pmapDataset,

--- a/include/dcmqi/ParaMapConverter.h
+++ b/include/dcmqi/ParaMapConverter.h
@@ -35,7 +35,7 @@ namespace dcmqi {
   class ParaMapConverter : public ConverterBase {
 
   public:
-    static DcmDataset* itkimage2paramap(const ImageType::Pointer &parametricMapImage, DcmDataset* dcmDataset,
+    static DcmDataset* itkimage2paramap(const ImageType::Pointer &parametricMapImage, vector<DcmDataset*> dcmDatasets,
                                         const string &metaData);
 
     static pair <ImageType::Pointer, string> paramap2itkimage(DcmDataset *pmapDataset);

--- a/include/dcmqi/ParaMapConverter.h
+++ b/include/dcmqi/ParaMapConverter.h
@@ -40,7 +40,7 @@ namespace dcmqi {
     static pair <FloatImageType::Pointer, string> paramap2itkimage(DcmDataset *pmapDataset);
   protected:
     static OFCondition addFrame(DPMParametricMapIOD &map, const FloatImageType::Pointer &parametricMapImage,
-                                const JSONParametricMapMetaInformationHandler &metaInfo, const unsigned long frameNo);
+                                const JSONParametricMapMetaInformationHandler &metaInfo, const unsigned long frameNo, OFVector<FGBase*> perFrameGroups);
 
     static void populateMetaInformationFromDICOM(DcmDataset *pmapDataset,
                                                  JSONParametricMapMetaInformationHandler &metaInfo);

--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -695,31 +695,6 @@ namespace dcmqi {
     return pair <map<unsigned,ShortImageType::Pointer>, string>(segment2image, metaInfo.getJSONOutputAsString());
   }
 
-  vector<vector<int> > ImageSEGConverter::getSliceMapForSegmentation2DerivationImage(const vector<DcmDataset*> dcmDatasets,
-                                                                                     const itk::Image<short, 3>::Pointer &labelImage) {
-    // Find mapping from the segmentation slice number to the derivation image
-    // Assume that orientation of the segmentation is the same as the source series
-    unsigned numLabelSlices = labelImage->GetLargestPossibleRegion().GetSize()[2];
-    vector<vector<int> > slice2derimg(numLabelSlices);
-    for(size_t i=0;i<dcmDatasets.size();i++){
-      OFString ippStr;
-      ShortImageType::PointType ippPoint;
-      ShortImageType::IndexType ippIndex;
-      for(int j=0;j<3;j++){
-        CHECK_COND(dcmDatasets[i]->findAndGetOFString(DCM_ImagePositionPatient, ippStr, j));
-        ippPoint[j] = atof(ippStr.c_str());
-      }
-      if(!labelImage->TransformPhysicalPointToIndex(ippPoint, ippIndex)){
-        //cout << "image position: " << ippPoint << endl;
-        //cerr << "ippIndex: " << ippIndex << endl;
-        // if certain DICOM instance does not map to a label slice, just skip it
-        continue;
-      }
-      slice2derimg[ippIndex[2]].push_back(i);
-    }
-    return slice2derimg;
-  }
-
   void ImageSEGConverter::populateMetaInformationFromDICOM(DcmDataset *segDataset, DcmSegmentation *segdoc,
                                JSONSegmentationMetaInformationHandler &metaInfo) {
     OFString creatorName, sessionID, timePointID, seriesDescription, seriesNumber, instanceNumber, bodyPartExamined, coordinatingCenter;

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 namespace dcmqi {
 
-  DcmDataset* ParaMapConverter::itkimage2paramap(const ImageType::Pointer &parametricMapImage, DcmDataset* dcmDataset,
+  DcmDataset* ParaMapConverter::itkimage2paramap(const ImageType::Pointer &parametricMapImage, vector<DcmDataset*> dcmDatasets,
                                          const string &metaData) {
 
     MinMaxCalculatorType::Pointer calculator = MinMaxCalculatorType::New();
@@ -50,8 +50,12 @@ namespace dcmqi {
 
     DPMParametricMapIOD* pMapDoc = OFget<DPMParametricMapIOD>(&obj);
 
-    if (dcmDataset != NULL)
-      CHECK_COND(pMapDoc->import(*dcmDataset, OFTrue, OFTrue, OFFalse, OFTrue));
+    DcmDataset* srcDataset = NULL;
+    if(dcmDatasets.size()){
+      srcDataset = dcmDatasets[0];
+    }
+    if (srcDataset)
+      CHECK_COND(pMapDoc->import(*srcDataset, OFTrue, OFTrue, OFFalse, OFTrue));
 
     /* Initialize dimension module */
     char dimUID[128];
@@ -232,9 +236,9 @@ namespace dcmqi {
 
   {
     string bodyPartAssigned = metaInfo.getBodyPartExamined();
-    if(dcmDataset != NULL && bodyPartAssigned.empty()) {
+    if(srcDataset != NULL && bodyPartAssigned.empty()) {
       OFString bodyPartStr;
-      if(dcmDataset->findAndGetOFString(DCM_BodyPartExamined, bodyPartStr).good()) {
+      if(srcDataset->findAndGetOFString(DCM_BodyPartExamined, bodyPartStr).good()) {
         if (!bodyPartStr.empty())
           bodyPartAssigned = bodyPartStr.c_str();
       }

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -244,7 +244,7 @@ namespace dcmqi {
       CastFilterType::Pointer cast = CastFilterType::New();
       cast->SetInput(parametricMapImage);
       cast->Update();
-      slice2derimg = ImageSEGConverter::getSliceMapForSegmentation2DerivationImage(dcmDatasets, cast->GetOutput());
+      slice2derimg = getSliceMapForSegmentation2DerivationImage(dcmDatasets, cast->GetOutput());
       cout << "Mapping from the ITK image slices to the DICOM instances in the input list" << endl;
       for(int i=0;i<slice2derimg.size();i++){
         cout << "  Slice " << i << ": ";


### PR DESCRIPTION
work towards addressing #186 

At the moment, crashes `itkimage2paramap_makeParametricMap` test

![image](https://cloud.githubusercontent.com/assets/313942/22526372/fe6002c6-e898-11e6-847f-60dbf4ef057a.png)

Stack trace:

```
#0  0x00007fff86043286 in __pthread_kill ()
#1  0x00007fff860189f9 in pthread_kill ()
#2  0x00007fff8a93d9a3 in abort ()
#3  0x00007fff834271cb in free ()
#4  0x0000000102687cd9 in IODComponent::~IODComponent (this=0x7fff5fbf51f8) at /Users/fedorov/local/builds/dcmqi-new-super/DCMTK/dcmiod/libsrc/modbase.cc:65
#5  0x000000010266612b in DcmIODUtil::freeContainer<OFVector<IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*> > (container=@0x7fff5fbf8200) at iodutil.h:840
#6  0x000000010268afa7 in IODCommonInstanceReferenceModule::freeMemory (this=0x7fff5fbf81e0) at /Users/fedorov/local/builds/dcmqi-new-super/DCMTK/dcmiod/libsrc/modcommoninstanceref.cc:353
#7  0x000000010268aea2 in IODCommonInstanceReferenceModule::~IODCommonInstanceReferenceModule (this=0x7fff5fbf81e0) at /Users/fedorov/local/builds/dcmqi-new-super/DCMTK/dcmiod/libsrc/modcommoninstanceref.cc:48
#8  0x000000010268afc5 in IODCommonInstanceReferenceModule::~IODCommonInstanceReferenceModule (this=0x7fff5fbf81e0) at /Users/fedorov/local/builds/dcmqi-new-super/DCMTK/dcmiod/libsrc/modcommoninstanceref.cc:47
#9  0x000000010264d870 in DcmIODCommon::~DcmIODCommon (this=0x7fff5fbf8060) at /Users/fedorov/local/builds/dcmqi-new-super/DCMTK/dcmiod/libsrc/iodcommn.cc:82
#10 0x00000001024fb3f1 in DcmIODImage<IODImagePixelModule<unsigned short>, IODImagePixelModule<short>, IODFloatingPointImagePixelModule, IODDoubleFloatingPointImagePixelModule, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil>::~DcmIODImage (this=0x7fff5fbf8060) at iodimage.h:110
#11 0x00000001024f97bb in DPMParametricMapBase::~DPMParametricMapBase (this=0x7fff5fbf8060) at /Users/fedorov/local/builds/dcmqi-new-super/DCMTK/dcmpmap/libsrc/dpmparametricmapbase.cc:57
#12 0x0000000102505af8 in DPMParametricMapIOD::~DPMParametricMapIOD (this=0x7fff5fbf8060) at /Users/fedorov/local/builds/dcmqi-new-super/DCMTK/dcmpmap/libsrc/dpmparametricmapiod.cc:897
#13 0x0000000102505ba5 in DPMParametricMapIOD::~DPMParametricMapIOD (this=0x7fff5fbf8060) at /Users/fedorov/local/builds/dcmqi-new-super/DCMTK/dcmpmap/libsrc/dpmparametricmapiod.cc:894
#14 0x000000010012466c in OFvariant_destroy_invoker::invoke<DPMParametricMapIOD> (this=0x7fff5fbf38c0, content=0x7fff5fbf8060) at variant.h:197
#15 0x0000000100124598 in OFvariant_invoke_t<OFvariant_destroy_invoker, OFCondition, DPMParametricMapIOD, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil>::operator() (this=0x1001ff038, index=1, content=0x7fff5fbf8060, invoker=@0x7fff5fbf38c0) at variant.h:95
#16 0x00000001001244b0 in OFvariant_invoke<OFvariant_destroy_invoker, OFCondition, DPMParametricMapIOD, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil> (index=1, content=0x7fff5fbf8060, invoker=@0x7fff5fbf38c0) at variant.h:130
#17 0x0000000100124430 in OFvariant<OFCondition, DPMParametricMapIOD, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil>::destroy (this=0x7fff5fbf8060) at variant.h:369
#18 0x00000001001243f5 in OFvariant<OFCondition, DPMParametricMapIOD, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil>::~OFvariant (this=0x7fff5fbf8060) at variant.h:335
#19 0x000000010011ea05 in OFvariant<OFCondition, DPMParametricMapIOD, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil, OFvariadic_nil>::~OFvariant (this=0x7fff5fbf8060) at variant.h:333
#20 0x000000010011a190 in dcmqi::ParaMapConverter::itkimage2paramap (parametricMapImage=@0x7fff5fbf9910, dcmDatasets={<std::__1::__vector_base<DcmDataset *, std::__1::allocator<DcmDataset *> >> = {<std::__1::__vector_base_common<true>> = {<No data fields>}, __begin_ = 0x106729e90, __end_ = 0x106729f30, __end_cap_ = {<std::__1::__libcpp_compressed_pair_imp<DcmDataset **, std::__1::allocator<DcmDataset *>, 2>> = {<std::__1::allocator<DcmDataset *>> = {<No data fields>}, __first_ = 0x106729f30}, <No data fields>}}, <No data fields>}, metaData=@0x7fff5fbf9840) at /Users/fedorov/github/dcmqi/libsrc/ParaMapConverter.cpp:355
#21 0x000000010002f7c7 in ModuleEntryPoint (argc=9, argv=0x7fff5fbff800) at /Users/fedorov/github/dcmqi/apps/paramaps/itkimage2paramap.cxx:59
#22 0x0000000100019bb2 in main (argc=9, argv=0x7fff5fbff800) at /Users/fedorov/local/builds/dcmqi-new-super/SlicerExecutionModel/CMake/SEMCommandLineLibraryWrapper.cxx:33
```

