### PR TITLE
Add fetch tags to exisitng workflows

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -37,21 +37,21 @@ jobs:
       run: |
         cd docker && make dcmqi.test
 
-    - name: "Publish docker image"
-      # Only run if the event is not a pull request and the repository owner is QIICR.
-      # The latter is to prevent forks from publishing packages even if the owner's token
-      # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
-      run: |
-         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
-         docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
-         || echo "skipping docker push"
+    # - name: "Publish docker image"
+    #   # Only run if the event is not a pull request and the repository owner is QIICR.
+    #   # The latter is to prevent forks from publishing packages even if the owner's token
+    #   # would have sufficient privileges.
+    #   if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+    #   run: |
+    #      docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
+    #      docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
+    #      || echo "skipping docker push"
 
     - name: "Publish linux package"
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
          pip install -U "scikit-ci-addons>=0.22.0"
          # python -m scikit-ci publish --package-name dcmqi --package-version `git
@@ -62,4 +62,4 @@ jobs:
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages-clear-pattern "dcmqi-*-linux-*" \
             --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-            --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN }}
+            --exit-success-if-missing-token --token ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -64,4 +64,4 @@ jobs:
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages-clear-pattern "dcmqi-*-linux-*" \
             --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-            --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN  }}
+            --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -45,7 +45,7 @@ jobs:
     #   run: |
     #      docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
     #      docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
-    #      || echo "skipping docker push"
+    ##      || echo "skipping docker push"
 
     - name: "Publish linux package"
       # Only run if the event is not a pull request and the repository owner is QIICR.

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -60,7 +60,7 @@ jobs:
          # describe --tags --exact-match 2> /dev/null || echo "latest"` --platform linux
          # --commit-range ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --repository ${{ github.event.pull_request.head.repo.full_name }} --token ${{ secrets.GITHUB_TOKEN }} --verbose
          ci_addons publish_github_release vkt1414/dcmqi \
-            --release-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
+            --release-packages "build/dcmqi-build/dcmqi-*-linux.tar.gz" \
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages-clear-pattern "dcmqi-*-linux-*" \
             --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -17,7 +17,9 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true    
     - uses: actions/setup-python@v4
       with:
         python-version: '3.7.14'
@@ -62,4 +64,4 @@ jobs:
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages-clear-pattern "dcmqi-*-linux-*" \
             --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-            --exit-success-if-missing-token --token ${{ secrets.GITHUB_TOKEN }}
+            --exit-success-if-missing-token --token ${{ secrets.PAT }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -39,29 +39,29 @@ jobs:
       run: |
         cd docker && make dcmqi.test
 
-    # - name: "Publish docker image"
-    #   # Only run if the event is not a pull request and the repository owner is QIICR.
-    #   # The latter is to prevent forks from publishing packages even if the owner's token
-    #   # would have sufficient privileges.
-    #   if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
-    #   run: |
-    #      docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
-    #      docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
-    #      || echo "skipping docker push"
+    - name: "Publish docker image"
+      # Only run if the event is not a pull request and the repository owner is QIICR.
+      # The latter is to prevent forks from publishing packages even if the owner's token
+      # would have sufficient privileges.
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      run: |
+         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
+         docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
+         || echo "skipping docker push"
 
     - name: "Publish linux package"
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
          pip install -U "scikit-ci-addons>=0.22.0"
          # python -m scikit-ci publish --package-name dcmqi --package-version `git
          # describe --tags --exact-match 2> /dev/null || echo "latest"` --platform linux
          # --commit-range ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --repository ${{ github.event.pull_request.head.repo.full_name }} --token ${{ secrets.GITHUB_TOKEN }} --verbose
-         ci_addons publish_github_release vkt1414/dcmqi \
+         ci_addons publish_github_release qiicr/dcmqi \
             --release-packages "build/dcmqi-build/dcmqi-*-linux.tar.gz" \
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages-clear-pattern "dcmqi-*-linux-*" \
             --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-            --exit-success-if-missing-token --token ${{ secrets.PAT }}
+            --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN  }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -47,7 +47,7 @@ jobs:
     #   run: |
     #      docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
     #      docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
-    ###      || echo "skipping docker push"
+    ####      || echo "skipping docker push"
 
     - name: "Publish linux package"
       # Only run if the event is not a pull request and the repository owner is QIICR.

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -17,9 +17,9 @@ jobs:
     timeout-minutes: 40
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       with:
-        fetch-tags: true    
+        fetch-tags: true 
     - uses: actions/setup-python@v4
       with:
         python-version: '3.7.14'
@@ -39,29 +39,29 @@ jobs:
       run: |
         cd docker && make dcmqi.test
 
-    # - name: "Publish docker image"
-    #   # Only run if the event is not a pull request and the repository owner is QIICR.
-    #   # The latter is to prevent forks from publishing packages even if the owner's token
-    #   # would have sufficient privileges.
-    #   if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
-    #   run: |
-    #      docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
-    #      docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
-    ####      || echo "skipping docker push"
+    - name: "Publish docker image"
+      # Only run if the event is not a pull request and the repository owner is QIICR.
+      # The latter is to prevent forks from publishing packages even if the owner's token
+      # would have sufficient privileges.
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      run: |
+         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
+         docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
+         || echo "skipping docker push"
 
     - name: "Publish linux package"
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
          pip install -U "scikit-ci-addons>=0.22.0"
          # python -m scikit-ci publish --package-name dcmqi --package-version `git
          # describe --tags --exact-match 2> /dev/null || echo "latest"` --platform linux
          # --commit-range ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --repository ${{ github.event.pull_request.head.repo.full_name }} --token ${{ secrets.GITHUB_TOKEN }} --verbose
-         ci_addons publish_github_release vkt1414/dcmqi \
+         ci_addons publish_github_release QIICR/dcmqi \
             --release-packages "build/dcmqi-build/dcmqi-*-linux.zip" \
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages-clear-pattern "dcmqi-*-linux-*" \
             --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-            --exit-success-if-missing-token --token ${{ secrets.PAT }}
+            --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -45,7 +45,7 @@ jobs:
     #   run: |
     #      docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
     #      docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
-    ##      || echo "skipping docker push"
+    ###      || echo "skipping docker push"
 
     - name: "Publish linux package"
       # Only run if the event is not a pull request and the repository owner is QIICR.

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -39,29 +39,29 @@ jobs:
       run: |
         cd docker && make dcmqi.test
 
-    - name: "Publish docker image"
-      # Only run if the event is not a pull request and the repository owner is QIICR.
-      # The latter is to prevent forks from publishing packages even if the owner's token
-      # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
-      run: |
-         docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
-         docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
-         || echo "skipping docker push"
+    # - name: "Publish docker image"
+    #   # Only run if the event is not a pull request and the repository owner is QIICR.
+    #   # The latter is to prevent forks from publishing packages even if the owner's token
+    #   # would have sufficient privileges.
+    #   if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+    #   run: |
+    #      docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASS }} && \
+    #      docker push fedorov/dcmqi:`git describe --tags --exact-match 2> /dev/null || echo "latest"` \
+    #      || echo "skipping docker push"
 
     - name: "Publish linux package"
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
          pip install -U "scikit-ci-addons>=0.22.0"
          # python -m scikit-ci publish --package-name dcmqi --package-version `git
          # describe --tags --exact-match 2> /dev/null || echo "latest"` --platform linux
          # --commit-range ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --repository ${{ github.event.pull_request.head.repo.full_name }} --token ${{ secrets.GITHUB_TOKEN }} --verbose
-         ci_addons publish_github_release QIICR/dcmqi \
-            --release-packages "build/dcmqi-build/dcmqi-*-linux.zip" \
+         ci_addons publish_github_release vkt1414/dcmqi \
+            --release-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages-clear-pattern "dcmqi-*-linux-*" \
             --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-            --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN }}
+            --exit-success-if-missing-token --token ${{ secrets.PAT }}

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -57,7 +57,7 @@ jobs:
          # python -m scikit-ci publish --package-name dcmqi --package-version `git
          # describe --tags --exact-match 2> /dev/null || echo "latest"` --platform linux
          # --commit-range ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} --repository ${{ github.event.pull_request.head.repo.full_name }} --token ${{ secrets.GITHUB_TOKEN }} --verbose
-         ci_addons publish_github_release QIICR/dcmqi \
+         ci_addons publish_github_release vkt1414/dcmqi \
             --release-packages "build/dcmqi-build/dcmqi-*-linux.zip" \
             --prerelease-packages "build/dcmqi-build/dcmqi-*-linux-*.tar.gz" \
             --prerelease-packages-clear-pattern "dcmqi-*-linux-*" \

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -102,7 +102,7 @@ jobs:
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      ##if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         cd ${{ github.workspace }}/dcmqi-build/dcmqi-build && ninja package
 
@@ -111,12 +111,12 @@ jobs:
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         pip install -U "scikit-ci-addons>=0.22.0"
-        ci_addons publish_github_release vkt1414/dcmqi \
+        ci_addons publish_github_release qiicr/dcmqi \
         --release-packages "${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac.tar.gz" \
         --prerelease-packages ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac-*.tar.gz \
         --prerelease-packages-clear-pattern "dcmqi-*-mac-*" \
         --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-        --exit-success-if-missing-token --token ${{ secrets.PAT }}
+        --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN  }}

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -102,7 +102,7 @@ jobs:
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      ##if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         cd ${{ github.workspace }}/dcmqi-build/dcmqi-build && ninja package
 

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -119,4 +119,4 @@ jobs:
         --prerelease-packages ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac-*.tar.gz \
         --prerelease-packages-clear-pattern "dcmqi-*-mac-*" \
         --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-        --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN  }}
+        --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN }}

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -102,7 +102,7 @@ jobs:
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         cd ${{ github.workspace }}/dcmqi-build/dcmqi-build && ninja package
 

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -117,4 +117,4 @@ jobs:
         --prerelease-packages ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac-*.tar.gz \
         --prerelease-packages-clear-pattern "dcmqi-*-mac-*" \
         --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-        --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN }}
+        --exit-success-if-missing-token --token ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -111,12 +111,12 @@ jobs:
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         pip install -U "scikit-ci-addons>=0.22.0"
-        ci_addons publish_github_release QIICR/dcmqi \
+        ci_addons publish_github_release vkt1414/dcmqi \
         --release-packages "${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac.tar.gz" \
         --prerelease-packages ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac-*.tar.gz \
         --prerelease-packages-clear-pattern "dcmqi-*-mac-*" \
         --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-        --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN }}
+        --exit-success-if-missing-token --token ${{ secrets.PAT }}

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -19,9 +19,9 @@ jobs:
 
     # Checkout and install python
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       with:
-        fetch-tags: true       
+        fetch-tags: true     
     - uses: actions/setup-python@v4
       with:
         python-version: '3.7.14'
@@ -102,7 +102,7 @@ jobs:
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         cd ${{ github.workspace }}/dcmqi-build/dcmqi-build && ninja package
 
@@ -111,12 +111,12 @@ jobs:
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         pip install -U "scikit-ci-addons>=0.22.0"
-        ci_addons publish_github_release vkt1414/dcmqi \
+        ci_addons publish_github_release QIICR/dcmqi \
         --release-packages "${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-linux.tar.gz" \
         --prerelease-packages ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac-*.tar.gz \
         --prerelease-packages-clear-pattern "dcmqi-*-mac-*" \
         --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-        --exit-success-if-missing-token --token ${{ secrets.PAT }}
+        --exit-success-if-missing-token --token ${{ secrets.GA_TOKEN }}

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -100,7 +100,7 @@ jobs:
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         cd ${{ github.workspace }}/dcmqi-build/dcmqi-build && ninja package
 

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -112,7 +112,7 @@ jobs:
       if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         pip install -U "scikit-ci-addons>=0.22.0"
-        ci_addons publish_github_release QIICR/dcmqi \
+        ci_addons publish_github_release vkt1414/dcmqi \
         --release-packages "${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-linux.tar.gz" \
         --prerelease-packages ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac-*.tar.gz \
         --prerelease-packages-clear-pattern "dcmqi-*-mac-*" \

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -115,7 +115,7 @@ jobs:
       run: |
         pip install -U "scikit-ci-addons>=0.22.0"
         ci_addons publish_github_release QIICR/dcmqi \
-        --release-packages "${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-linux.tar.gz" \
+        --release-packages "${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac.tar.gz" \
         --prerelease-packages ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac-*.tar.gz \
         --prerelease-packages-clear-pattern "dcmqi-*-mac-*" \
         --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -109,7 +109,7 @@ jobs:
       # Only run if the event is not a pull request and the repository owner is QIICR.
       # The latter is to prevent forks from publishing packages even if the owner's token
       # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
       run: |
         pip install -U "scikit-ci-addons>=0.22.0"
         ci_addons publish_github_release vkt1414/dcmqi \

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -19,7 +19,9 @@ jobs:
 
     # Checkout and install python
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-tags: true       
     - uses: actions/setup-python@v4
       with:
         python-version: '3.7.14'
@@ -117,4 +119,4 @@ jobs:
         --prerelease-packages ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac-*.tar.gz \
         --prerelease-packages-clear-pattern "dcmqi-*-mac-*" \
         --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" \
-        --exit-success-if-missing-token --token ${{ secrets.GITHUB_TOKEN }}
+        --exit-success-if-missing-token --token ${{ secrets.PAT }}

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -84,7 +84,7 @@ jobs:
     # Only run if the event is not a pull request and the repository owner is QIICR.
     # The latter is to prevent forks from publishing packages even if the owner's token
     # would have sufficient privileges.
-    if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+    #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
 
     needs: build-windows
 

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -86,7 +86,7 @@ jobs:
     # Only run if the event is not a pull request and the repository owner is QIICR.
     # The latter is to prevent forks from publishing packages even if the owner's token
     # would have sufficient privileges.
-    if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+    #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
 
     needs: build-windows
 
@@ -102,10 +102,10 @@ jobs:
       - name: Publish package
         run: |
           pip install -U "scikit-ci-addons>=0.22.0"
-          ci_addons publish_github_release qiicr/dcmqi `
+          ci_addons publish_github_release vkt1414/dcmqi `
           --exit-success-if-missing-token `
           --release-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64.zip" `
           --prerelease-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64-*.zip" `
           --prerelease-packages-clear-pattern "dcmqi-*-win64-*" `
           --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" `
-          --token ${{ secrets.GA_TOKEN }}
+          --token ${{ secrets.PAT }}

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Publish package
         run: |
           pip install -U "scikit-ci-addons>=0.22.0"
-          ci_addons publish_github_release qiicr/dcmqi `
+          ci_addons publish_github_release vkt1414/dcmqi `
           --exit-success-if-missing-token `
           --release-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64.zip" `
           --prerelease-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64-*.zip" `

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -108,4 +108,4 @@ jobs:
           --prerelease-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64-*.zip" `
           --prerelease-packages-clear-pattern "dcmqi-*-win64-*" `
           --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" `
-          --token ${{ secrets.GA_TOKEN  }}
+          --token ${{ secrets.GA_TOKEN }}

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -109,4 +109,4 @@ jobs:
           --prerelease-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64-*.zip" `
           --prerelease-packages-clear-pattern "dcmqi-*-win64-*" `
           --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" `
-          --token ${{ secrets.GITHUB_TOKEN }}
+          --token ${{ secrets.PAT }}

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -86,7 +86,7 @@ jobs:
     # Only run if the event is not a pull request and the repository owner is QIICR.
     # The latter is to prevent forks from publishing packages even if the owner's token
     # would have sufficient privileges.
-    #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+    if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
 
     needs: build-windows
 
@@ -102,10 +102,10 @@ jobs:
       - name: Publish package
         run: |
           pip install -U "scikit-ci-addons>=0.22.0"
-          ci_addons publish_github_release vkt1414/dcmqi `
+          ci_addons publish_github_release qiicr/dcmqi `
           --exit-success-if-missing-token `
           --release-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64.zip" `
           --prerelease-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64-*.zip" `
           --prerelease-packages-clear-pattern "dcmqi-*-win64-*" `
           --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" `
-          --token ${{ secrets.PAT }}
+          --token ${{ secrets.GA_TOKEN  }}

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Publish package
         run: |
           pip install -U "scikit-ci-addons>=0.22.0"
+          git describe
           ci_addons publish_github_release vkt1414/dcmqi `
           --exit-success-if-missing-token `
           --release-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64.zip" `

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -15,7 +15,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - uses: microsoft/setup-msbuild@v1.1
         with:
           vs-version: '17'
@@ -89,7 +91,9 @@ jobs:
     needs: build-windows
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - uses: actions/download-artifact@v3
         with:
           name: dcmqi-build

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -15,9 +15,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
-          fetch-tags: true
+          fetch-tags: true     
       - uses: microsoft/setup-msbuild@v1.1
         with:
           vs-version: '17'
@@ -86,14 +86,14 @@ jobs:
     # Only run if the event is not a pull request and the repository owner is QIICR.
     # The latter is to prevent forks from publishing packages even if the owner's token
     # would have sufficient privileges.
-    #if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+    if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
 
     needs: build-windows
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
-          fetch-tags: true
+          fetch-tags: true          
       - uses: actions/download-artifact@v3
         with:
           name: dcmqi-build
@@ -102,11 +102,10 @@ jobs:
       - name: Publish package
         run: |
           pip install -U "scikit-ci-addons>=0.22.0"
-          git describe
-          ci_addons publish_github_release vkt1414/dcmqi `
+          ci_addons publish_github_release qiicr/dcmqi `
           --exit-success-if-missing-token `
           --release-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64.zip" `
           --prerelease-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64-*.zip" `
           --prerelease-packages-clear-pattern "dcmqi-*-win64-*" `
           --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" `
-          --token ${{ secrets.PAT }}
+          --token ${{ secrets.GA_TOKEN }}

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -104,4 +104,4 @@ jobs:
           --prerelease-packages "${{ github.workspace }}\dcmqi-build\dcmqi-build\dcmqi-*-win64-*.zip" `
           --prerelease-packages-clear-pattern "dcmqi-*-win64-*" `
           --prerelease-packages-keep-pattern "*<COMMIT_DATE>-<COMMIT_SHORT_SHA>*" `
-          --token ${{ secrets.GA_TOKEN }}
+          --token ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To address #482, I found that the reason for scikit unable to make releases with tagged commits (w/ versioned tags). The git checkout action does not fetch tags unless we explicitly mention it. Some discussion can be seen here..https://github.com/actions/checkout/issues/206
I came to know about this issue when I simply wanted to see the tags while running the GitHub actions workflow with 'git describe' and the logs said no tags found. I then searched if this is a common issue and found the above discussion.
![image](https://github.com/QIICR/dcmqi/assets/115020590/46a8695f-e659-4ff8-8617-d2216f5c961b)
