### PR TITLE
ENH: add version reporting to the converters output

### DIFF
--- a/CMake/FindGit.cmake
+++ b/CMake/FindGit.cmake
@@ -99,6 +99,15 @@ if(GIT_EXECUTABLE)
           OUTPUT_STRIP_TRAILING_WHITESPACE)
     endif(NOT ${GIT_error} EQUAL 0)
 
+    execute_process(COMMAND ${GIT_EXECUTABLE} describe --tag
+       WORKING_DIRECTORY ${dir}
+       OUTPUT_VARIABLE ${prefix}_WC_TAG
+       OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(NOT ${GIT_error} EQUAL 0)
+      set(${prefix}_WC_TAG "not available")
+    endif(NOT ${GIT_error} EQUAL 0)
+
     execute_process(COMMAND ${GIT_EXECUTABLE} config --get remote.origin.url
        WORKING_DIRECTORY ${dir}
        OUTPUT_VARIABLE ${prefix}_WC_URL

--- a/CMake/dcmqiVersionConfigure.h.in
+++ b/CMake/dcmqiVersionConfigure.h.in
@@ -15,5 +15,8 @@
 
 #define dcmqi_WC_REVISION "@dcmqi_WC_REVISION@"
 #define dcmqi_WC_URL "@dcmqi_WC_URL@"
+#define dcmqi_WC_TAG "@dcmqi_WC_TAG@"
+
+#define dcmqi_INFO "dcmqi revision hash: @dcmqi_WC_REVISION@ tag: @dcmqi_WC_TAG@"
 
 #endif // __dcmqiVersionConfigure_h

--- a/CMake/dcmqiVersionConfigure.h.in
+++ b/CMake/dcmqiVersionConfigure.h.in
@@ -17,6 +17,6 @@
 #define dcmqi_WC_URL "@dcmqi_WC_URL@"
 #define dcmqi_WC_TAG "@dcmqi_WC_TAG@"
 
-#define dcmqi_INFO "dcmqi revision hash: @dcmqi_WC_REVISION@ tag: @dcmqi_WC_TAG@"
+#define dcmqi_INFO "dcmqi repository URL: @dcmqi_WC_URL@ revision: @dcmqi_WC_REVISION@ tag: @dcmqi_WC_TAG@"
 
 #endif // __dcmqiVersionConfigure_h

--- a/apps/paramaps/itkimage2paramap.cxx
+++ b/apps/paramaps/itkimage2paramap.cxx
@@ -4,10 +4,12 @@
 // DCMQI includes
 #undef HAVE_SSTREAM // Avoid redefinition warning
 #include "dcmqi/ParaMapConverter.h"
-
+#include "dcmqi/internal/VersionConfigure.h"
 
 int main(int argc, char *argv[])
 {
+  std::cout << dcmqi_INFO << std::endl;
+
   PARSE_ARGS;
 
   if (inputFileName.empty() || metaDataFileName.empty() || outputParaMapFileName.empty() )

--- a/apps/paramaps/paramap2itkimage.cxx
+++ b/apps/paramaps/paramap2itkimage.cxx
@@ -4,10 +4,13 @@
 // DCMQI includes
 #undef HAVE_SSTREAM // Avoid redefinition warning
 #include "dcmqi/ParaMapConverter.h"
+#include "dcmqi/internal/VersionConfigure.h"
 
 
 int main(int argc, char *argv[])
 {
+  std::cout << dcmqi_INFO << std::endl;
+
   PARSE_ARGS;
 
   DcmFileFormat sliceFF;

--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -4,11 +4,12 @@
 // DCMQI includes
 #undef HAVE_SSTREAM // Avoid redefinition warning
 #include "dcmqi/ImageSEGConverter.h"
-
-
+#include "dcmqi/internal/VersionConfigure.h"
 
 int main(int argc, char *argv[])
 {
+  std::cout << dcmqi_INFO << std::endl;
+  
   PARSE_ARGS;
 
   if (segImageFiles.empty()){

--- a/apps/seg/segimage2itkimage.cxx
+++ b/apps/seg/segimage2itkimage.cxx
@@ -4,10 +4,13 @@
 // DCMQI includes
 #undef HAVE_SSTREAM // Avoid redefinition warning
 #include "dcmqi/ImageSEGConverter.h"
+#include "dcmqi/internal/VersionConfigure.h"
 
 
 int main(int argc, char *argv[])
 {
+  std::cout << dcmqi_INFO << std::endl;
+  
   PARSE_ARGS;
 
   DcmFileFormat sliceFF;

--- a/apps/sr/tid1500reader.cxx
+++ b/apps/sr/tid1500reader.cxx
@@ -25,6 +25,7 @@
 #include "dcmqi/Exceptions.h"
 #include "dcmqi/QIICRConstants.h"
 #include "dcmqi/QIICRUIDs.h"
+#include "dcmqi/internal/VersionConfigure.h"
 
 using namespace std;
 
@@ -130,6 +131,8 @@ Json::Value getMeasurements(DSRDocument &doc) {
 }
 
 int main(int argc, char** argv){
+  std::cout << dcmqi_INFO << std::endl;
+
   PARSE_ARGS;
 
   Json::Value metaRoot;

--- a/apps/sr/tid1500writer.cxx
+++ b/apps/sr/tid1500writer.cxx
@@ -25,6 +25,7 @@
 #include "dcmqi/Exceptions.h"
 #include "dcmqi/QIICRConstants.h"
 #include "dcmqi/QIICRUIDs.h"
+#include "dcmqi/internal/VersionConfigure.h"
 
 using namespace std;
 
@@ -60,6 +61,9 @@ DcmFileFormat addFileToEvidence(DSRDocument &doc, string dirStr, string fileStr)
 }
 
 int main(int argc, char** argv){
+
+  std::cout << dcmqi_INFO << std::endl;
+
   PARSE_ARGS;
 
   Json::Value metaRoot;


### PR DESCRIPTION
With the current setup, especially with the use of Docker images, it is not easy
to determine the version of the software being used. This commit adds console
output of the git hash and tag (when available) as the first line in the command
line output of the converters.