### PR TITLE
ENH: add support for describing device observer context

### DIFF
--- a/apps/sr/tid1500reader.cxx
+++ b/apps/sr/tid1500reader.cxx
@@ -96,13 +96,6 @@ int main(int argc, char** argv){
   doc.getInstanceNumber(temp);
   metaRoot["InstanceNumber"] = temp.c_str();
 
-  OFString observerName, observingDateTime, organizationName;
-  if (doc.hasVerifyingObservers()) {
-    doc.getVerifyingObserver(1, observingDateTime, observerName, organizationName);
-    metaRoot["observerContext"]["ObserverType"] = "PERSON";
-    metaRoot["observerContext"]["PersonObserverName"] = observerName.c_str();
-  }
-
   metaRoot["VerificationFlag"] = DSRTypes::verificationFlagToEnumeratedValue(doc.getVerificationFlag());
   metaRoot["CompletionFlag"] = DSRTypes::completionFlagToEnumeratedValue(doc.getCompletionFlag());
 

--- a/apps/sr/tid1500reader.cxx
+++ b/apps/sr/tid1500reader.cxx
@@ -78,6 +78,9 @@ int main(int argc, char** argv){
       metaRoot["procedureReported"] = procedureCode;
     }
 
+    Json::Value observerContext = reader.getObserverContext();
+    metaRoot["observerContext"] = observerContext;
+
     //DSRDocumentTreeNodeCursor rootCursor;
     //if(doc.getTree().getCursorToRootNode(rootCursor) == 1)
     //  std::cout << "Have root node: " << rootCursor.getNode()->getNodeID() << std::endl;

--- a/doc/examples/sr-tid1500-ct-liver-example.json
+++ b/doc/examples/sr-tid1500-ct-liver-example.json
@@ -16,8 +16,10 @@
   ],
 
   "observerContext": {
-    "ObserverType": "PERSON",
-    "PersonObserverName": "Reader1"
+    "ObserverType": "DEVICE",
+    "DeviceObserverName": "SecretSauceGenerator",
+    "DeviceObserverManufacturer": "The friends of friends",
+    "DeviceObserverUID": "1.2.3.4"
   },
 
   "VerificationFlag": "VERIFIED",

--- a/doc/examples/sr-tid1500-ct-liver-example.json
+++ b/doc/examples/sr-tid1500-ct-liver-example.json
@@ -22,7 +22,7 @@
     "DeviceObserverUID": "1.2.3.4"
   },
 
-  "VerificationFlag": "VERIFIED",
+  "VerificationFlag": "UNVERIFIED",
   "CompletionFlag": "COMPLETE",
 
   "activitySession": "1",

--- a/doc/schemas/sr-common-schema.json
+++ b/doc/schemas/sr-common-schema.json
@@ -50,10 +50,21 @@
               "enum": [
                 "DEVICE"
               ]
+            },
+            "DeviceObserverName": {
+              "$ref": "#/definitions/TEXT"
+            },
+            "DeviceObserverManufacturer": {
+              "$ref": "#/definitions/TEXT"
+            },
+            "DeviceObserverModelName": {
+              "$ref": "#/definitions/TEXT"
+            },
+            "DeviceObserverSerialNumber": {
+              "$ref": "#/definitions/TEXT"
             }
           },
           "required": [
-            "DeviceObserverUID",
             "ObserverType"
           ]
         }

--- a/include/dcmqi/TID1500Reader.h
+++ b/include/dcmqi/TID1500Reader.h
@@ -31,6 +31,7 @@ class TID1500Reader
     TID1500Reader(const DSRDocumentTree &tree);
 
     Json::Value getProcedureReported();
+    Json::Value getObserverContext();
     Json::Value getMeasurements();
     Json::Value getSingleMeasurement(const DSRNumTreeNode &numNode,
                                      DSRDocumentTreeNodeCursor cursor);


### PR DESCRIPTION
This functionality was needed in particular to be able to better describe software version in https://github.com/Radiomics/pyradiomics/pull/437.