### PR TITLE
circle: Fix discovery of git tag associated with docker image generation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,5 +33,5 @@ deployment:
       - |
         [ "$DOCKER_EMAIL" != "" ] \
         && docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS \
-        && docker push qiicr/dcmqi:`git describe --exact-match 2> /dev/null || echo "latest"` \
+        && docker push qiicr/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
         || echo "skipping docker push"

--- a/circle.yml
+++ b/circle.yml
@@ -27,8 +27,17 @@ test:
     - cp ~/dcmqi/build/BaseTest.xml ${CIRCLE_TEST_REPORTS}/junit
 
 deployment:
-  release: # just a label
+  nightly: # just a label
     branch: master
+    commands:
+      - |
+        [ "$DOCKER_EMAIL" != "" ] \
+        && docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS \
+        && docker push qiicr/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
+        || echo "skipping docker push"
+  release: # just a label
+    tag: /v[0-9]+\.[0-9]+\.[0-9]+/
+    owner: qiicr
     commands:
       - |
         [ "$DOCKER_EMAIL" != "" ] \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -64,7 +64,7 @@ dcmqi.generate_package: prereq.pull_dockcross
 dcmqi.docker_image:
 	tar -xzvf $(ROOT_DIR)/$(BUILD_DIR)/dcmqi-build/dcmqi-linux.tar.gz -C $(DOCKER_DIR)/dcmqi
 	cd $(DOCKER_DIR) && \
-	docker build -t $(ORG)/dcmqi:`git describe --exact-match 2> /dev/null || echo "latest"` \
+	docker build -t $(ORG)/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
 		--build-arg IMAGE=$(ORG)/dcmqi \
 		--build-arg VCS_REF=`git describe --exact-match 2> /dev/null || git rev-parse --short HEAD` \
 		--build-arg VCS_URL=`git config --get remote.origin.url` \


### PR DESCRIPTION
Since the current tag are neither annotated or signed, this commit
updates the logic to be able to resolve lightweight tags.

Lightweight tags are just pointer to a specific commit and are not
associated with "Tagger" information.

See https://git-scm.com/book/en/v2/Git-Basics-Tagging