### PR TITLE
COMP: Consistently propagate CMAKE_MACOSX_RPATH to all projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,15 @@ if(NOT DCMQI_USE_GIT_PROTOCOL)
   set(git_protocol "http")
 endif()
 
+# macOS rpath
+if(NOT DEFINED CMAKE_MACOSX_RPATH)
+  set(CMAKE_MACOSX_RPATH 1)
+endif()
+mark_as_superbuild(
+  VARS CMAKE_MACOSX_RPATH:BOOL
+  ALL_PROJECTS
+  )
+
 #-----------------------------------------------------------------------------
 # Dependencies
 #


### PR DESCRIPTION
With update of the minimum required version of CMake to 3.5.0 in Slicer,
default value for CMAKE_MACOSX_RPATH changed to ON but Slicer required this
option to be OFF.
This commit makes sure the value passed by the Slicer extension build
system is used consistently.

This commit associated with the use of Slicer >= r26305 [1]
will prevent error like the following:

```
Error copying file "@rpath/libitkminc2-4.12.1.dylib" to "/.../DCMQI-build/dcmqi-build/_CPack_Packages/Darwin/TGZ/26304-macosx-amd64-DCMQI-git87fce09-2017-08-23/Slicer.app/Contents/lib/Slicer-4.7/libitkminc2-4.12.1.dylib".
```

Related Slicer discussions:

https://discourse.slicer.org/t/interpreting-cdash-reporting-extension-is-packaged-despite-build-errors/856
https://discourse.slicer.org/t/extension-build-failure-on-mac-due-to-error-copying-files/935

[1] r26305 COMP: Update ITK and CTK to fix remaining extension packaging issues
    http://viewvc.slicer.org/viewvc.cgi/Slicer4?view=revision&revision=26305