### PR TITLE
Only publish on master and on qiicr/dcmqi repo.

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -38,16 +38,24 @@ jobs:
         cd docker && make dcmqi.test
 
     - name: "Publish docker image"
+      # Only run if the event is not a pull request and the repository owner is QIICR.
+      # The latter is to prevent forks from publishing packages even if the owner's token
+      # would have sufficient privileges.
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
          docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
          docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
          || echo "skipping docker push"
 
     - name: "Publish linux package"
+      # Only run if the event is not a pull request and the repository owner is QIICR.
+      # The latter is to prevent forks from publishing packages even if the owner's token
+      # would have sufficient privileges.
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
          pip install -U "scikit-ci-addons>=0.22.0"
-         # python -m scikit-ci publish --package-name dcmqi --package-version `git 
-         # describe --tags --exact-match 2> /dev/null || echo "latest"` --platform linux 
+         # python -m scikit-ci publish --package-name dcmqi --package-version `git
+         # describe --tags --exact-match 2> /dev/null || echo "latest"` --platform linux
          # --commit-range ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --repository ${{ github.event.pull_request.head.repo.full_name }} --token ${{ secrets.GITHUB_TOKEN }} --verbose
          ci_addons publish_github_release QIICR/dcmqi \
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -92,11 +92,19 @@ jobs:
 
     # ...and finally package it.
     - name: "Package dcmqi"
+      # Only run if the event is not a pull request and the repository owner is QIICR.
+      # The latter is to prevent forks from publishing packages even if the owner's token
+      # would have sufficient privileges.
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         cd ${{ github.workspace }}/dcmqi-build/dcmqi-build && ninja package
 
 
     - name: Publish package
+      # Only run if the event is not a pull request and the repository owner is QIICR.
+      # The latter is to prevent forks from publishing packages even if the owner's token
+      # would have sufficient privileges.
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         pip install -U "scikit-ci-addons>=0.22.0"
         ci_addons publish_github_release qiicr/dcmqi 


### PR DESCRIPTION
As already implemented for Windows, only publish packages, if dcmqi
build is not triggered by pull request (only) and also if build
happens on the qiicr/dcmqi repo.
