### PR TITLE
ENH: Don't check functional groups (speedup)

### DIFF
--- a/libsrc/ImageSEGConverter.cpp
+++ b/libsrc/ImageSEGConverter.cpp
@@ -421,6 +421,10 @@ namespace dcmqi {
       CHECK_COND(segdoc->getFrameOfReference().setFrameOfReferenceUID(frameOfRefUIDchar));
     }
 
+    // Don't check functional groups since its very time consuming and we trust
+    // ourselves to put together valid datasets
+    segdoc->setCheckFGOnWrite(OFFalse);
+
     OFCondition writeResult = segdoc->writeDataset(segdocDataset);
     if(writeResult.bad()){
       cerr << "FATAL ERROR: Writing of the SEG dataset failed!";
@@ -482,7 +486,7 @@ namespace dcmqi {
 
   pair <map<unsigned,ShortImageType::Pointer>, string> ImageSEGConverter::dcmSegmentation2itkimage(DcmDataset *segDataset) {
     DcmSegmentation *segdoc = NULL;
-    
+
     DcmRLEDecoderRegistration::registerCodecs();
 
     OFCondition cond = DcmSegmentation::loadDataset(*segDataset, segdoc);

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -445,6 +445,10 @@ namespace dcmqi {
     pMapDoc->getSeries().setSeriesNumber(metaInfo.getSeriesNumber().c_str());
 
     DcmDataset* output = new DcmDataset();
+
+    // Don't check functional groups since its very time consuming and we trust
+    // ourselves to put together valid datasets
+    pMapDoc->getFunctionalGroups().setCheckOnWrite(OFFalse);
     CHECK_COND(pMapDoc->writeDataset(*output));
     return output;
   }


### PR DESCRIPTION
Speedup writing of DICOM segmentation and parametric map objects by disabling functional group checking when writing.