### PR TITLE
ENH: Added detailed logging option to itkimage2segimage and segimage2itkimage

### DIFF
--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -6,6 +6,9 @@
 #include "dcmqi/ImageSEGConverter.h"
 #include "dcmqi/internal/VersionConfigure.h"
 
+// DCMTK includes
+#include <dcmtk/oflog/configrt.h>
+
 typedef dcmqi::Helper helper;
 
 int main(int argc, char *argv[])
@@ -33,6 +36,13 @@ int main(int argc, char *argv[])
     reader->Update();
     ShortImageType::Pointer labelImage = reader->GetOutput();
     segmentations.push_back(labelImage);
+  }
+
+  if (verbose) {
+    // Display DCMTK debug, warning, and error logs in the console
+    // For some reason, this code has no effect if it is called too early (e.g., directly after PARSE_ARGS)
+    // therefore we call it here.
+    dcmtk::log4cplus::BasicConfigurator::doConfigure();
   }
 
   if(dicomDirectory.size()){
@@ -126,5 +136,6 @@ int main(int argc, char *argv[])
     return EXIT_SUCCESS;
   } catch (int e) {
     std::cerr << "Fatal error encountered." << std::endl;
+    return EXIT_FAILURE;
   }
 }

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -61,7 +61,16 @@
       <channel>input</channel>
       <longflag>skip</longflag>
       <default>true</default>
-      <description>Skip empty slices while encoding segmentation image. By default, empty slices will not be encoded, resulting in a smaller output file size.</description>-->
+      <description>Skip empty slices while encoding segmentation image. By default, empty slices will not be encoded, resulting in a smaller output file size.</description>
+    </boolean>
+
+    <boolean>
+      <name>verbose</name>
+      <label>Verbose</label>
+      <channel>input</channel>
+      <longflag>verbose</longflag>
+      <default>false</default>
+      <description>Display more verbose output, useful for troubleshooting.</description>
     </boolean>
 
     <!--<boolean>-->

--- a/apps/seg/segimage2itkimage.cxx
+++ b/apps/seg/segimage2itkimage.cxx
@@ -6,6 +6,8 @@
 #include "dcmqi/ImageSEGConverter.h"
 #include "dcmqi/internal/VersionConfigure.h"
 
+// DCMTK includes
+#include <dcmtk/oflog/configrt.h>
 
 typedef dcmqi::Helper helper;
 
@@ -15,6 +17,11 @@ int main(int argc, char *argv[])
   std::cout << dcmqi_INFO << std::endl;
 
   PARSE_ARGS;
+
+  if (verbose) {
+    // Display DCMTK debug, warning, and error logs in the console
+    dcmtk::log4cplus::BasicConfigurator::doConfigure();
+  }
 
   if(helper::isUndefinedOrPathDoesNotExist(inputSEGFileName, "Input DICOM file")
      || helper::isUndefinedOrPathDoesNotExist(outputDirName, "Output directory"))

--- a/apps/seg/segimage2itkimage.xml
+++ b/apps/seg/segimage2itkimage.xml
@@ -57,6 +57,15 @@
       <element>img</element>
     </string-enumeration>
 
+    <boolean>
+      <name>verbose</name>
+      <label>Verbose</label>
+      <channel>input</channel>
+      <longflag>verbose</longflag>
+      <default>false</default>
+      <description>Display more verbose output, useful for troubleshooting.</description>
+    </boolean>
+
   </parameters>
 
 </executable>

--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -421,8 +421,13 @@ namespace dcmqi {
       CHECK_COND(segdoc->getFrameOfReference().setFrameOfReferenceUID(frameOfRefUIDchar));
     }
 
-    if(segdoc->writeDataset(segdocDataset).bad()){
-      cerr << "FATAL ERROR: Writing of the SEG dataset failed! Please report the problem to the developers, ideally accompanied by a de-identified dataset allowing to reproduce the problem!" << endl;
+    OFCondition writeResult = segdoc->writeDataset(segdocDataset);
+    if(writeResult.bad()){
+      cerr << "FATAL ERROR: Writing of the SEG dataset failed!";
+      if (writeResult.text()){
+        cerr << " Error: " << writeResult.text() << ".";
+      }
+      cerr << " Please report the problem to the developers, ideally accompanied by a de-identified dataset allowing to reproduce the problem!" << endl;
       return NULL;
     }
 


### PR DESCRIPTION
I had really hard time figuring out why segmentation export fails, and it turned out that the in the input DICOM images ProcedureCodeSequence was defined but did not contain any items, and because of this DCMTK refused to create the segmentation object. It took several hours of debugging to investigate this issue.

Along the way, I realized that DCMTK provides pretty detailed logging of all relevant details, but this logging is not enabled. To prevent such tedious investigations in the future, I added a --verbose command-line switch to segmentation converters, which enable printing of detailed information. It prints debug-level messages, which can be quite detailed, so by default the switch is disabled.