### PR TITLE
Use const pointer to input segmentations

### DIFF
--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
     return EXIT_FAILURE;
   }
 
-  vector<ShortImageType::Pointer> segmentations;
+  vector<ShortImageType::ConstPointer> segmentations;
 
   for(size_t segFileNumber=0; segFileNumber<segImageFiles.size(); segFileNumber++){
     ShortReaderType::Pointer reader = ShortReaderType::New();
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
     Json::Value reorderedSegmentAttributes;
     vector<int> fileOrder(segImageFiles.size());
     fill(fileOrder.begin(), fileOrder.end(), -1);
-    vector<ShortImageType::Pointer> segmentationsReordered(segImageFiles.size());
+    vector<ShortImageType::ConstPointer> segmentationsReordered(segImageFiles.size());
     for(size_t filePosition=0;filePosition<segImageFiles.size();filePosition++){
       for(size_t mappingPosition=0;mappingPosition<segImageFiles.size();mappingPosition++){
         string mappingItem = metaRoot["segmentAttributesFileMapping"][static_cast<int>(mappingPosition)].asCString();

--- a/include/dcmqi/ConverterBase.h
+++ b/include/dcmqi/ConverterBase.h
@@ -299,7 +299,7 @@ namespace dcmqi {
 
     // AF: I could not quickly figure out how to template this function over image type - suggestions are welcomed!
     static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<DcmDataset*> dcmDatasets,
-                                                                                       const ShortImageType::Pointer &labelImage) {
+                                                                                       const ShortImageType::ConstPointer &labelImage) {
       // Find mapping from the segmentation slice number to the derivation image
       // Assume that orientation of the segmentation is the same as the source series
       unsigned numLabelSlices = labelImage->GetLargestPossibleRegion().GetSize()[2];

--- a/include/dcmqi/Itk2DicomConverter.h
+++ b/include/dcmqi/Itk2DicomConverter.h
@@ -63,7 +63,7 @@ namespace dcmqi {
      * @return A pointer to the resulting DICOM Segmentation object.
      */
     static DcmDataset* itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
-                          vector<ShortImageType::Pointer> segmentations,
+                          vector<ShortImageType::ConstPointer> segmentations,
                           const string &metaData,
                           bool skipEmptySlices=true,
                           bool useLabelIDAsSegmentNumber=false,

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -26,7 +26,7 @@ namespace dcmqi {
   // -------------------------------------------------------------------------------------
 
   DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
-                                                          vector<ShortImageType::Pointer> segmentations,
+                                                          vector<ShortImageType::ConstPointer> segmentations,
                                                           const string &metaData,
                                                           bool skipEmptySlices,
                                                           bool useLabelIDAsSegmentNumber,


### PR DESCRIPTION
Use constant pointers to input segmentation images (`itk::Image::ConstPointer`) since we don't expect the function to change these images.