### PR TITLE
BUG: fix several issues with CLI XML

### DIFF
--- a/apps/paramaps/itkimage2paramap.xml
+++ b/apps/paramaps/itkimage2paramap.xml
@@ -10,7 +10,7 @@
   <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
-
+    <label>Required input/output parameters</label>
     <file>
       <name>inputFileName</name>
       <label>Parametric Map file name</label>
@@ -35,6 +35,19 @@
       <description>File name of the DICOM Parametric map object with the result of the conversion.</description>
     </file>
 
+    <directory>
+      <name>dicomDirectory</name>
+      <label>Source DICOM directory</label>
+      <channel>input</channel>
+      <longflag>inputDICOMDirectory</longflag>
+      <default></default>
+      <description>Directory with the source DICOM images that were used to generate the parametric map.</description>
+    </directory>
+
+  </parameters>
+
+  <parameters advanced="true">
+    <label>Additional input/output</label>
     <string-vector>
       <name>dicomImageFileList</name>
       <label>DICOM images file name</label>
@@ -43,16 +56,6 @@
       <default></default>
       <description>File name of the DICOM image file that should be used to populate the composite context (attributes related to the patient and imaging study).</description>
     </string-vector>
-
-    <file>
-      <name>dicomDirectory</name>
-      <label>Source DICOM directory</label>
-      <channel>input</channel>
-      <longflag>inputDICOMDirectory</longflag>
-      <default></default>
-      <description>Directory with the source DICOM images that were used to generate the parametric map.</description>
-    </file>
-
   </parameters>
 
 </executable>

--- a/apps/paramaps/itkimage2paramap.xml
+++ b/apps/paramaps/itkimage2paramap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Informatics.Converters</category>
-  <title>Encode DICOM Parametric Map</title>
+  <title>Convert ITK image to DICOM Parametric Map</title>
   <description>Convert a parametric map provided in any of the formats supported by ITK, such as NRRD or NIFTI, into a DICOM Parametric Map image object.</description>
   <version>1.0</version>
   <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>

--- a/apps/paramaps/paramap2itkimage.xml
+++ b/apps/paramaps/paramap2itkimage.xml
@@ -10,6 +10,7 @@
   <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
+    <label>Required input/output parameters</label>
     <file>
       <name>inputFileName</name>
       <label>Parametric Map DICOM file name</label>
@@ -25,6 +26,10 @@
       <longflag>outputDirectory</longflag>
       <description>Directory to store parametric map in an ITK format, and the JSON metadata file.</description>
     </directory>
+  </parameters>
+
+  <parameters advanced="true">
+    <label>Advanced parameters</label>
 
     <string-enumeration>
       <name>outputType</name>

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -10,7 +10,7 @@
   <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
-
+    <label>Required input/output parameters</label>
     <file>
       <name>metaDataFileName</name>
       <label>JSON metadata file</label>
@@ -50,6 +50,10 @@
       <longflag>inputImageList</longflag>
       <description>Comma-separated list of file names of the segmentation images in a format readable by ITK (NRRD, NIfTI, MHD, etc.). Each of the individual files can contain one or more labels (segments). Segments from different files are allowed to overlap. See documentation for details.</description>
     </string-vector>
+  </parameters>
+
+  <parameters advanced="true">
+    <label>Advanced processing parameters</label>
 
     <boolean>
       <name>skipEmptySlices</name>

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Informatics.Converters</category>
-  <title>Encode DICOM SEG</title>
+  <title>Convert ITK image(s) into DICOM Segmentation Image</title>
   <description>Convert the volumetric segmentation(s) stored as labeled pixels using any of the formats supported by ITK, such as NRRD or NIFTI, into a DICOM Segmentation Object (further referred to as SEG).</description>
   <version>1.0</version>
   <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -10,6 +10,7 @@
   <acknowledgements>This work is supported in part the National Institutes of Health, National Cancer Institute, Informatics Technology for Cancer Research (ITCR) program, grant Quantitative Image Informatics for Cancer Research (QIICR) (U24 CA180918, PIs Kikinis and Fedorov).</acknowledgements>
 
   <parameters>
+    <label>Required input/output parameters</label>
     <file>
       <name>inputSEGFileName</name>
       <label>SEG file name</label>
@@ -18,13 +19,18 @@
       <description>File name of the input DICOM Segmentation image object.</description>
     </file>
 
-    <file>
+    <directory>
       <name>outputDirName</name>
       <label>Output directory name</label>
       <channel>input</channel>
       <longflag>outputDirectory</longflag>
       <description>Directory to store individual segments saved using the output format specified files. When specified, file names will contain prefix, followed by the segment number.</description>
-    </file>
+    </directory>
+
+  </parameters>
+
+  <parameters advanced="true">
+    <label>Advanced parameters</label>
 
     <string>
       <name>prefix</name>

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Informatics</category>
-  <title>Convert DICOM SEG into ITK image</title>
+  <title>Convert DICOM Segmentation Image into ITK image(s)</title>
   <description>This tool can be used to convert DICOM Segmentation into volumetric segmentations stored as labeled pixels using research format, such as NRRD or NIfTI, and meta information stored in the JSON file format.</description>
   <version>1.0</version>
   <documentation-url>https://github.com/QIICR/dcmqi</documentation-url>


### PR DESCRIPTION
This fixes CLI type from file to directory where appropriate, assigns label to
parameter names, and separates advanced options.

This is important when using converters from Slicer UI, which may be easier than
dealing with the issues of path separators and other Windows idiosyncrasies while
running converters from the command line.