### PR TITLE
Fix order of pixel spacing converting ITK->DICOM.

### DIFF
--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -88,7 +88,7 @@ namespace dcmqi {
 
       ShortImageType::SpacingType labelSpacing = segmentations[0]->GetSpacing();
       ostringstream spacingSStream;
-      spacingSStream << scientific << labelSpacing[0] << "\\" << labelSpacing[1];
+      spacingSStream << scientific << labelSpacing[1] << "\\" << labelSpacing[0];
       CHECK_COND(pixmsr->setPixelSpacing(spacingSStream.str().c_str()));
 
       spacingSStream.clear(); spacingSStream.str("");


### PR DESCRIPTION
The order in which the values for pixel spacing in ITK and DICOM are stored is different. In DICOM the first value is the row spacing (i.e. Y axis) while in ITK the first value is spacing along the X axis.

Reading asymmetric spacings from DICOM segmentations has already been fixed in 46c6f0.

This commit fixes writing DICOM segmentation objects with asymmetric spacings.