### PR TITLE
bug: switch to integer for the skip flag

### DIFF
--- a/CMakeExternals/SlicerExecutionModel.cmake
+++ b/CMakeExternals/SlicerExecutionModel.cmake
@@ -34,7 +34,7 @@ if(NOT DEFINED SlicerExecutionModel_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM
 
   ExternalProject_SetIfNotDefined(
     ${proj}_REVISION_TAG
-    "62d0121dbb0fb057ebbd7c9ab84520accacec8bc"
+    "4325526343f582dd2080d0ffd93a63c8817dfb95"
     QUIET
     )
 

--- a/apps/seg/Testing/CMakeLists.txt
+++ b/apps/seg/Testing/CMakeLists.txt
@@ -293,6 +293,7 @@ foreach(seg_size ${TEST_SEG_SIZES})
       --inputImageList ${BASELINE}/${seg_size}/nrrd/label.nrrd
       --inputDICOMDirectory ${BASELINE}/${seg_size}/image
       --outputDICOM ${MODULE_TEMP_DIR}/${seg_size}_seg.dcm
+      --skip 0
     )
 
   dcmqi_add_test(

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -55,14 +55,14 @@
   <parameters advanced="true">
     <label>Advanced processing parameters</label>
 
-    <boolean>
+    <integer>
       <name>skipEmptySlices</name>
       <label>Skip empty slices</label>
       <channel>input</channel>
       <longflag>skip</longflag>
-      <default>true</default>
+      <default>1</default>
       <description>Skip empty slices while encoding segmentation image. By default, empty slices will not be encoded, resulting in a smaller output file size.</description>
-    </boolean>
+    </integer>
 
     <boolean>
       <name>useLabelIDAsSegmentNumber</name>


### PR DESCRIPTION
re #498

It appears that defaults are ignored for boolean SEM parameters. Even though the parameter was set to true in https://github.com/QIICR/dcmqi/blob/2990dbd01d1fa61c16777950732ff19dc87318e3/apps/seg/itkimage2segimage.xml#L58-L65, the default reported by the executable was 0.

Local tests show that integer parameters do not have this problem.

Also switch to the most recent has for SlicerExecutionModel.