### PR TITLE
clean up console output

### DIFF
--- a/include/dcmqi/ConverterBase.h
+++ b/include/dcmqi/ConverterBase.h
@@ -274,6 +274,7 @@ namespace dcmqi {
       vector<vector<int> > slice2derimg(numLabelSlices);
       vector<bool> slice2derimgPresent(numLabelSlices, false);
 
+      int slicesMapped = 0;
       for(size_t i=0;i<dcmDatasets.size();i++){
         OFString ippStr;
         ShortImageType::PointType ippPoint;
@@ -289,10 +290,11 @@ namespace dcmqi {
           continue;
         }
         slice2derimg[ippIndex[2]].push_back(i);
+        if(slice2derimgPresent[ippIndex[2]] == false)
+          slicesMapped++;
         slice2derimgPresent[ippIndex[2]] = true;
       }
-      cout << count_if(slice2derimgPresent.begin(), slice2derimgPresent.end(), [](bool f){return f;}) 
-         << " of " << slice2derimgPresent.size() << " slices mapped to source DICOM images" << endl;
+      cout << slicesMapped << " of " << slice2derimgPresent.size() << " slices mapped to source DICOM images" << endl;
       return slice2derimg;
     }
 

--- a/include/dcmqi/ConverterBase.h
+++ b/include/dcmqi/ConverterBase.h
@@ -2,6 +2,7 @@
 #define DCMQI_CONVERTERBASE_H
 
 // STD includes
+#include <algorithm>
 #include <iostream>
 #include <vector>
 
@@ -271,6 +272,8 @@ namespace dcmqi {
       // Assume that orientation of the segmentation is the same as the source series
       unsigned numLabelSlices = labelImage->GetLargestPossibleRegion().GetSize()[2];
       vector<vector<int> > slice2derimg(numLabelSlices);
+      vector<bool> slice2derimgPresent(numLabelSlices, false);
+
       for(size_t i=0;i<dcmDatasets.size();i++){
         OFString ippStr;
         ShortImageType::PointType ippPoint;
@@ -280,13 +283,16 @@ namespace dcmqi {
           ippPoint[j] = atof(ippStr.c_str());
         }
         if(!labelImage->TransformPhysicalPointToIndex(ippPoint, ippIndex)){
-          //cout << "image position: " << ippPoint << endl;
-          //cerr << "ippIndex: " << ippIndex << endl;
+          cout << "image position: " << ippPoint << endl;
+          cerr << "ippIndex: " << ippIndex << endl;
           // if certain DICOM instance does not map to a label slice, just skip it
           continue;
         }
         slice2derimg[ippIndex[2]].push_back(i);
+        slice2derimgPresent[ippIndex[2]] = true;
       }
+      cout << count_if(slice2derimgPresent.begin(), slice2derimgPresent.end(), [](bool f){return f;}) 
+         << " of " << slice2derimgPresent.size() << " slices mapped to source DICOM images" << endl;
       return slice2derimg;
     }
 

--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -11,7 +11,7 @@ namespace dcmqi {
                                                           bool skipEmptySlices) {
 
     ShortImageType::SizeType inputSize = segmentations[0]->GetBufferedRegion().GetSize();
-    cout << "Input image size: " << inputSize << endl;
+    //cout << "Input image size: " << inputSize << endl;
 
     JSONSegmentationMetaInformationHandler metaInfo(metaData.c_str());
     metaInfo.read();
@@ -56,7 +56,7 @@ namespace dcmqi {
     {
       ShortImageType::DirectionType labelDirMatrix = segmentations[0]->GetDirection();
 
-      cout << "Directions: " << labelDirMatrix << endl;
+      //cout << "Directions: " << labelDirMatrix << endl;
 
       FGPlaneOrientationPatient *planor =
           FGPlaneOrientationPatient::createMinimal(
@@ -129,7 +129,7 @@ namespace dcmqi {
 
     for(size_t segFileNumber=0; segFileNumber<segmentations.size(); segFileNumber++){
 
-      cout << "Processing input label " << segmentations[segFileNumber] << endl;
+      //cout << "Processing input label " << segmentations[segFileNumber] << endl;
 
       LabelToLabelMapFilterType::Pointer l2lm = LabelToLabelMapFilterType::New();
       l2lm->SetInput(segmentations[segFileNumber]);


### PR DESCRIPTION
- do not print out ITK image, directions, matrices - not helpful
- do print out how many segmentation slices were mapped to the source DICOM images

TODO:

- [x] revisit `count_if` -- the lambda function requires C++11