### PR TITLE
ENH: add output of missing SR TID1500 attributes

### DIFF
--- a/apps/sr/tid1500reader.cxx
+++ b/apps/sr/tid1500reader.cxx
@@ -70,9 +70,16 @@ Json::Value getMeasurements(DSRDocument &doc) {
         if (st.gotoNamedChildNode(DSRCodedEntryValue("C67447", "NCIt", "Activity Session"))) {
           // TODO: think about it
           cout << "Activity Session: " << st.getCurrentContentItem().getStringValue().c_str() << endl;
-          measurement["ActivitySession"] = st.getCurrentContentItem().getStringValue().c_str();
+          measurement["activitySession"] = st.getCurrentContentItem().getStringValue().c_str();
         }
         st.gotoNode(nnid);
+        if (st.gotoNamedChildNode(DSRCodedEntryValue("C2348792", "UMLS", "Time Point"))) {
+          // TODO: think about it
+          cout << "Time Point: " << st.getCurrentContentItem().getStringValue().c_str() << endl;
+          measurement["timePoint"] = st.getCurrentContentItem().getStringValue().c_str();
+        }
+        st.gotoNode(nnid);
+
         if (st.gotoNamedChildNode(CODE_DCM_ReferencedSegment)) {
           DSRImageReferenceValue referenceImage = st.getCurrentContentItem().getImageReference();
           OFVector<Uint16> items;
@@ -94,6 +101,12 @@ Json::Value getMeasurements(DSRDocument &doc) {
           measurement["TrackingIdentifier"] = st.getCurrentContentItem().getStringValue().c_str();
         }
         st.gotoNode(nnid);
+        if (st.gotoNamedChildNode(CODE_DCM_TrackingUniqueIdentifier)) {
+          cout << "TrackingUniqueIdentifier: " << st.getCurrentContentItem().getStringValue().c_str() << endl;
+          measurement["TrackingUniqueIdentifier"] = st.getCurrentContentItem().getStringValue().c_str();
+        }
+        st.gotoNode(nnid);
+
         if (st.gotoNamedChildNode(CODE_DCM_Finding)) {
           measurement["Finding"] = DSRCodedEntryValue2CodeSequence(st.getCurrentContentItem().getCodeValue());
         }

--- a/apps/sr/tid1500reader.cxx
+++ b/apps/sr/tid1500reader.cxx
@@ -73,10 +73,16 @@ Json::Value getMeasurements(DSRDocument &doc) {
           measurement["activitySession"] = st.getCurrentContentItem().getStringValue().c_str();
         }
         st.gotoNode(nnid);
+
         if (st.gotoNamedChildNode(DSRCodedEntryValue("C2348792", "UMLS", "Time Point"))) {
           // TODO: think about it
           cout << "Time Point: " << st.getCurrentContentItem().getStringValue().c_str() << endl;
           measurement["timePoint"] = st.getCurrentContentItem().getStringValue().c_str();
+        }
+        st.gotoNode(nnid);
+
+        if (st.gotoNamedChildNode(DSRCodedEntryValue("G-C036", "SRT", "Measurement Method"))) {
+          measurement["measurementMethod"] = DSRCodedEntryValue2CodeSequence(st.getCurrentContentItem().getCodeValue());
         }
         st.gotoNode(nnid);
 

--- a/doc/schemas/sr-tid1500-schema.json
+++ b/doc/schemas/sr-tid1500-schema.json
@@ -88,6 +88,9 @@
       "type": "string",
       "default": "1"
     },
+    "measurementMethod": {
+      "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"
+    },
     "VerificationFlag": {
       "allOf": [
         {


### PR DESCRIPTION
 - TrackingUniqueIdentier, activitySession, timePoint
 - fix capitalization of activitySession and timePoint to be consistent with
   the schema, and the conventions, since these are not DICOM tags, but concept
   code mapped