### PR TITLE
Switch to framesorter class

### DIFF
--- a/include/dcmqi/OverlapUtil.h
+++ b/include/dcmqi/OverlapUtil.h
@@ -233,10 +233,7 @@ public:
     void printNonOverlappingSegments(OFStringStream& ss);
 
 protected:
-    /** Collect all physical frame positions in m_FramePositions
-     *  @return EC_Normal if successful, error otherwise
-     */
-    OFCondition collectPhysicalFramePositions();
+
 
     /** Group physical frame positions into logical positions. This is done by sorting
      *  frames after *that* position coordinate that in its mean position difference is

--- a/include/dcmqi/framesorter.h
+++ b/include/dcmqi/framesorter.h
@@ -69,7 +69,7 @@ public:
     /// The error code should be set in any case (default: EC_Normal)
     OFCondition errorCode;
     /// The frame numbers, in sorted order (default: empty)
-    OFVector<Uint16> frameNumbers;
+    OFVector<Uint32> frameNumbers;
     /// Tag key that contains the information that was crucial for sorting.
     /// This is especially useful for creating dimension indices. Should be
     /// set to (0xffff,0xfff) if none was used (default).


### PR DESCRIPTION
OverlapUtil:
- Use framesorter class instead of using homegrown sorting.
- Remove the related (then) unused sorting functionality

FrameSorter class: 
- Remember frame positions in Result
- Also remember frame positions in sorting result since it is usually
accessed anyway and interesting for library users that otherwise call
the underlying method on FGInterface for all frames again.
- The DummySorter does not provide frame positions to keep it as simple
as possible (i.e. keep  it "zero" cost).
- Allow 2^32-1 frames as permitted in in DICOM (i.e. use Uint32 instead
of  Uint16) for frame number index.
- Changed precision from Float32 to Float64 where applicable.
- Added some documentation and some other small changes.