### PR TITLE
Util Classes to build Measurement Report and generate JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ CMakeLists.txt.user*
 __pycache__/
 *.py[cod]
 *$py.class
+
+# VSCode             #
+######################
+.vscode

--- a/util/measurementReportUtils/__init__.py
+++ b/util/measurementReportUtils/__init__.py
@@ -1,0 +1,7 @@
+# Defining convenience import shortcuts for those classes which are
+# supposed to be used publicly
+from .measurementReport import MeasurementReport
+from .measurementGroup import MeasurementGroup
+from .measurementItem import VolumeMeasurementItem, MeanADCMeasurementItem
+from .findings import Finding, FindingSite
+

--- a/util/measurementReportUtils/__init__.py
+++ b/util/measurementReportUtils/__init__.py
@@ -3,5 +3,5 @@
 from .measurementReport import MeasurementReport
 from .measurementGroup import MeasurementGroup
 from .measurementItem import VolumeMeasurementItem, MeanADCMeasurementItem
-from .findings import Finding, FindingSite
+from .codeSequences import CodeSequence, Finding, FindingSite, ProcedureReported
 

--- a/util/measurementReportUtils/codeSequences.py
+++ b/util/measurementReportUtils/codeSequences.py
@@ -1,5 +1,5 @@
 
-class GenericFindingStruct(object):
+class CodeSequence(object):
 
   def __init__(self, codeMeaning, codingSchemeDesignator, codeValue):
     self.CodeValue = codeValue
@@ -7,7 +7,7 @@ class GenericFindingStruct(object):
     self.CodeMeaning = codeMeaning
 
 
-class Finding(GenericFindingStruct):
+class Finding(CodeSequence):
 
   def __init__(self, segmentedStructure):
     if segmentedStructure == "NormalROI_PZ_1":
@@ -19,10 +19,10 @@ class Finding(GenericFindingStruct):
     elif segmentedStructure == "WholeGland":
       super().__init__("Entire Gland", "SRT", "T-F6078")
     else:
-      raise ValueError("Segmented Structure Type {} is not supported yet. Build your own Finding object using GenericFindingStruct".format(segmentedStructure))
+      raise ValueError("Segmented Structure Type {} is not supported yet. Build your own Finding code sequence using the class CodeSequence".format(segmentedStructure))
   
 
-class FindingSite(GenericFindingStruct):
+class FindingSite(CodeSequence):
   
   def __init__(self, segmentedStructure):
     if segmentedStructure == "NormalROI_PZ_1":
@@ -34,7 +34,14 @@ class FindingSite(GenericFindingStruct):
     elif segmentedStructure == "WholeGland":
       super().__init__("Prostate", "SRT", "T-9200B")
     else:
-      raise ValueError("Segmented Structure Type {} is not supported yet. Build your own FindingSite object using GenericFindingStruct".format(segmentedStructure))
+      raise ValueError("Segmented Structure Type {} is not supported yet. Build your own FindingSite code sequence using the class CodeSequence".format(segmentedStructure))
 
 
+class ProcedureReported(CodeSequence):
+
+  def __init__(self, codeMeaning):
+    if codeMeaning == "Multiparametric MRI of prostate":
+      super().__init__("Multiparametric MRI of prostate", "DCM", "126021")
+    else:
+      raise ValueError("Procedure Type {} is not supported yet. Build your own ProcedureReported code sequence using the class CodeSequence".format(codeMeaning))
 

--- a/util/measurementReportUtils/findings.py
+++ b/util/measurementReportUtils/findings.py
@@ -1,0 +1,40 @@
+
+class GenericFindingStruct(object):
+
+  def __init__(self, codeMeaning, codingSchemeDesignator, codeValue):
+    self.CodeValue = codeValue
+    self.CodingSchemeDesignator = codingSchemeDesignator
+    self.CodeMeaning = codeMeaning
+
+
+class Finding(GenericFindingStruct):
+
+  def __init__(self, segmentedStructure):
+    if segmentedStructure == "NormalROI_PZ_1":
+      super().__init__("Normal", "SRT", "G-A460")
+    elif segmentedStructure == "PeripheralZone":
+      super().__init__("Entire", "SRT", "R-404A4")
+    elif segmentedStructure == "TumorROI_PZ_1":
+      super().__init__("Abnormal", "SRT", "R-42037")
+    elif segmentedStructure == "WholeGland":
+      super().__init__("Entire Gland", "SRT", "T-F6078")
+    else:
+      raise ValueError("Segmented Structure Type {} is not supported yet. Build your own Finding object using GenericFindingStruct".format(segmentedStructure))
+  
+
+class FindingSite(GenericFindingStruct):
+  
+  def __init__(self, segmentedStructure):
+    if segmentedStructure == "NormalROI_PZ_1":
+      super().__init__("Peripheral zone of the prostate", "SRT", "T-D05E4")
+    elif segmentedStructure == "PeripheralZone":
+      super().__init__("Peripheral zone of the prostate", "SRT", "T-D05E4")
+    elif segmentedStructure == "TumorROI_PZ_1":
+      super().__init__("Peripheral zone of the prostate", "SRT", "T-D05E4")
+    elif segmentedStructure == "WholeGland":
+      super().__init__("Prostate", "SRT", "T-9200B")
+    else:
+      raise ValueError("Segmented Structure Type {} is not supported yet. Build your own FindingSite object using GenericFindingStruct".format(segmentedStructure))
+
+
+

--- a/util/measurementReportUtils/measurementGroup.py
+++ b/util/measurementReportUtils/measurementGroup.py
@@ -1,0 +1,26 @@
+
+class MeasurementGroup(object):
+  """
+  Data structure plus convenience methods to create measurment groups following
+  the required format to be processed by the DCMQI tid1500writer tool. Use this
+  to populate the Measurements list in :class:`MeasurementReport`.
+  """
+
+  def __init__(self, 
+               trackingIdentifier, referencedSegment, 
+               sourceSeriesInstanceUID, segmentationSOPInstanceUID,
+               finding, findingSite):
+    self.TrackingIdentifier = trackingIdentifier
+    self.ReferencedSegment = referencedSegment
+    self.SourceSeriesForImageSegmentation = sourceSeriesInstanceUID
+    self.segmentationSOPInstanceUID = segmentationSOPInstanceUID
+    self.Finding = finding
+    self.FindingSite = findingSite
+    self.measurementItems = []
+
+  def addMeasurementItem(self, measurementItem):
+    self.measurementItems.append(measurementItem)
+
+    
+
+

--- a/util/measurementReportUtils/measurementGroup.py
+++ b/util/measurementReportUtils/measurementGroup.py
@@ -7,10 +7,11 @@ class MeasurementGroup(object):
   """
 
   def __init__(self, 
-               trackingIdentifier, referencedSegment, 
+               trackingIdentifier, trackingUniqueIdentifier, referencedSegment, 
                sourceSeriesInstanceUID, segmentationSOPInstanceUID,
                finding, findingSite):
     self.TrackingIdentifier = trackingIdentifier
+    self.TrackingUniqueIdentifier = trackingUniqueIdentifier
     self.ReferencedSegment = referencedSegment
     self.SourceSeriesForImageSegmentation = sourceSeriesInstanceUID
     self.segmentationSOPInstanceUID = segmentationSOPInstanceUID

--- a/util/measurementReportUtils/measurementItem.py
+++ b/util/measurementReportUtils/measurementItem.py
@@ -1,0 +1,53 @@
+
+class MeasurementItem(object):
+
+  def __init__(self, value):
+    self.value = self.convertNumericToDcmtkFittingString(value)
+
+  def convertNumericToDcmtkFittingString(self, value):
+    if isinstance(value, float) or isinstance(value, int):
+      s = str(value)
+      if (len(s) <= 16):
+        return s
+      elif (s.find(".") >= 0) and (s.find(".") < 15):
+        return s[:16]
+      else:
+        raise ValueError("Value cannot be converted to 16 digits without loosing too much precision!")
+    else:
+      raise TypeError("Value to convert is not of type float or int")
+
+
+class VolumeMeasurementItem(MeasurementItem):
+
+  def __init__(self, value):
+    super().__init__(value)
+    self.quantity = {
+      "CodeValue": "G-D705", 
+      "CodingSchemeDesignator": "SRT", 
+      "CodeMeaning": "Volume"
+    }
+    self.units = {
+      "CodeValue": "cm3",
+      "CodingSchemeDesignator": "UCUM",
+      "CodeMeaning": "cubic centimeter"
+    }
+
+
+class MeanADCMeasurementItem(MeasurementItem):
+  def __init__(self, value):
+    super().__init__(value)
+    self.quantity = {    
+      "CodeValue": "113041",
+      "CodingSchemeDesignator": "DCM",
+      "CodeMeaning": "Apparent Diffusion Coefficient"
+    }
+    self.units = {
+      "CodeValue": "um2/s",
+      "CodingSchemeDesignator": "UCUM",
+      "CodeMeaning": "um2/s"
+    }
+    self.derivationModifier = {
+      "CodeValue": "R-00317",
+      "CodingSchemeDesignator": "SRT",
+      "CodeMeaning": "Mean"
+    }

--- a/util/measurementReportUtils/measurementReport.py
+++ b/util/measurementReportUtils/measurementReport.py
@@ -11,8 +11,9 @@ class MeasurementReport(object):
   JSON export of this).
   """
 
-  def __init__(self, seriesNumber, compositeContext, dicomSourceFileList, timePoint):
-    self.SeriesDescription = "Measurements"
+  def __init__(self, seriesNumber, compositeContext, dicomSourceFileList, timePoint, 
+               seriesDescription = "Measurements"):
+    self.SeriesDescription = str(seriesDescription)
     self.SeriesNumber = str(seriesNumber)
     self.InstanceNumber = "1"
 

--- a/util/measurementReportUtils/measurementReport.py
+++ b/util/measurementReportUtils/measurementReport.py
@@ -2,7 +2,7 @@ import json
 
 from .measurementGroup import MeasurementGroup
 from .measurementItem import MeasurementItem
-from .findings import GenericFindingStruct
+from .codeSequences import CodeSequence
 
 class MeasurementReport(object):
   """
@@ -12,7 +12,7 @@ class MeasurementReport(object):
   """
 
   def __init__(self, seriesNumber, compositeContext, dicomSourceFileList, timePoint, 
-               seriesDescription = "Measurements"):
+               seriesDescription = "Measurements", procedureReported = None):
     self.SeriesDescription = str(seriesDescription)
     self.SeriesNumber = str(seriesNumber)
     self.InstanceNumber = "1"
@@ -25,6 +25,9 @@ class MeasurementReport(object):
       "ObserverType": "PERSON",
       "PersonObserverName": "Reader01"
     }
+
+    if procedureReported:
+      self.procedureReported = procedureReported
 
     self.VerificationFlag = "VERIFIED"
     self.CompletionFlag = "COMPLETE"
@@ -65,7 +68,7 @@ class MeasurementReport(object):
       if (isinstance(obj, MeasurementReport) or 
           isinstance(obj, MeasurementGroup) or
           isinstance(obj, MeasurementItem) or
-          isinstance(obj, GenericFindingStruct)):
+          isinstance(obj, CodeSequence)):
         return obj.__dict__
       else:
         return super(MyEncoder, self).default(obj)

--- a/util/measurementReportUtils/measurementReport.py
+++ b/util/measurementReportUtils/measurementReport.py
@@ -1,0 +1,70 @@
+import json
+
+from .measurementGroup import MeasurementGroup
+from .measurementItem import MeasurementItem
+from .findings import GenericFindingStruct
+
+class MeasurementReport(object):
+  """
+  Data structure plus convenience methods to create measurment reports following
+  the required format to be processed by the DCMQI tid1500writer tool (using the
+  JSON export of this).
+  """
+
+  def __init__(self, seriesNumber, compositeContext, dicomSourceFileList, timePoint):
+    self.SeriesDescription = "Measurements"
+    self.SeriesNumber = str(seriesNumber)
+    self.InstanceNumber = "1"
+
+    self.compositeContext = [compositeContext]
+
+    self.imageLibrary = dicomSourceFileList
+
+    self.observerContext = {
+      "ObserverType": "PERSON",
+      "PersonObserverName": "Reader01"
+    }
+
+    self.VerificationFlag = "VERIFIED"
+    self.CompletionFlag = "COMPLETE"
+
+    self.activitySession = "1"
+    self.timePoint = str(timePoint)
+
+    self.Measurements = []
+
+
+  def addMeasurementGroup(self, measurementGroup):
+    self.Measurements.append(measurementGroup)
+
+  
+  def exportToJson(self, fileName):
+    with open(fileName, 'w') as fp:
+      json.dump(self._getAsDict(), fp, indent = 2)
+
+
+  def getJsonStr(self):
+    return json.dumps(self._getAsDict(), indent = 2)
+
+
+  def _getAsDict(self):
+    # This is a bit of a hack to get the "@schema" in there, didn't figure out how to 
+    # do this otherwise with json.dumps. If this wasn't needed I could just dump
+    # the json directly with my custom encoder.
+    jsonStr = json.dumps(self, indent = 2, cls = self._MyJSONEncoder)
+    tempDict = json.loads(jsonStr)
+    outDict = {}
+    outDict["@schema"] = "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/sr-tid1500-schema.json#"
+    outDict.update(tempDict)
+    return outDict
+
+  # Inner private class to define a custom JSON encoder for serializing MeasurmentReport
+  class _MyJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+      if (isinstance(obj, MeasurementReport) or 
+          isinstance(obj, MeasurementGroup) or
+          isinstance(obj, MeasurementItem) or
+          isinstance(obj, GenericFindingStruct)):
+        return obj.__dict__
+      else:
+        return super(MyEncoder, self).default(obj)


### PR DESCRIPTION
These are a few classes I used to be able to conveniently put together measurement reports from custom data storage in a python batch processing script. The classes allow export to JSON which then can directly be processed by the tid1500 writer.

Currently these classes are still quite specific to my task (converting Prostate MRI Test-Retest Data/Measurements to DICOM). However I think the basic idea is nice and can be easily extended to be much more generic. The classes are mainly data structures with the same layout as the respective parts of the JSON meta file, plus some convenience methods (e.g. exporting as JSON, adding sub-items).

To make it more generic my idea would be to extend e.g. the Findings and MeasurementItem classes by proper factories that create all the typical objects by a few keywords (and also give the user a generic fallback to set all members of an object manually for cases not covered yet). In general: create convenient prepared classes so a user only has to provide the essential data/info and not worry about which special codes to populate them with.

Building this in python would also allow double use of this util library: 
1. Users can write python scripts to convert their measurement data in batch processing
2. We can also build a web-app (like the one for segmentations) on top of this lib (I think Django would be an appropriate web framework  that uses python as backend)