### PR TITLE
BUG: fix the order of parameters to import() call

### DIFF
--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -36,8 +36,9 @@ namespace dcmqi {
         eq,     // equipment
         ident);   // content identification
 
-    /* Import patient and study from existing file */
-    CHECK_COND(segdoc->import(*dcmDatasets[0], OFTrue, OFTrue, OFFalse, OFTrue));
+    // import Patient, Study and Frame of Reference; do not import Series
+    // attributes
+    CHECK_COND(segdoc->import(*dcmDatasets[0], OFTrue, OFTrue, OFTrue, OFFalse));
 
     /* Initialize dimension module */
     char dimUID[128];

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -56,7 +56,9 @@ namespace dcmqi {
       srcDataset = dcmDatasets[0];
     }
     if (srcDataset)
-      CHECK_COND(pMapDoc->import(*srcDataset, OFTrue, OFTrue, OFFalse, OFTrue));
+      // import Patient, Study and Frame of Reference; do not import Series
+      // attributes
+      CHECK_COND(pMapDoc->import(*srcDataset, OFTrue, OFTrue, OFTrue, OFFalse));
 
     /* Initialize dimension module */
     char dimUID[128];


### PR DESCRIPTION
Due to a fixed bug in DCMTK - see discussion in

https://github.com/QIICR/QuantitativeReporting/issues/170#issuecomment-317540337

the order of parameters passed to import changed and dcmqi was incorrectly
importing series attributes, and not importing frame of reference.