### PR TITLE
BUG: Fix dockcross script creation container cleanup

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -28,9 +28,7 @@ image: dcmqi dcmqi.test
 # Pull dockcross image
 prereq.pull_dockcross:
 	$(DOCKER) pull dockcross/manylinux-x64
-	$(DOCKER) run dockcross/manylinux-x64 > $(TMP)/dockcross
-	# Ignore error because of https://circleci.com/docs/docker-btrfs-error/
-	$(DOCKER) rm -f dockcross/manylinux-x64 || true
+	$(DOCKER) run --rm dockcross/manylinux-x64 > $(TMP)/dockcross
 	chmod u+x $(TMP)/dockcross
 
 # Download and build dicom3tools


### PR DESCRIPTION
When the container is created, it does not have the name
'dockcross/manylinux-x64'. This is the name of the image as opposed to
the container. Docker gives a random, human-readable name
to a container if the `--name` flag is not provided.

Use the `--rm` flag so the container does not need to be removed.