### PR TITLE
BUG: check for the number of inner lists in metadata

### DIFF
--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -16,6 +16,11 @@ namespace dcmqi {
     JSONSegmentationMetaInformationHandler metaInfo(metaData.c_str());
     metaInfo.read();
 
+    if(metaInfo.segmentsAttributesMappingList.size() != segmentations.size()){
+      cerr << "Mismatch between the number of input segmentation files and the size of metainfo list!" << endl;
+      return NULL;
+    };
+
     IODGeneralEquipmentModule::EquipmentInfo eq = getEquipmentInfo();
     ContentIdentificationMacro ident = createContentIdentificationInformation(metaInfo);
     CHECK_COND(ident.setInstanceNumber(metaInfo.getInstanceNumber().c_str()));


### PR DESCRIPTION
Abort conversion if the number of inner lists does not match the number of input
segmentations.

Fixes #243