### PR TITLE
ENH: use SegmentDescription to populate SegmentLabel

### DIFF
--- a/doc/examples/seg-example.json
+++ b/doc/examples/seg-example.json
@@ -14,6 +14,7 @@
       {
         "labelID": 1,
         "SegmentDescription": "Liver Segmentation",
+        "SegmentLabel": "Liver",
         "SegmentedPropertyCategoryCodeSequence": {
           "CodeValue": "85756007",
           "CodingSchemeDesignator": "SCT",

--- a/doc/examples/seg-example_multiple_segments.json
+++ b/doc/examples/seg-example_multiple_segments.json
@@ -14,6 +14,7 @@
       {
         "labelID": 1,
         "SegmentDescription": "Liver Segmentation",
+        "SegmentLabel": "Liver",
         "SegmentedPropertyCategoryCodeSequence": {
           "CodeValue": "85756007",
           "CodingSchemeDesignator": "SCT",
@@ -37,6 +38,7 @@
       {
         "labelID": 2,
         "SegmentDescription": "Anatomical Structure",
+        "SegmentLabel": "Thoracic spine",
         "SegmentedPropertyTypeCodeSequence": {
           "CodeMeaning": "Thoracic spine",
           "CodingSchemeDesignator": "SCT",
@@ -59,6 +61,7 @@
       {
         "labelID": 3,
         "SegmentDescription": "Anatomical Structure",
+        "SegmentLabel": "Heart",
         "SegmentedPropertyCategoryCodeSequence": {
           "CodeMeaning": "Anatomical Structure",
           "CodingSchemeDesignator": "SCT",

--- a/doc/examples/seg-example_multiple_segments_reordered.json
+++ b/doc/examples/seg-example_multiple_segments_reordered.json
@@ -20,6 +20,7 @@
       {
         "labelID": 1,
         "SegmentDescription": "Liver Segmentation",
+        "SegmentLabel": "Liver",
         "SegmentedPropertyCategoryCodeSequence": {
           "CodeValue": "85756007",
           "CodingSchemeDesignator": "SCT",
@@ -43,6 +44,7 @@
       {
         "labelID": 2,
         "SegmentDescription": "Anatomical Structure",
+        "SegmentLabel": "Thoracic spine",
         "SegmentedPropertyTypeCodeSequence": {
           "CodeMeaning": "Thoracic spine",
           "CodingSchemeDesignator": "SCT",
@@ -65,6 +67,7 @@
       {
         "labelID": 3,
         "SegmentDescription": "Anatomical Structure",
+        "SegmentLabel": "Heart",
         "SegmentedPropertyCategoryCodeSequence": {
           "CodeMeaning": "Anatomical Structure",
           "CodingSchemeDesignator": "SCT",

--- a/doc/examples/seg-example_multiple_segments_single_input_file.json
+++ b/doc/examples/seg-example_multiple_segments_single_input_file.json
@@ -14,6 +14,7 @@
       {
         "labelID": 1,
         "SegmentDescription": "Liver Segmentation",
+        "SegmentLabel": "Liver",
         "SegmentedPropertyCategoryCodeSequence": {
           "CodeValue": "85756007",
           "CodingSchemeDesignator": "SCT",
@@ -35,6 +36,7 @@
       {
         "labelID": 2,
         "SegmentDescription": "Anatomical Structure",
+        "SegmentLabel": "Thoracic spine",
         "SegmentedPropertyTypeCodeSequence": {
           "CodeMeaning": "Thoracic spine",
           "CodingSchemeDesignator": "SCT",
@@ -55,6 +57,7 @@
       {
         "labelID": 3,
         "SegmentDescription": "Anatomical Structure",
+        "SegmentLabel": "Heart",
         "SegmentedPropertyCategoryCodeSequence": {
           "CodeMeaning": "Anatomical Structure",
           "CodingSchemeDesignator": "SCT",

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -245,6 +245,9 @@ namespace dcmqi {
         if(segmentAttributes->getSegmentLabel().length() > 0){
           cout << "Populating segment label to " << segmentAttributes->getSegmentLabel() << endl;
           segmentLabel = segmentAttributes->getSegmentLabel().c_str();
+        } else if(segmentAttributes->getSegmentDescription().length() > 0){
+          cout << "Populating segment label from SegmentDescription to " << segmentAttributes->getSegmentDescription() << endl;
+          segmentLabel = segmentAttributes->getSegmentDescription().c_str();
         } else
           CHECK_COND(typeCode->getCodeMeaning(segmentLabel));
 


### PR DESCRIPTION
This will be done when SegmentLabel is not passed in configuration. SegmentDescription is better than using CodeMeaning from SegmentationType, as it allows more precise control by the user.