### PR TITLE
cmake: Fix forcebuild step

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -100,9 +100,9 @@ ExternalProject_Add(${proj}
 # version will be at least 3.1.
 #
 if(CMAKE_CONFIGURATION_TYPES)
-  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${CMAKE_CFG_INTDIR}/${proj}-build")
+  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME_LC}-prefix/src/${proj}-stamp/${CMAKE_CFG_INTDIR}/${proj}-build")
 else()
-  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${proj}-prefix/src/${proj}-stamp/${proj}-build")
+  set(BUILD_STAMP_FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME_LC}-prefix/src/${proj}-stamp/${proj}-build")
 endif()
 ExternalProject_Add_Step(${proj} forcebuild
   COMMAND ${CMAKE_COMMAND} -E remove ${BUILD_STAMP_FILE}


### PR DESCRIPTION
This commit ensures the step attempts to remove an existing file by
fixing a regression introduced in b569199 (cmake: Introduce PROJECT_NAME_LC
var to allow consistent naming of inner build dir)