### PR TITLE
ci: Add missing checkout comment to CircleCI deploy-* jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
     docker:
       - image: circleci/python:3.7.0-stretch
     steps:
+      - checkout
       - attach_workspace:
           at: ./
       - run:
@@ -74,6 +75,7 @@ jobs:
     docker:
       - image: circleci/python:3.7.0-stretch
     steps:
+      - checkout
       - attach_workspace:
           at: ./
       - run:


### PR DESCRIPTION
This commit fixes the following error:

  RuntimeError: Current directory is expected to be inside a git working tree: /home/circleci/project