### PR TITLE
WIP: Use DcmItem in API where possible.

### DIFF
--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -28,13 +28,13 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/commontk/DCMTK.git"
+    "${EP_GIT_PROTOCOL}://github.com/michaelonken/dcmtk.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     ${proj}_REVISION_TAG
-    "patched-DCMTK-3.6.6_20210115"
+    "use_dcmitem_instead_of_dcmdataset"
     QUIET
     )
 
@@ -94,11 +94,14 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DDCMTK_WITH_PNG:BOOL=OFF # see github issue #25
       -DDCMTK_WITH_TIFF:BOOL=OFF  # see github issue #25
       -DDCMTK_WITH_XML:BOOL=OFF  # see github issue #25
-      -DDCMTK_WITH_ICONV:BOOL=OFF  # see github issue #178
+      -DDCMTK_WITH_ICU:BOOL=OFF  # make sure to not include any ICU dependencies
+      -DDCMTK_WITH_ICONV:BOOL=OFF  # make sure to not include any iconv dependencies
       -DDCMTK_WITH_SNDFILE:BOOL=OFF # see github issue #395
       -DDCMTK_FORCE_FPIC_ON_UNIX:BOOL=ON
       -DDCMTK_OVERWRITE_WIN32_COMPILER_FLAGS:BOOL=OFF
-      -DDCMTK_ENABLE_BUILTIN_DICTIONARY:BOOL=ON
+      -DDCMTK_DEFAULT_DICT:STRING=builtin
+      -DDCMTK_ENABLE_CHARSET_CONVERSION:STRING=oficonv
+      -DDCMTK_ENABLE_BUILTIN_OFICONV_DATA:BOOL=ON
       -DDCMTK_ENABLE_PRIVATE_TAGS:BOOL=ON
       -DDCMTK_COMPILE_WIN32_MULTITHREADED_DLL:BOOL=ON
       -DDCMTK_ENABLE_STL:BOOL=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ set(export_targets TRUE)
 if(DCMQI_SUPERBUILD_BINARY_DIR)
   string(FIND ${ITK_DIR}   "${DCMQI_SUPERBUILD_BINARY_DIR}" itk_here)
   string(FIND ${DCMTK_DIR} "${DCMQI_SUPERBUILD_BINARY_DIR}" dcmtk_here)
+  message(STATUS "---------------------------------------- DCMTK DIR: ${DCMTK_DIR} ------------------------------------------")
 
   if(NOT ${itk_here} EQUAL -1 OR NOT ${dcmtk_here} EQUAL -1)
     set(export_targets FALSE)

--- a/apps/paramaps/itkimage2paramap.cxx
+++ b/apps/paramaps/itkimage2paramap.cxx
@@ -45,7 +45,8 @@ int main(int argc, char *argv[])
                         (std::istreambuf_iterator<char>()));
 
   try {
-    DcmDataset* result = dcmqi::ParaMapConverter::itkimage2paramap(parametricMapImage, dcmDatasets, metadata);
+    std::vector<DcmItem*> toItems(dcmDatasets.begin(), dcmDatasets.end());
+    DcmDataset* result = dcmqi::ParaMapConverter::itkimage2paramap(parametricMapImage, toItems, metadata);
 
     if (result == NULL) {
       std::cerr << "ERROR: Conversion failed." << std::endl;

--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -120,9 +120,10 @@ int main(int argc, char *argv[])
     }
     segmentations = segmentationsReordered;
   }
-
+  // Copy to DcmItem* vector to use it in itkimage2dcmSegmentation() call
+  std::vector<DcmItem*> dcmItems(dcmDatasets.begin(), dcmDatasets.end());
   try {
-    DcmDataset* result = dcmqi::Itk2DicomConverter::itkimage2dcmSegmentation(dcmDatasets,
+    DcmDataset* result = dcmqi::Itk2DicomConverter::itkimage2dcmSegmentation(dcmItems,
                                                                              segmentations,
                                                                              metadata,
                                                                              skipEmptySlices,

--- a/include/dcmqi/ConverterBase.h
+++ b/include/dcmqi/ConverterBase.h
@@ -298,8 +298,8 @@ namespace dcmqi {
     }
 
     // AF: I could not quickly figure out how to template this function over image type - suggestions are welcomed!
-    static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<DcmDataset*> dcmDatasets,
-                                                                                       const ShortImageType::Pointer &labelImage) {
+    static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<DcmItem*> dcmDatasets,
+                                                                           const ShortImageType::Pointer &labelImage) {
       // Find mapping from the segmentation slice number to the derivation image
       // Assume that orientation of the segmentation is the same as the source series
       unsigned numLabelSlices = labelImage->GetLargestPossibleRegion().GetSize()[2];

--- a/include/dcmqi/Dicom2ItkConverter.h
+++ b/include/dcmqi/Dicom2ItkConverter.h
@@ -97,7 +97,7 @@ protected:
      *
      * @param segDataset A pointer to the DICOM dataset containing the metadata.
      */
-    void populateMetaInformationFromDICOM(DcmDataset* segDataset);
+    void populateMetaInformationFromDICOM(DcmItem* segDataset);
 
     /**
      * Helper method that uses the OverlapUtil class to retrieve non-overlapping segment

--- a/include/dcmqi/Itk2DicomConverter.h
+++ b/include/dcmqi/Itk2DicomConverter.h
@@ -39,7 +39,7 @@ namespace dcmqi {
     /**
      * @brief Converts itk images data into a DICOM Segmentation object.
      *
-     * @param dcmDatasets A vector of DICOM datasets with the images that the segmentation is based on.
+     * @param dcmDatasets A vector of DICOM items (usually dataset level) with the images that the segmentation is based on.
      * @param segmentations A vector of itk images to be converted.
      * @param metaData A string containing the metadata to be used for the DICOM Segmentation object.
      * @param skipEmptySlices A boolean indicating whether to skip empty slices during the conversion.
@@ -59,7 +59,7 @@ namespace dcmqi {
      *        display.
      * @return A pointer to the resulting DICOM Segmentation object.
      */
-    static DcmDataset* itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
+    static DcmDataset* itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
                           vector<ShortImageType::Pointer> segmentations,
                           const string &metaData,
                           bool skipEmptySlices=true,
@@ -78,7 +78,7 @@ namespace dcmqi {
      *  @param  segNum2Label mapping from segment number (old) to label ID (new)
      *  @return true if successful, false otherwise
      */
-    static bool mapLabelIDsToSegmentNumbers(DcmDataset* dset, map<Uint16, Uint16> segNum2Label);
+    static bool mapLabelIDsToSegmentNumbers(DcmItem* dset, map<Uint16, Uint16> segNum2Label);
 
     /** Check whether labels (values in given map) are unique and monotonically increasing by 1
      *  @param  segNum2Label mapping from segment number (old) to label ID (new)

--- a/include/dcmqi/ParaMapConverter.h
+++ b/include/dcmqi/ParaMapConverter.h
@@ -34,10 +34,10 @@ namespace dcmqi {
   class ParaMapConverter : public ConverterBase {
 
   public:
-    static DcmDataset* itkimage2paramap(const FloatImageType::Pointer &parametricMapImage, vector<DcmDataset*> dcmDatasets,
+    static DcmDataset* itkimage2paramap(const FloatImageType::Pointer &parametricMapImage, vector<DcmItem*> dcmDatasets,
                                         const string &metaData);
 
-    static pair <FloatImageType::Pointer, string> paramap2itkimage(DcmDataset *pmapDataset);
+    static pair <FloatImageType::Pointer, string> paramap2itkimage(DcmDataset *pmapDataset); //TODO: Check
   protected:
     static OFCondition addFrame(DPMParametricMapIOD &map, const FloatImageType::Pointer &parametricMapImage,
                                 const JSONParametricMapMetaInformationHandler &metaInfo, const unsigned long frameNo, OFVector<FGBase*> perFrameGroups);

--- a/libsrc/CMakeLists.txt
+++ b/libsrc/CMakeLists.txt
@@ -72,14 +72,9 @@ set(_dcmtk_libs)
 set(_dcmtk_includes)
 if(TARGET DCMTK::DCMTK)
   set(_dcmtk_libs DCMTK::DCMTK)
-  # TODO
-  MESSAGE(STATUS "------------------------------------- DCMTK::DCMTK: _dcmtk_libs1: ${_dcmtk_libs} --------------------------------")
 else()
-  set(_dcmtk_libs ${DCMTK_LIBRARIES})
+  set(_dcmtk_libs DCMTK::DCMTK)
   set(_dcmtk_includes ${DCMTK_INCLUDE_DIRS})
-  # TODO
-  MESSAGE(STATUS "------------------------------------- DCMTK::DCMTK: ${DCMTK_LIBRARIES} --------------------------------")
-  MESSAGE(STATUS "------------------------------------- DCMTK::DCMTK: _dcmtk_libs2: ${_dcmtk_libs} --------------------------------")
 endif()
 
 set(${lib_name}_INCLUDE_DIRS
@@ -104,8 +99,6 @@ target_link_libraries(${lib_name} PUBLIC
   ${ITK_LIBRARIES}
   $<$<NOT:$<BOOL:${DCMQI_BUILTIN_JSONCPP}>>:${JsonCpp_LIBRARY}>
   )
-  # TODO
-  MESSAGE(STATUS "------------------------------------- DCMTK::DCMTK: _dcmtk_libs3: ${_dcmtk_libs} --------------------------------")
 
 if(export_targets)
   install(TARGETS ${lib_name}

--- a/libsrc/CMakeLists.txt
+++ b/libsrc/CMakeLists.txt
@@ -72,9 +72,14 @@ set(_dcmtk_libs)
 set(_dcmtk_includes)
 if(TARGET DCMTK::DCMTK)
   set(_dcmtk_libs DCMTK::DCMTK)
+  # TODO
+  MESSAGE(STATUS "------------------------------------- DCMTK::DCMTK: _dcmtk_libs1: ${_dcmtk_libs} --------------------------------")
 else()
   set(_dcmtk_libs ${DCMTK_LIBRARIES})
   set(_dcmtk_includes ${DCMTK_INCLUDE_DIRS})
+  # TODO
+  MESSAGE(STATUS "------------------------------------- DCMTK::DCMTK: ${DCMTK_LIBRARIES} --------------------------------")
+  MESSAGE(STATUS "------------------------------------- DCMTK::DCMTK: _dcmtk_libs2: ${_dcmtk_libs} --------------------------------")
 endif()
 
 set(${lib_name}_INCLUDE_DIRS
@@ -99,6 +104,8 @@ target_link_libraries(${lib_name} PUBLIC
   ${ITK_LIBRARIES}
   $<$<NOT:$<BOOL:${DCMQI_BUILTIN_JSONCPP}>>:${JsonCpp_LIBRARY}>
   )
+  # TODO
+  MESSAGE(STATUS "------------------------------------- DCMTK::DCMTK: _dcmtk_libs3: ${_dcmtk_libs} --------------------------------")
 
 if(export_targets)
   install(TARGETS ${lib_name}

--- a/libsrc/Dicom2ItkConverter.cpp
+++ b/libsrc/Dicom2ItkConverter.cpp
@@ -253,7 +253,7 @@ itk::SmartPointer<ShortImageType> Dicom2ItkConverter::nextResult()
 
 // -------------------------------------------------------------------------------------
 
-void Dicom2ItkConverter::populateMetaInformationFromDICOM(DcmDataset* segDataset)
+void Dicom2ItkConverter::populateMetaInformationFromDICOM(DcmItem* segDataset)
 {
     OFString creatorName, sessionID, timePointID, seriesDescription, seriesNumber, instanceNumber, bodyPartExamined,
         coordinatingCenter;

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -25,11 +25,11 @@ namespace dcmqi {
 
   // -------------------------------------------------------------------------------------
 
-  DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
-                                                          vector<ShortImageType::Pointer> segmentations,
-                                                          const string &metaData,
-                                                          bool skipEmptySlices,
-                                                          bool useLabelIDAsSegmentNumber) {
+  DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
+                                                           vector<ShortImageType::Pointer> segmentations,
+                                                           const string &metaData,
+                                                           bool skipEmptySlices,
+                                                           bool useLabelIDAsSegmentNumber) {
 
     ShortImageType::SizeType inputSize = segmentations[0]->GetBufferedRegion().GetSize();
 
@@ -359,7 +359,7 @@ namespace dcmqi {
                 frameData[framePixelCnt] = 0;
             }
 
-            OFVector<DcmDataset*> siVector;
+            OFVector<DcmItem*> siVector;
             for(size_t derImageInstanceNum=0;
                 derImageInstanceNum<slice2derimg[sliceNumber].size();
                 derImageInstanceNum++){
@@ -503,7 +503,7 @@ namespace dcmqi {
   }
 
 
-  bool Itk2DicomConverter::mapLabelIDsToSegmentNumbers(DcmDataset* dset, map<Uint16,Uint16> segNum2Label)
+  bool Itk2DicomConverter::mapLabelIDsToSegmentNumbers(DcmItem* dset, map<Uint16,Uint16> segNum2Label)
   {
     cout << "Mapping Label IDs to Segment Numbers" << endl;
     DcmSequenceOfItems* seq = NULL;

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 namespace dcmqi {
 
-  DcmDataset* ParaMapConverter::itkimage2paramap(const FloatImageType::Pointer &parametricMapImage, vector<DcmDataset*> dcmDatasets,
+  DcmDataset* ParaMapConverter::itkimage2paramap(const FloatImageType::Pointer &parametricMapImage, vector<DcmItem*> dcmDatasets,
                                          const string &metaData) {
 
     MinMaxCalculatorType::Pointer calculator = MinMaxCalculatorType::New();
@@ -67,7 +67,7 @@ namespace dcmqi {
 
     DPMParametricMapIOD* pMapDoc = OFget<DPMParametricMapIOD>(&obj);
 
-    DcmDataset* srcDataset = NULL;
+    DcmItem* srcDataset = NULL;
     if(dcmDatasets.size()){
       srcDataset = dcmDatasets[0];
     }
@@ -296,7 +296,7 @@ namespace dcmqi {
 
     for (unsigned long sliceNumber = 0; result.good() && (sliceNumber < inputSize[2]); sliceNumber++) {
 
-      OFVector<DcmDataset*> siVector;
+      OFVector<DcmItem*> siVector;
       for(size_t derImageInstanceNum=0;
           derImageInstanceNum<slice2derimg[sliceNumber].size();
           derImageInstanceNum++){


### PR DESCRIPTION

This is work in progress, do NOT merge.

The API  change in dcmqi requires an updated DCMTK. 

However, if I use a recent DCMTK version in the build (by pointing the superbuild to it), I run into linker errors since the build tries to link DCMTK libraries twice (one time each lib with full path, which works fine, and another time by just the library name, which fails), see attached log ([linker.log](https://github.com/QIICR/dcmqi/files/14260822/linker.log))

@jcfr I think you authored the dcmqi suberbuild: Any idea what goes wrong? I fiddled around with it quite some time but could not find out where the "short" libs are added, or how to remove them. Maybe this is a quick one for you...

