### PR TITLE
ENH: always initialize TrackingUID

### DIFF
--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -241,6 +241,11 @@ namespace dcmqi {
 
         if(segmentAttributes->getTrackingUniqueIdentifier().length() > 0)
           segment->setTrackingUID(segmentAttributes->getTrackingUniqueIdentifier().c_str());
+        else {
+          char dimUID[128];
+          dcmGenerateUniqueIdentifier(dimUID, QIICR_UID_ROOT);
+          segment->setTrackingUID(dimUID);
+        }
 
         CodeSequenceMacro* typeModifierCode = segmentAttributes->getSegmentedPropertyTypeModifierCodeSequence();
         if (typeModifierCode != NULL) {


### PR DESCRIPTION
If not provided by the user, initialize it. This can't hurt, but will come handy if measurements are done later using this segmentation.