### PR TITLE
WIP: Add qualitative evaluations to TID 1500 converters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - run:
           name: build dcmqi
           command: cd docker && make dcmqi
+          no_output_timeout: 20m
       - run:
           name: test dcmqi
           command: cd docker && make dcmqi.test

--- a/apps/sr/Testing/CMakeLists.txt
+++ b/apps/sr/Testing/CMakeLists.txt
@@ -113,6 +113,15 @@ dcmqi_add_test(
     ${WRITER_MODULE_NAME}_ct-liver
   )
 
+dcmqi_add_test(
+  NAME ${READER_MODULE_NAME}_qualitative
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:${READER_MODULE_NAME}>
+    --inputDICOM ${MODULE_TEMP_DIR}/sr-tid1500-qualitative.dcm
+    --outputMetadata ${MODULE_TEMP_DIR}/sr-tid1500-qualitative.json
+  TEST_DEPENDS
+    ${WRITER_MODULE_NAME}_qualitative
+  )
 
 #-----------------------------------------------------------------------------
 set(MODULE_NAME tid1500)

--- a/apps/sr/Testing/CMakeLists.txt
+++ b/apps/sr/Testing/CMakeLists.txt
@@ -51,6 +51,16 @@ dcmqi_add_test(
     --outputDICOM ${MODULE_TEMP_DIR}/sr-tid1500-ct-liver-example.dcm
   )
 
+  dcmqi_add_test(
+    NAME ${WRITER_MODULE_NAME}_qualitative
+    MODULE_NAME ${MODULE_NAME}
+    COMMAND $<TARGET_FILE:${WRITER_MODULE_NAME}>
+      --inputMetadata ${EXAMPLES}/sr-tid1500-qualitative.json
+      --inputImageLibraryDirectory ${DICOM_DIR}
+      --inputCompositeContextDirectory ${CMAKE_SOURCE_DIR}/data/sr-example
+      --outputDICOM ${MODULE_TEMP_DIR}/sr-tid1500-qualitative.dcm
+    )
+
 find_program(DCIODVFY_EXECUTABLE dciodvfy)
 
 if(EXISTS ${DCIODVFY_EXECUTABLE})

--- a/apps/sr/tid1500writer.cxx
+++ b/apps/sr/tid1500writer.cxx
@@ -253,6 +253,19 @@ int main(int argc, char** argv){
       }
 
     }
+
+    if(measurementGroup.isMember("qualitativeEvaluations")){
+      for(Json::ArrayIndex k=0;k<measurementGroup["qualitativeEvaluations"].size();k++){
+        Json::Value evaluation = measurementGroup["qualitativeEvaluations"][k];
+        if(evaluation["conceptValue"].type() == Json::stringValue){
+          measurements.addQualitativeEvaluation(json2cev(evaluation["conceptCode"]),
+            evaluation["conceptValue"].asString().c_str());
+        } else {
+          measurements.addQualitativeEvaluation(json2cev(evaluation["conceptCode"]),
+            json2cev(evaluation["conceptValue"]));
+        }
+      }
+    }
   }
 
  if(!report.isValid()){
@@ -389,6 +402,7 @@ int main(int argc, char** argv){
   bool compositeContextInitialized = false;
   if(metaRoot.isMember("compositeContext")){
     for(Json::ArrayIndex i=0;i<metaRoot["compositeContext"].size();i++){
+      cout << "Adding to compositeContext: " << metaRoot["compositeContext"][i].asString() << endl;
       ccFileFormat = addFileToEvidence(doc,compositeContextDataDir,metaRoot["compositeContext"][i].asString());
       compositeContextInitialized = true;
     }

--- a/doc/examples/sr-tid1500-qualitative.json
+++ b/doc/examples/sr-tid1500-qualitative.json
@@ -1,0 +1,100 @@
+{
+  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/sr-tid1500-schema.json#",
+
+  "SeriesDescription": "Measurements",
+  "SeriesNumber": "1001",
+  "InstanceNumber": "1",
+
+  "compositeContext": [
+    "rwvm.dcm",
+    "seg.dcm"
+  ],
+
+  "imageLibrary": [
+    "01.dcm",
+    "02.dcm",
+    "03.dcm"
+  ],
+
+  "observerContext": {
+    "ObserverType": "PERSON",
+    "PersonObserverName": "Reader1"
+  },
+
+  "VerificationFlag": "VERIFIED",
+  "CompletionFlag": "COMPLETE",
+
+  "activitySession": "1",
+  "timePoint": "1",
+
+  "Measurements": [
+    {
+      "TrackingIdentifier": "Measurements group 1",
+      "ReferencedSegment": 1,
+      "SourceSeriesForImageSegmentation": "1.3.6.1.4.1.14519.5.2.1.2744.7002.261560220703676715130542397405",
+      "segmentationSOPInstanceUID": "1.2.276.0.7230010.3.1.4.8323329.18591.1440001312.777033",
+      "rwvmMapUsedForMeasurement": "1.2.276.0.7230010.3.1.4.8323329.18215.1440001297.928457",
+      "MeasurementMethod": {
+        "CodeValue": "126401",
+        "CodingSchemeDesignator": "DCM",
+        "CodeMeaning": "SUV body weight calculation method"
+      },
+      "Finding": {
+        "CodeValue": "M-80003",
+        "CodingSchemeDesignator": "SRT",
+        "CodeMeaning": "Neoplasm, Primary"
+      },
+      "FindingSite": {
+        "CodeValue": "T-00317",
+        "CodingSchemeDesignator": "SRT",
+        "CodeMeaning": "pharyngeal tonsil (adenoid)"
+      },
+      "measurementItems": [
+        {
+          "value": "1.96772",
+          "quantity": {
+            "CodeValue": "126401",
+            "CodingSchemeDesignator": "DCM",
+            "CodeMeaning": "SUVbw"
+          },
+          "units": {
+            "CodeValue": "{SUVbw}g/ml",
+            "CodingSchemeDesignator": "UCUM",
+            "CodeMeaning": "Standardized Uptake Value body weight"
+          },
+          "derivationModifier": {
+            "CodeValue": "R-00317",
+            "CodingSchemeDesignator": "SRT",
+            "CodeMeaning": "Mean"
+          },
+          "measurementAlgorithmIdentification": {
+            "AlgorithmName": "3D Slicer Editor effect",
+            "AlgorithmVersion": "4.6"
+          }
+        }
+      ],
+      "qualitativeEvaluations": [
+        {
+          "conceptCode": {
+            "CodeValue": "123",
+            "CodingSchemeDesignator": "99TEST",
+            "CodeMeaning": "Tremendousness"
+          },
+          "conceptValue": "Bad"
+        },
+        {
+          "conceptCode": {
+            "CodeValue": "123",
+            "CodingSchemeDesignator": "99TEST",
+            "CodeMeaning": "Tremendousness"
+          },
+          "conceptValue": {
+            "CodeValue": "124",
+            "CodingSchemeDesignator": "99TEST",
+            "CodeMeaning": "Absent"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/doc/schemas/sr-tid1500-schema.json
+++ b/doc/schemas/sr-tid1500-schema.json
@@ -108,6 +108,22 @@
 
       }
     },
+    "qualitativeEvaluationItem":{
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "conceptCode": {
+          "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"
+        },
+        "conceptValue": {
+          "oneOf": [
+            { "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence" },
+            { "type": "string" }
+          ]
+        }
+      }
+    },
+
     "MeasurementGroup": {
       "type": "object",
       "additionalProperties": false,
@@ -144,6 +160,12 @@
           "minItems": 1,
           "items": {
             "$ref": "#/definitions/measurementItem"
+          }
+        },
+        "qualitativeEvaluations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/qualitativeEvaluationItem"
           }
         }
       }


### PR DESCRIPTION
Aims to address #352.

- [x] updated schema to support metadata JSON organization
- [x] add support to tid1500writer
- [x] add support to tid1500reader

Unresolved issue that needs to be discussed is summarized below in an email sent to @dclunie today:

>Today I was working on adding support for qualitative evaluations to dcmqi, and it occurred to me that it would 1) be more consistent and 2) simplify implementation, if the qualitative assessment items (rows 16 and 17) in TID 1411 [1] were nested within a container with the heading (C0034375, UMLS, "Qualitative Evaluations"), as it is done in TID 1500 row 12 [2].
>
> As is right now, I think it is confusing since there are other CODE items in 1411 (e.g., "Finding"), and the order of items is non-significant. So I guess to parse the document, one would need to look for all CODEs that do not have concepts that otherwise can appear in the document per template structure. And then I guess there is no guarantee that someone would not report something about concept "Finding" as a Qualitative Evaluation. Needless to say, maintenance of the parser becomes a lot more complicated.
>
> I do not see a reason why it should be this way, instead of unambiguously including a container with qualitative evaluations. Unless I miss some other parsing strategy that would take care of this issue.
>
> The same issue is applicable to 1500 and 1410, both of which are also inconsistent with 1500.
> 
> [1] http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1411
> [2] http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#table_TID_1500

@jriesmeier FYI