### PR TITLE
ci: Update scikit-ci-addons to handle leftover temporary release tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 # Use scikit-ci-addons to
 # * streamline installation of CMake
 # * install package required to automatically create or update GitHub releases
-- pip install -U "scikit-ci-addons>=0.17.0"
+- pip install -U "scikit-ci-addons>=0.18.0"
 - ci_addons travis/install_cmake 3.6.2
 # Install Ninja
 - wget --no-check-certificate https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-mac.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ before_build:
         $client.DownloadFile("https://github.com/fedorov/SlicerExecutionModel/releases/download/SlicerExecutionModel-dcmqi-VS12-Win64-Release-v0.0.5/SlicerExecutionModel-dcmqi.zip", "C:\SlicerExecutionModel-dcmqi.zip")
   - 7z x C:\SlicerExecutionModel-dcmqi.zip -oC:\SlicerExecutionModel\SlicerExecutionModel-build
   # Install package required to automatically create or update GitHub releases
-  - pip install -U "scikit-ci-addons>=0.17.0"
+  - pip install -U "scikit-ci-addons>=0.18.0"
   # Configure project
   - |
     mkdir c:\dcmqi\dcmqi-build

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
         ../build/dcmqi-build/ \
         ../util/junit/conv.xsl > ../build/BaseTest.xml
     # Install package required to automatically create or update GitHub releases
-    - pip install -U "scikit-ci-addons>=0.17.0"
+    - pip install -U "scikit-ci-addons>=0.18.0"
 
 test:
   post:


### PR DESCRIPTION
See #260

```
$ git shortlog 0.17.0..0.18.0 --no-merges
Jean-Christophe Fillion-Robin (1):
      publish_github_release: Update githubrelease 1.5.6 to handle leftover tmp release tag
```

This commit fixes exception like the following happening when the temporary
release tag (e.g latest-tmp) remains for a previous failed attempt to upload
packages.

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/anyci/publish_github_release.py", line 443, in <module>
    main()
  File "/usr/local/lib/python2.7/site-packages/anyci/publish_github_release.py", line 436, in main
    _upload_prerelease(args)
  File "/usr/local/lib/python2.7/site-packages/anyci/publish_github_release.py", line 346, in _upload_prerelease
    target_commitish=sha
  File "/usr/local/lib/python2.7/site-packages/github_release.py", line 116, in with_check_for_credentials
    return func(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/github_release.py", line 479, in gh_release_edit
    patch_release(repo_name, current_tag_name, **attributes)
  File "/usr/local/lib/python2.7/site-packages/github_release.py", line 327, in patch_release
    dry_run
  File "/usr/local/lib/python2.7/site-packages/github_release.py", line 301, in _update_release_sha
    dry_run=dry_run)
  File "/usr/local/lib/python2.7/site-packages/github_release.py", line 327, in patch_release
    dry_run
  File "/usr/local/lib/python2.7/site-packages/github_release.py", line 301, in _update_release_sha
    dry_run=dry_run)
  File "/usr/local/lib/python2.7/site-packages/github_release.py", line 320, in patch_release
    release = get_release_info(repo_name, current_tag_name)
  File "/usr/local/lib/python2.7/site-packages/github_release.py", line 272, in get_release_info
    raise Exception('Release with tag_name {0} not found'.format(tag_name))
Exception: Release with tag_name latest-tmp not found
```

[ci skip]