### PR TITLE
COMP: Update python executable location and usage

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-tags: true 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.7.14'
+        python-version: '3.9'
 
     - name: "Install jsondiff"
       run: pip install jsondiff

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8.0'
+          python-version: '3.9.0'
 
       - name: Download prerequisite packages
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,10 +246,10 @@ mark_as_superbuild(JsonCpp_INCLUDE_DIR:PATH)
 mark_as_superbuild(JsonCpp_LIBRARY:FILEPATH)
 mark_as_superbuild(DCMQI_BUILTIN_JSONCPP:BOOL)
 
-# Python 2.7
+# Python 3
 if(BUILD_TESTING)
-  find_package(PythonInterp 2.7 REQUIRED)
-  mark_as_superbuild(PYTHON_EXECUTABLE)
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  mark_as_superbuild(Python3_EXECUTABLE)
 endif()
 
 #-----------------------------------------------------------------------------

--- a/apps/paramaps/Testing/CMakeLists.txt
+++ b/apps/paramaps/Testing/CMakeLists.txt
@@ -129,7 +129,7 @@ dcmqi_add_test(
 dcmqi_add_test(
   NAME ${MODULE_NAME}_meta_roundtrip
   MODULE_NAME ${MODULE_NAME}
-  COMMAND python ${CMAKE_SOURCE_DIR}/util/comparejson.py
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/util/comparejson.py
     ${CMAKE_SOURCE_DIR}/doc/examples/pm-example.json
     ${MODULE_TEMP_DIR}/makeNRRDParametricMap-meta.json
   TEST_DEPENDS
@@ -153,7 +153,7 @@ dcmqi_add_test(
 dcmqi_add_test(
   NAME ${MODULE_NAME}_FP_meta_roundtrip
   MODULE_NAME ${MODULE_NAME}
-  COMMAND python ${CMAKE_SOURCE_DIR}/util/comparejson.py
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/util/comparejson.py
     ${CMAKE_SOURCE_DIR}/doc/examples/pm-example-float.json
     ${MODULE_TEMP_DIR}/makeNRRDParametricMapFP-meta.json
   TEST_DEPENDS

--- a/apps/seg/Testing/CMakeLists.txt
+++ b/apps/seg/Testing/CMakeLists.txt
@@ -263,7 +263,7 @@ dcmqi_add_test(
 dcmqi_add_test(
   NAME seg_meta_roundtrip
   MODULE_NAME ${MODULE_NAME}
-  COMMAND python ${CMAKE_SOURCE_DIR}/util/comparejson.py
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/util/comparejson.py
     ${CMAKE_SOURCE_DIR}/doc/examples/seg-example.json
     ${MODULE_TEMP_DIR}/makeNRRD-meta.json
   TEST_DEPENDS
@@ -273,7 +273,7 @@ dcmqi_add_test(
 dcmqi_add_test(
   NAME multi_seg_meta_roundtrip
   MODULE_NAME ${MODULE_NAME}
-  COMMAND python ${CMAKE_SOURCE_DIR}/util/comparejson.py
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/util/comparejson.py
     ${CMAKE_SOURCE_DIR}/doc/examples/seg-example_multiple_segments.json
     ${MODULE_TEMP_DIR}/makeNRRD_multiple_segments-meta.json
         "['labelID']"

--- a/apps/sr/Testing/CMakeLists.txt
+++ b/apps/sr/Testing/CMakeLists.txt
@@ -129,7 +129,7 @@ set(MODULE_NAME tid1500)
 dcmqi_add_test(
   NAME ${MODULE_NAME}_meta_roundtrip
   MODULE_NAME ${READER_MODULE_NAME}
-  COMMAND python ${CMAKE_SOURCE_DIR}/util/comparejson.py
+  COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/util/comparejson.py
     ${EXAMPLES}/sr-tid1500-ct-liver-example.json
     ${MODULE_TEMP_DIR}/sr-tid1500-ct-liver-example.json
       "['activitySession', 'timePoint', 'imageLibrary', 'compositeContext','procedureReported']"


### PR DESCRIPTION
Use the CMake Python3 module instead of PythonInterp, which it has
replaced with the Interpreter COMPONENT.

Use Python 3 instead of Python 2, which is end-of-life.

Ensure we use ${Python3_EXECUTABLE} in the test commands.
