### PR TITLE
ENH: remove DerivedPixelContrast initialization

### DIFF
--- a/doc/examples/pm-example-float.json
+++ b/doc/examples/pm-example-float.json
@@ -33,6 +33,5 @@
     "CodeMeaning": "Prostate"
   },
   "FrameLaterality" : "U",
-  "RealWorldValueSlope" : 1,
-  "DerivedPixelContrast" : "ADC"
+  "RealWorldValueSlope" : 1
 }

--- a/doc/examples/pm-example.json
+++ b/doc/examples/pm-example.json
@@ -33,6 +33,5 @@
     "CodeMeaning": "Prostate"
   },
   "FrameLaterality" : "U",
-  "RealWorldValueSlope" : 1,
-  "DerivedPixelContrast" : "ADC"
+  "RealWorldValueSlope" : 1
 }

--- a/doc/pmContexts/pm-dce-context.json
+++ b/doc/pmContexts/pm-dce-context.json
@@ -8,7 +8,6 @@
       "CodeMeaning": "Mean Transit Time",
       "CodingSchemeDesignator": "DCM",
       "cid": "4108",
-      "DerivedPixelContrast": "MTT",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -22,7 +21,6 @@
       "CodeMeaning": "Regional Cerebral Blood Flow",
       "CodingSchemeDesignator": "DCM",
       "cid": "4108",
-      "DerivedPixelContrast": "RCBF",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -41,7 +39,6 @@
       "CodeMeaning": "Regional Cerebral Blood Volume",
       "CodingSchemeDesignator": "DCM",
       "cid": "4108",
-      "DerivedPixelContrast": "RCBV",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -60,7 +57,6 @@
       "CodeMeaning": "Time To Peak",
       "CodingSchemeDesignator": "DCM",
       "cid": "4108,4109",
-      "DerivedPixelContrast": "TTP",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -74,7 +70,6 @@
       "CodeMeaning": "Tmax",
       "CodingSchemeDesignator": "DCM",
       "cid": "4108",
-      "DerivedPixelContrast": "TMAX",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -88,7 +83,6 @@
       "CodeMeaning": "Ktrans",
       "CodingSchemeDesignator": "DCM",
       "cid": "4107",
-      "DerivedPixelContrast": "KTRANS",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -102,7 +96,6 @@
       "CodeMeaning": "kep",
       "CodingSchemeDesignator": "DCM",
       "cid": "4107",
-      "DerivedPixelContrast": "KEP",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -116,7 +109,6 @@
       "CodeMeaning": "ve",
       "CodingSchemeDesignator": "DCM",
       "cid": "4107",
-      "DerivedPixelContrast": "VE",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -130,7 +122,6 @@
       "CodeMeaning": "IAUC",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "IAUC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -144,7 +135,6 @@
       "CodeMeaning": "IAUC60",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "IAUC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -158,7 +148,6 @@
       "CodeMeaning": "IAUC90",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "IAUC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -172,7 +161,6 @@
       "CodeMeaning": "IAUC180",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "IAUC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -186,7 +174,6 @@
       "CodeMeaning": "IAUCBN",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "IAUC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -200,7 +187,6 @@
       "CodeMeaning": "IAUC60BN",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "IAUC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -214,7 +200,6 @@
       "CodeMeaning": "IAUC90BN",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "IAUC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -228,7 +213,6 @@
       "CodeMeaning": "IAUC180BN",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "IAUC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -242,7 +226,6 @@
       "CodeMeaning": "tau_m",
       "CodingSchemeDesignator": "DCM",
       "cid": "4107",
-      "DerivedPixelContrast": "IAUC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -256,7 +239,6 @@
       "CodeMeaning": "vp",
       "CodingSchemeDesignator": "DCM",
       "cid": "4107",
-      "DerivedPixelContrast": "VP",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -270,7 +252,6 @@
       "CodeMeaning": "Time of Peak Concentration",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "T_OF_PEAK",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -284,7 +265,6 @@
       "CodeMeaning": "Bolus Arrival Time",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "BAT",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -298,7 +278,6 @@
       "CodeMeaning": "Time of Leading Half-Peak Concentration",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "T_OF_PEAK",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -312,7 +291,6 @@
       "CodeMeaning": "Temporal Derivative Threshold",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "TDT",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -326,7 +304,6 @@
       "CodeMeaning": "Maximum Slope",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "MAX_SLOPE",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -340,7 +317,6 @@
       "CodeMeaning": "Maximum Difference",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "MAX_DIFF",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -354,7 +330,6 @@
       "CodeMeaning": "Tracer Concentration",
       "CodingSchemeDesignator": "DCM",
       "cid": "4109",
-      "DerivedPixelContrast": "TRACER_CONC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -368,7 +343,6 @@
       "CodeMeaning": "Regional Blood Flow",
       "CodingSchemeDesignator": "DCM",
       "cid": "4108",
-      "DerivedPixelContrast": "RBF",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -387,7 +361,6 @@
       "CodeMeaning": "Regional Blood Volume",
       "CodingSchemeDesignator": "DCM",
       "cid": "4108",
-      "DerivedPixelContrast": "RBV",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -406,7 +379,6 @@
       "CodeMeaning": "Oxygen Extraction Fraction",
       "CodingSchemeDesignator": "DCM",
       "cid": "4108",
-      "DerivedPixelContrast": "OXY_FRAC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",

--- a/doc/pmContexts/pm-dwi-context.json
+++ b/doc/pmContexts/pm-dwi-context.json
@@ -8,7 +8,6 @@
       "CodeMeaning": "Fractional Anisotropy",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn2",
-      "DerivedPixelContrast": "DIFFUSION_ANISO",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -22,7 +21,6 @@
       "CodeMeaning": "Relative Anisotropy",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn2",
-      "DerivedPixelContrast": "DIFFUSION_ANISO",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -36,7 +34,6 @@
       "CodeMeaning": "Volumetric Diffusion Dxx Component",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn1",
-      "DerivedPixelContrast": "DIFFUSION",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -50,7 +47,6 @@
       "CodeMeaning": "Volumetric Diffusion Dxy Component",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn1",
-      "DerivedPixelContrast": "DIFFUSION",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -64,7 +60,6 @@
       "CodeMeaning": "Volumetric Diffusion Dxz Component",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn1",
-      "DerivedPixelContrast": "DIFFUSION",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -78,7 +73,6 @@
       "CodeMeaning": "Volumetric Diffusion Dyy Component",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn1",
-      "DerivedPixelContrast": "DIFFUSION",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -92,7 +86,6 @@
       "CodeMeaning": "Volumetric Diffusion Dyz Component",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn1",
-      "DerivedPixelContrast": "DIFFUSION",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -106,7 +99,6 @@
       "CodeMeaning": "Volumetric Diffusion Dzz Component",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn1",
-      "DerivedPixelContrast": "DIFFUSION",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -120,7 +112,6 @@
       "CodeMeaning": "Apparent Diffusion Coefficient",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -149,7 +140,6 @@
       "CodeMeaning": "Diffusion weighted",
       "CodingSchemeDesignator": "DCM",
       "cid": "nnn1",
-      "DerivedPixelContrast": "DIFFUSION",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -163,7 +153,6 @@
       "CodeMeaning": "Diffusion Coefficient",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "DIFFUSION",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -192,7 +181,6 @@
       "CodeMeaning": "Mono-exponential Apparent Diffusion Coefficient",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -221,7 +209,6 @@
       "CodeMeaning": "Slow Diffusion Coefficient",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -250,7 +237,6 @@
       "CodeMeaning": "Fast Diffusion Coefficient",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -279,7 +265,6 @@
       "CodeMeaning": "Fast Diffusion Coefficient Fraction",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -293,7 +278,6 @@
       "CodeMeaning": "Kurtosis Diffusion Coefficient",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -322,7 +306,6 @@
       "CodeMeaning": "Gamma Distribution Scale Parameter",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -336,7 +319,6 @@
       "CodeMeaning": "Gamma Distribution Shape Parameter",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -350,7 +332,6 @@
       "CodeMeaning": "Gamma Distribution Mode",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -364,7 +345,6 @@
       "CodeMeaning": "Distributed Diffusion Coefficient",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -393,7 +373,6 @@
       "CodeMeaning": "Anomalous Exponent Parameter",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn3",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",
@@ -407,7 +386,6 @@
       "CodeMeaning": "Volume Ratio",
       "CodingSchemeDesignator": "99DCMCP1665",
       "cid": "nnn2",
-      "DerivedPixelContrast": "ADC",
       "MeasurementUnitsCode": [
         {
           "CodingSchemeDesignator": "UCUM",

--- a/doc/schemas/pm-context-schema.json
+++ b/doc/schemas/pm-context-schema.json
@@ -27,9 +27,6 @@
         "SNOMEDConceptID": {
           "type": "string"
         },
-        "DerivedPixelContrast": {
-          "type": "string"
-        },
         "MeasurementUnitsCodes": {
           "type": "array",
           "minItems": 1,

--- a/doc/schemas/pm-schema.json
+++ b/doc/schemas/pm-schema.json
@@ -3,7 +3,6 @@
   "id": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/pm-schema.json#",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "required": [
-    "DerivedPixelContrast",
     "AnatomicRegionSequence",
     "FrameLaterality",
     "QuantityValueCode",
@@ -75,10 +74,6 @@
     "RealWorldValueSlope": {
       "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/FD",
       "default": 1.0
-    },
-    "DerivedPixelContrast": {
-      "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/CS",
-      "default": "NONE"
     },
     "AnatomicRegionSequence": {
       "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -119,12 +119,7 @@ namespace dcmqi {
     CHECK_COND(pMapDoc->addForAllFrames(idTransFG));
 
     FGParametricMapFrameType frameTypeFG;
-    std::string frameTypeStr = "DERIVED\\PRIMARY\\VOLUME\\";
-    if(metaInfo.metaInfoRoot.isMember("DerivedPixelContrast")){
-      frameTypeStr = frameTypeStr + metaInfo.metaInfoRoot["DerivedPixelContrast"].asCString();
-    } else {
-      frameTypeStr = frameTypeStr + "NONE";
-    }
+    std::string frameTypeStr = "DERIVED\\PRIMARY\\VOLUME\\QUANTITY";
     frameTypeFG.setFrameType(frameTypeStr.c_str());
     CHECK_COND(pMapDoc->addForAllFrames(frameTypeFG));
 


### PR DESCRIPTION
As discussed with David Clunie, "QUANTITY" will be proposed to be used for all
Parametric maps. Note that this relies on a CP that has not even been submitted
yet! Resolves #216.