### PR TITLE
WIP: add support for initializing measurement properties

### DIFF
--- a/doc/examples/sr-tid1500-ct-liver-example.json
+++ b/doc/examples/sr-tid1500-ct-liver-example.json
@@ -85,7 +85,7 @@
                 "CodeMeaning": "Top secret filter b"
               }
             }
- 
+
           ],
 
           "measurementDerivationParameters": [
@@ -128,6 +128,35 @@
                 "CodeMeaning": "Apples"
               }
             }
+          ],
+          "measurementPopulationDescription": "Elves of the Black Forest",
+          "measurementNumProperties": [
+            {
+              "numProperty": {
+                "CodeValue": "1234",
+                "CodingSchemeDesignator": "99TEST",
+                "CodeMeaning": "Elf average weight"
+              },
+              "numPropertyValue": "10",
+              "numPropertyUnits": {
+                "CodeValue": "kg",
+                "CodingSchemeDesignator": "UCUM",
+                "CodeMeaning": "kilogram"
+              }
+            },
+            {
+              "numProperty": {
+                "CodeValue": "1235",
+                "CodingSchemeDesignator": "99TEST",
+                "CodeMeaning": "Elf average height"
+              },
+              "numPropertyValue": "11",
+              "numPropertyUnits": {
+                "CodeValue": "cm",
+                "CodingSchemeDesignator": "UCUM",
+                "CodeMeaning": "centimeter"
+              }
+            }
           ]
         },
         {
@@ -146,7 +175,36 @@
             "CodeValue": "R-404FB",
             "CodingSchemeDesignator": "SRT",
             "CodeMeaning": "Minimum"
-          }
+          },
+          "measurementPopulationDescription": "Elves of the Black Forest 2",
+          "measurementNumProperties": [
+            {
+              "numProperty": {
+                "CodeValue": "1234",
+                "CodingSchemeDesignator": "99TEST",
+                "CodeMeaning": "Elf average weight"
+              },
+              "numPropertyValue": "20",
+              "numPropertyUnits": {
+                "CodeValue": "kg",
+                "CodingSchemeDesignator": "UCUM",
+                "CodeMeaning": "kilogram"
+              }
+            },
+            {
+              "numProperty": {
+                "CodeValue": "1235",
+                "CodingSchemeDesignator": "99TEST",
+                "CodeMeaning": "Elf average height"
+              },
+              "numPropertyValue": "21",
+              "numPropertyUnits": {
+                "CodeValue": "cm",
+                "CodingSchemeDesignator": "UCUM",
+                "CodeMeaning": "centimeter"
+              }
+            }
+          ]
         },
         {
           "value": "221",

--- a/doc/schemas/sr-tid1500-schema.json
+++ b/doc/schemas/sr-tid1500-schema.json
@@ -23,7 +23,10 @@
           "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"
         },
         "numPropertyValue": {
-          "type": "number"
+          "type": "string"
+        },
+        "numPropertyUnits": {
+          "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"
         }
       }
     },

--- a/doc/schemas/sr-tid1500-schema.json
+++ b/doc/schemas/sr-tid1500-schema.json
@@ -16,6 +16,18 @@
       }
     },
 
+    "measurementNumProperty": {
+      "type": "object",
+      "properties": {
+        "numProperty": {
+          "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"
+        },
+        "numPropertyValue": {
+          "type": "number"
+        }
+      }
+    },
+
     "measurementDerivationParameter": {
       "type": "object",
       "properties": {
@@ -60,6 +72,17 @@
           "items": {
             "$ref": "#/definitions/measurementDerivationParameter"
           }
+        },
+
+        "measurementNumProperties": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/measurementNumProperty"
+          }
+        },
+
+        "measurementPopulationDescription": {
+          "type": "string"
         }
 
       }


### PR DESCRIPTION
This aims to address #305. Schema extended to support numeric and text properties
of the measurement, as suggested by @dclunie in

https://github.com/QIICR/dcmqi/issues/305#issuecomment-335172718

Since these attributes are not supported by the dcmsr wrapper class, they are added
in a separate iteration by iterating over all measurement items using gotoAnnotatedNode(),
and setting measurement properties, when applicable.

Reading SR and saving JSON is not supported yet.