### PR TITLE
BUG: Ensure binaries bundled into dcmqi docker image can run

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -87,7 +87,17 @@ dcmqi.docker_image:
 		--build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 	dcmqi
 
-dcmqi: prereq.build_dicom3tools prereq.install_npm_packages dcmqi.generate_package dcmqi.docker_image
+dcmqi.docker_image_test:
+	$(info $$DOCKER_DIR ${DOCKER_DIR})
+	cd $(DOCKER_DIR) && \
+	docker run --rm $(ORG)/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` itkimage2paramap --help
+	docker run --rm $(ORG)/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` paramap2itkimage --help
+	docker run --rm $(ORG)/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` itkimage2segimage --help
+	docker run --rm $(ORG)/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` segimage2itkimage --help
+	docker run --rm $(ORG)/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` tid1500reader --help
+	docker run --rm $(ORG)/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` tid1500writer --help
+
+dcmqi: prereq.build_dicom3tools prereq.install_npm_packages dcmqi.generate_package dcmqi.docker_image dcmqi.docker_image_test
 
 dcmqi.test:
 	cd $(ROOT_DIR) && \

--- a/docker/dcmqi/Dockerfile
+++ b/docker/dcmqi/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:5
+FROM centos:7
 MAINTAINER http://github.com/QIICR
 
 COPY imagefiles/docker_entry.sh /dcmqi/


### PR DESCRIPTION
This commit is a follow-up of eca78a5c5 (replace deprecated dockcross image) updating the build environment from `dockcross/manylinux-x64` to `dockcross/manylinux2014-x64`.

Since `dockcross/manylinux2014-x64` is based on Centos 7, this commit also updates the base distribution associated with the dcmqi docker image to be consistent.

See https://github.com/pypa/manylinux#manylinux2014-centos-7-based