### PR TITLE
ENH: add support for finding site laterality

### DIFF
--- a/apps/sr/tid1500writer.cxx
+++ b/apps/sr/tid1500writer.cxx
@@ -195,8 +195,14 @@ int main(int argc, char** argv){
     CHECK_COND(measurements.setReferencedSegment(segment));
 
     CHECK_COND(measurements.setFinding(json2cev(measurementGroup["Finding"])));
-    if(measurementGroup.isMember("FindingSite"))
-      CHECK_COND(measurements.addFindingSite(json2cev(measurementGroup["FindingSite"])));
+    if(measurementGroup.isMember("FindingSite")){
+      if(measurementGroup.isMember("Laterality")){
+        CHECK_COND(measurements.addFindingSite(json2cev(measurementGroup["FindingSite"]),
+                                               json2cev(measurementGroup["Laterality"])));
+      } else {
+        CHECK_COND(measurements.addFindingSite(json2cev(measurementGroup["FindingSite"])));
+      }
+    }
 
     if(measurementGroup.isMember("MeasurementMethod"))
       CHECK_COND(measurements.setMeasurementMethod(json2cev(measurementGroup["MeasurementMethod"])));

--- a/doc/examples/sr-tid1500-example.json
+++ b/doc/examples/sr-tid1500-example.json
@@ -49,6 +49,11 @@
         "CodingSchemeDesignator": "SRT",
         "CodeMeaning": "pharyngeal tonsil (adenoid)"
       },
+      "Laterality": {
+        "CodeValue": "G-A101",
+        "CodingSchemeDesignator": "SRT",
+        "CodeMeaning": "Left"
+      },
       "measurementItems": [
         {
           "value": "1.96",

--- a/doc/schemas/sr-tid1500-schema.json
+++ b/doc/schemas/sr-tid1500-schema.json
@@ -155,6 +155,9 @@
         "FindingSite": {
           "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"
         },
+        "Laterality": {
+          "$ref": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/common-schema.json#/definitions/codeSequence"
+        },
         "measurementItems": {
           "type": "array",
           "minItems": 1,

--- a/libsrc/TID1500Reader.cpp
+++ b/libsrc/TID1500Reader.cpp
@@ -78,6 +78,15 @@ Json::Value TID1500Reader::getMeasurements() {
           // iterate over all direct child nodes
           do {
             const DSRDocumentTreeNode *node = cursor.getNode();
+
+            if(node->getConceptName() == CODE_SRT_FindingSite){
+              // check if Laterality is present
+              DSRDocumentTreeNodeCursor tempCursor(cursor);
+              Json::Value laterality = getContentItem(CODE_SRT_Laterality, tempCursor);
+              if(laterality!=Json::nullValue)
+                measurementGroup["Laterality"] = laterality;
+            }
+
             /* and check for numeric measurement value content items */
             if ((node != NULL) && (node->getValueType() == VT_Num)) {
               //COUT << "  #" << (++counter) << " ";
@@ -126,7 +135,7 @@ Json::Value TID1500Reader::getContentItem(const DSRCodedEntryValue &conceptName,
   if (gotoNamedChildNode(conceptName, cursor)) {
     const DSRDocumentTreeNode *node = cursor.getNode();
     if (node != NULL) {
-      //COUT << "- " << conceptName.getCodeMeaning() << ": ";
+      //COUT << "  - " << conceptName.getCodeMeaning() << ": ";
       // use appropriate value for output
       switch (node->getValueType()) {
         case VT_Text:


### PR DESCRIPTION
Note Laterality is located at the same level as Finding Site in
the input JSON, not subordinate to Finding Site.

Fixes #358