### PR TITLE
circleci/publish_github_release: do not fail if there no token available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,4 +38,5 @@ jobs:
             ci_addons publish_github_release qiicr/dcmqi \
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages-clear-pattern "dcmqi-*-linux-*" \
-            --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*"
+            --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
+            --exit-success-if-missing-token


### PR DESCRIPTION
Since GITHUB_TOKEN is usually not available when building PR, this commit
prevents failure.

See https://github.com/QIICR/dcmqi/pull/351#issuecomment-415489912