### PR TITLE
ci: Fix installation of python packages in deploy-* jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,10 @@ jobs:
           at: ./
       - run:
           name: install sckit-ci-addons
-          command: pip install -U "scikit-ci-addons>=0.22.0"
+          command: |
+            python -m venv ../venv
+            . ../venv/bin/activate
+            pip install -U "scikit-ci-addons>=0.22.0"
       - run:
           name: publish binary package on GitHub
           command: |
@@ -74,7 +77,10 @@ jobs:
           at: ./
       - run:
           name: install sckit-ci-addons
-          command: pip install -U "scikit-ci-addons>=0.22.0"
+          command: |
+            python -m venv ../venv
+            . ../venv/bin/activate
+            pip install -U "scikit-ci-addons>=0.22.0"
       - run:
           name: publish binary package on GitHub
           command: |


### PR DESCRIPTION
This commit fixes a regression introduced in 529dccd5 (circleci: Use
workflow to separately upload latest and tagged releases). It creates
a virtual environment to avoid error like the following:

  Could not install packages due to an EnvironmentError: [Errno 13] Permission denied: '/usr/local/lib/python3.7/site-packages/lxml'