### PR TITLE
Fix Windows Release publishing.

### DIFF
--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -67,10 +67,10 @@ jobs:
       - name: Publish package
         run: |
           pip install -U "scikit-ci-addons>=0.22.0"
-          ci_addons publish_github_release qiicr/dcmqi 
-           --exit-success-if-missing-token 
-           --release-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64.zip" 
-           --prerelease-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64-*.zip" 
-           --prerelease-packages-clear-pattern "dcmqi-*-win64-*" 
-           --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*"
-           --token ${{ secrets.GA_TOKEN }}
+          ci_addons publish_github_release qiicr/dcmqi `
+          --exit-success-if-missing-token `
+          --release-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64.zip" `
+          --prerelease-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64-*.zip" `
+          --prerelease-packages-clear-pattern "dcmqi-*-win64-*" `
+          --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" `
+          --token ${{ secrets.GA_TOKEN }}


### PR DESCRIPTION
Use powershell multi-line command separators (backticks) for long command line call.