### PR TITLE
ENH: compare to epsilon instead of zero

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ before_build:
   # Downloads
   - ps: |
         $client = new-object System.Net.WebClient;
-        $client.DownloadFile("http://slicer.kitware.com/midas3/download/item/270309/dicom3tools_winexe_1.00.snapshot.20161218101718.zip",          "C:\dicom3tools.zip")
+        $client.DownloadFile("https://github.com/QIICR/dicom3tools/releases/download/20200512090031/dicom3tools_winexe_1.00.snapshot.20200512090031.zip", "C:\dicom3tools.zip")
         $client.DownloadFile("https://github.com/qiicr/zlib-dcmqi/releases/download/zlib-dcmqi-1.2.3-VS12-Win64-Release-static/zlib-dcmqi.zip", "C:\zlib-dcmqi.zip")
         $client.DownloadFile("https://github.com/QIICR/dcmtk-dcmqi/releases/download/DCMTK-dcmqi-3.6.5_20200113-VS12-Win64-Release-v0.0.28-static/DCMTK-dcmqi.zip", "C:\DCMTK-dcmqi.zip")
         $client.DownloadFile("https://github.com/QIICR/ITK-dcmqi/releases/download/ITK-dcmqi-VS12-Win64-Release-v0.0.30-static/ITK-dcmqi.zip", "C:\ITK-dcmqi.zip")

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -17,7 +17,7 @@ TMP = /tmp
 # Shell
 SHELL = /bin/bash
 
-dicom3tools_version=dicom3tools_1.00.snapshot.20160721064406
+dicom3tools_version=dicom3tools_1.00.snapshot.20200512090031
 
 #
 # Targets
@@ -36,8 +36,8 @@ prereq.build_dicom3tools: prereq.pull_dockcross
 	mkdir -p $(ROOT_DIR)/$(BUILD_DIR)
 	cd $(ROOT_DIR)/$(BUILD_DIR) \
 	&& [ ! -e $(dicom3tools_version) ] \
-	&& wget --no-check-certificate http://slicer.kitware.com/midas3/download/item/270310/dicom3tools_1.00.snapshot.20160721064406.tar.bz2 -O dicom3tools.tar.bz2 \
-	&& tar xjf dicom3tools.tar.bz2 \
+	&& wget --no-check-certificate  https://github.com/QIICR/dicom3tools/releases/download/20200512090031/dicom3tools_winexe_1.00.snapshot.20200512090031.zip -O dicom3tools.zip \
+	&& tar xjf dicom3tools.zip \
 	&& cd $(dicom3tools_version)/ \
 	&& $(TMP)/dockcross ./Configure \
 	&& $(TMP)/dockcross imake -I./config -DUseQIICRID \

--- a/include/dcmqi/ConverterBase.h
+++ b/include/dcmqi/ConverterBase.h
@@ -254,9 +254,10 @@ namespace dcmqi {
       pixelMeasures->getPixelSpacing(spacing[1], 1);
 
       Float64 spacingFloat;
-      if(pixelMeasures->getSpacingBetweenSlices(spacingFloat,0).good() && spacingFloat != 0){
+      float epsilon = 1.e-5;
+      if(pixelMeasures->getSpacingBetweenSlices(spacingFloat,0).good() && fabs(spacingFloat) > epsilon){
         spacing[2] = spacingFloat;
-      } else if(pixelMeasures->getSliceThickness(spacingFloat,0).good() && spacingFloat != 0){
+      } else if(pixelMeasures->getSliceThickness(spacingFloat,0).good() && fabs(spacingFloat) > epsilon){
         // SliceThickness can be carried forward from the source images, and may not be what we need
         // As an example, this ePAD example has 1.25 carried from CT, but true computed thickness is 1!
         cerr << "WARNING: SliceThickness is present and is " << spacingFloat << ". using it!" << endl;
@@ -301,6 +302,5 @@ namespace dcmqi {
   };
 
 }
-
 
 #endif //DCMQI_CONVERTERBASE_H


### PR DESCRIPTION
Based on the observed very tiny invalid values for SpacingBetweenSlices
in the SEGs generated by TeraRecon.