### PR TITLE
BUG: serialize floats with maximum precision

### DIFF
--- a/Design/DICOMSegmentationConverter.puml
+++ b/Design/DICOMSegmentationConverter.puml
@@ -45,7 +45,7 @@ package dcmqi {
 class Helper {
     + {static} tokenizeString(string str, vector<string> &tokens, string delimiter): void
     + {static} splitString(string str, string &head, string &tail, string delimiter): void
-    + {static} floatToStrScientific(float f): string
+    + {static} floatToStr(float f): string
 ---
     + {static} stringToCodeSequenceMacro(std::string str): CodeSequenceMacro
     + {static} stringToDSRCodedEntryValue(std::string str): DSRCodedEntryValue

--- a/include/dcmqi/Helper.h
+++ b/include/dcmqi/Helper.h
@@ -13,6 +13,8 @@
 #include <vector>
 #include <map>
 #include <algorithm>
+#include <limits>
+#include <locale>
 
 // DCMQI includes
 #include "dcmqi/Exceptions.h"
@@ -45,7 +47,7 @@ namespace dcmqi {
     static vector<string> getFileListRecursively(string directory);
     static vector<DcmDataset*> loadDatasets(const vector<string>& dicomImageFiles);
 
-    static string floatToStrScientific(float f);
+    static string floatToStr(float f);
     static void tokenizeString(string str, vector<string> &tokens, string delimiter);
     static void splitString(string str, string &head, string &tail, string delimiter);
 

--- a/libsrc/Helper.cpp
+++ b/libsrc/Helper.cpp
@@ -105,8 +105,10 @@ namespace dcmqi {
   string Helper::floatToStr(float f) {
     ostringstream sstream;
     sstream.imbue(std::locale::classic());
-    sstream.precision(std::numeric_limits<float>::max_digits10);
+    sstream.precision(9);
     sstream << f;
+    string f_str = sstream.str();
+    cout << "Formatted float (length): " << f_str << "(" << f_str.size() << ")" << endl;
     return sstream.str();
   }
 

--- a/libsrc/Helper.cpp
+++ b/libsrc/Helper.cpp
@@ -102,9 +102,11 @@ namespace dcmqi {
   }
 
 
-  string Helper::floatToStrScientific(float f) {
+  string Helper::floatToStr(float f) {
     ostringstream sstream;
-    sstream << scientific << f;
+    sstream.imbue(std::locale::classic());
+    sstream.precision(std::numeric_limits<float>::max_digits10);
+    sstream << f;
     return sstream.str();
   }
 

--- a/libsrc/Helper.cpp
+++ b/libsrc/Helper.cpp
@@ -107,8 +107,8 @@ namespace dcmqi {
     sstream.imbue(std::locale::classic());
     sstream.precision(9);
     sstream << f;
-    string f_str = sstream.str();
-    cout << "Formatted float (length): " << f_str << "(" << f_str.size() << ")" << endl;
+    //string f_str = sstream.str();
+    //cout << "Formatted float (length): " << f_str << "(" << f_str.size() << ")" << endl;
     return sstream.str();
   }
 

--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -66,12 +66,12 @@ namespace dcmqi {
 
       FGPlaneOrientationPatient *planor =
           FGPlaneOrientationPatient::createMinimal(
-              Helper::floatToStrScientific(labelDirMatrix[0][0]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[1][0]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[2][0]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[0][1]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[1][1]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[2][1]).c_str());
+              Helper::floatToStr(labelDirMatrix[0][0]).c_str(),
+              Helper::floatToStr(labelDirMatrix[1][0]).c_str(),
+              Helper::floatToStr(labelDirMatrix[2][0]).c_str(),
+              Helper::floatToStr(labelDirMatrix[0][1]).c_str(),
+              Helper::floatToStr(labelDirMatrix[1][1]).c_str(),
+              Helper::floatToStr(labelDirMatrix[2][1]).c_str());
 
       CHECK_COND(segdoc->addForAllFrames(*planor));
     }
@@ -311,9 +311,9 @@ namespace dcmqi {
               segmentations[segFileNumber]->TransformIndexToPhysicalPoint(prevIndex, prevOrigin);
             }
             fgppp->setImagePositionPatient(
-                Helper::floatToStrScientific(sliceOriginPoint[0]).c_str(),
-                Helper::floatToStrScientific(sliceOriginPoint[1]).c_str(),
-                Helper::floatToStrScientific(sliceOriginPoint[2]).c_str());
+                Helper::floatToStr(sliceOriginPoint[0]).c_str(),
+                Helper::floatToStr(sliceOriginPoint[1]).c_str(),
+                Helper::floatToStr(sliceOriginPoint[2]).c_str());
           }
 
           /* Add frame that references this segment */

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -99,12 +99,12 @@ namespace dcmqi {
 
       FGPlaneOrientationPatient *planor =
           FGPlaneOrientationPatient::createMinimal(
-              Helper::floatToStrScientific(labelDirMatrix[0][0]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[1][0]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[2][0]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[0][1]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[1][1]).c_str(),
-              Helper::floatToStrScientific(labelDirMatrix[2][1]).c_str());
+              Helper::floatToStr(labelDirMatrix[0][0]).c_str(),
+              Helper::floatToStr(labelDirMatrix[1][0]).c_str(),
+              Helper::floatToStr(labelDirMatrix[2][0]).c_str(),
+              Helper::floatToStr(labelDirMatrix[0][1]).c_str(),
+              Helper::floatToStr(labelDirMatrix[1][1]).c_str(),
+              Helper::floatToStr(labelDirMatrix[2][1]).c_str());
 
       //CHECK_COND(planor->setImageOrientationPatient(imageOrientationPatientStr));
       CHECK_COND(pMapDoc->addForAllFrames(*planor));
@@ -174,7 +174,7 @@ namespace dcmqi {
     // initialize optional items, if available
     if(metaInfo.metaInfoRoot.isMember("MeasurementMethodCode")){
       ContentItemMacro* measureMethod = new ContentItemMacro;
-	  
+
       CodeSequenceMacro* qCodeName = new CodeSequenceMacro("370129005", "SCT", "Measurement Method");
       CodeSequenceMacro* qSpec = new CodeSequenceMacro(
         metaInfo.metaInfoRoot["MeasurementMethodCode"]["CodeValue"].asCString(),
@@ -383,9 +383,9 @@ namespace dcmqi {
         FloatImageType::PointType sliceOriginPoint;
         parametricMapImage->TransformIndexToPhysicalPoint(sliceIndex, sliceOriginPoint);
         fgppp->setImagePositionPatient(
-            Helper::floatToStrScientific(sliceOriginPoint[0]).c_str(),
-            Helper::floatToStrScientific(sliceOriginPoint[1]).c_str(),
-            Helper::floatToStrScientific(sliceOriginPoint[2]).c_str());
+            Helper::floatToStr(sliceOriginPoint[0]).c_str(),
+            Helper::floatToStr(sliceOriginPoint[1]).c_str(),
+            Helper::floatToStr(sliceOriginPoint[2]).c_str());
 
         // Frame Content
         OFCondition result = fgfc->setDimensionIndexValues(sliceNumber+1 /* value within dimension */, 0 /* first dimension */);
@@ -606,9 +606,9 @@ namespace dcmqi {
     FloatImageType::PointType sliceOriginPoint;
     parametricMapImage->TransformIndexToPhysicalPoint(sliceIndex, sliceOriginPoint);
     fgPlanePos->setImagePositionPatient(
-        Helper::floatToStrScientific(sliceOriginPoint[0]).c_str(),
-        Helper::floatToStrScientific(sliceOriginPoint[1]).c_str(),
-        Helper::floatToStrScientific(sliceOriginPoint[2]).c_str());
+        Helper::floatToStr(sliceOriginPoint[0]).c_str(),
+        Helper::floatToStr(sliceOriginPoint[1]).c_str(),
+        Helper::floatToStr(sliceOriginPoint[2]).c_str());
 
     // Frame Content
     OFCondition result = fgFracon->setDimensionIndexValues(frameNo+1 /* value within dimension */, 0 /* first dimension */);


### PR DESCRIPTION
API-breaking change: Helper::floatToStrScientific() was renamed to
Helper::floatToStr().

Signed-off-by: Stefan Dinkelacker <s.dinkelacker@dkfz-heidelberg.de>