### PR TITLE
Bump DCMTK version to 3.6.9 and import DcmItem.

### DIFF
--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -41,13 +41,13 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/DCMTK/dcmtk.git"
+    "${EP_GIT_PROTOCOL}://github.com/michaelonken/dcmtk.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     ${proj}_GIT_TAG
-    "DCMTK-3.6.9"
+    "dcmqi_dcmtk_upgrade_369"
     QUIET
     )
 

--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -41,13 +41,13 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${proj}_GIT_REPOSITORY
-    "${EP_GIT_PROTOCOL}://github.com/commontk/DCMTK.git"
+    "${EP_GIT_PROTOCOL}://github.com/DCMTK/dcmtk.git"
     QUIET
     )
 
   ExternalProject_SetIfNotDefined(
     ${proj}_GIT_TAG
-    "ea07125078cd097245867a71d8fba8b36fd92878" # patched-DCMTK-3.6.8_20241024
+    "DCMTK-3.6.9"
     QUIET
     )
 

--- a/apps/paramaps/itkimage2paramap.cxx
+++ b/apps/paramaps/itkimage2paramap.cxx
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
     dicomImageFileList.insert(dicomImageFileList.end(), dicomFileList.begin(), dicomFileList.end());
   }
 
-  vector<DcmDataset*> dcmDatasets = helper::loadDatasets(dicomImageFileList);
+  vector<DcmItem*> dcmDatasets = helper::loadDatasets(dicomImageFileList);
 
   if(dcmDatasets.empty()){
     cerr << "ERROR: no DICOM could be loaded from the specified list/directory" << endl;

--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
   if(!helper::pathsExist(dicomImageFiles))
     return EXIT_FAILURE;
 
-  vector<DcmDataset*> dcmDatasets = helper::loadDatasets(dicomImageFiles);
+  vector<DcmItem*> dcmDatasets = helper::loadDatasets(dicomImageFiles);
 
   if(dcmDatasets.empty()){
     cerr << "Error: no DICOM could be loaded from the specified list/directory" << endl;

--- a/include/dcmqi/ConverterBase.h
+++ b/include/dcmqi/ConverterBase.h
@@ -299,7 +299,7 @@ namespace dcmqi {
 
     // AF: I could not quickly figure out how to template this function over image type - suggestions are welcomed!
     template<class ImageSourceType>
-    static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<DcmDataset*> dcmDatasets,
+    static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<DcmItem*> dcmDatasets,
                                                                                        const ImageSourceType& labelImage) {
       // Find mapping from the segmentation slice number to the derivation image
       // Assume that orientation of the segmentation is the same as the source series

--- a/include/dcmqi/Helper.h
+++ b/include/dcmqi/Helper.h
@@ -45,7 +45,7 @@ namespace dcmqi {
 
     static string getFileExtensionFromType(const string& type);
     static vector<string> getFileListRecursively(string directory);
-    static vector<DcmDataset*> loadDatasets(const vector<string>& dicomImageFiles);
+    static vector<DcmItem*> loadDatasets(const vector<string>& dicomImageFiles);
 
     static string floatToStr(float f);
     static void tokenizeString(string str, vector<string> &tokens, string delimiter);

--- a/include/dcmqi/Itk2DicomConverter.h
+++ b/include/dcmqi/Itk2DicomConverter.h
@@ -57,13 +57,13 @@ namespace dcmqi {
      *        are updated by this flag, compared to the default behavior (false). Of course, the
      *        resulting DICOM object is still valid, dimensions are consistent and lead to meaningful
      *        display.
-     * @param referencesGeometryCheck A boolean indicating whether the conversion process should attempt checking if the geometry of the referenced DICOM images is consistent with the corresponding slices of the segmentation. 
-     *        By default, this check is enabled. If disabled, all of the references will be 
+     * @param referencesGeometryCheck A boolean indicating whether the conversion process should attempt checking if the geometry of the referenced DICOM images is consistent with the corresponding slices of the segmentation.
+     *        By default, this check is enabled. If disabled, all of the references will be
      *        added in the SharedFunctionalGroupsSequence without any geometry checks.
      * @return A pointer to the resulting DICOM Segmentation object.
      */
     template<class ImageSourceType, std::enable_if_t<std::is_same<short, typename ImageSourceType::PixelType>::value, bool> = 0>
-    static DcmDataset* itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
+    static DcmDataset* itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
                           vector<itk::SmartPointer<const ImageSourceType>> segmentations,
                           const string &metaData,
                           bool skipEmptySlices=true,

--- a/include/dcmqi/ParaMapConverter.h
+++ b/include/dcmqi/ParaMapConverter.h
@@ -34,7 +34,7 @@ namespace dcmqi {
   class ParaMapConverter : public ConverterBase {
 
   public:
-    static DcmDataset* itkimage2paramap(const FloatImageType::Pointer &parametricMapImage, vector<DcmDataset*> dcmDatasets,
+    static DcmDataset* itkimage2paramap(const FloatImageType::Pointer &parametricMapImage, vector<DcmItem*> dcmDatasets,
                                         const string &metaData);
 
     static pair <FloatImageType::Pointer, string> paramap2itkimage(DcmDataset *pmapDataset);

--- a/libsrc/Helper.cpp
+++ b/libsrc/Helper.cpp
@@ -67,13 +67,13 @@ namespace dcmqi {
     return dicomImageFiles;
   }
 
-  vector<DcmDataset*> Helper::loadDatasets(const vector<string>& dicomImageFiles) {
-    vector<DcmDataset*> dcmDatasets;
+  vector<DcmItem*> Helper::loadDatasets(const vector<string>& dicomImageFiles) {
+    vector<DcmItem*> dcmDatasets;
     OFString tmp, sopInstanceUID;
     DcmFileFormat* sliceFF = new DcmFileFormat();
     for(size_t dcmFileNumber=0; dcmFileNumber<dicomImageFiles.size(); dcmFileNumber++){
       if(sliceFF->loadFile(dicomImageFiles[dcmFileNumber].c_str()).good()){
-        DcmDataset* currentDataset = sliceFF->getAndRemoveDataset();
+        DcmItem* currentDataset = sliceFF->getAndRemoveDataset();
         if(!currentDataset->tagExistsWithValue(DCM_PixelData)){
           std::cerr << "Source DICOM file does not contain PixelData, skipping: " << std::endl
              << "  >>>   " << dicomImageFiles[dcmFileNumber] << std::endl;

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -27,7 +27,7 @@ namespace dcmqi {
   // -------------------------------------------------------------------------------------
 
   template<class ImageSourceType, std::enable_if_t<std::is_same<short, typename ImageSourceType::PixelType>::value, bool>>
-  DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation(vector<DcmDataset*> dcmDatasets,
+  DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
                                                           vector<itk::SmartPointer<const ImageSourceType>> segmentations,
                                                           const string &metaData,
                                                           bool skipEmptySlices,
@@ -137,11 +137,11 @@ namespace dcmqi {
 			code_seg.CodeMeaning),"",derimgItem));
 
       OFVector<SourceImageItem*> srcimgItems;
-      OFVector<DcmDataset*> dcmDatasets_ofvector;
+      OFVector<DcmItem*> dcmDatasets_ofvector;
       for (const auto& dataset : dcmDatasets) {
         dcmDatasets_ofvector.push_back(dataset);
       }
-      derimgItem->addSourceImageItems(dcmDatasets_ofvector, 
+      derimgItem->addSourceImageItems(dcmDatasets_ofvector,
         CodeSequenceMacro(code_seg.CodeValue,code_seg.CodingSchemeDesignator, code_seg.CodeMeaning), srcimgItems, OFTrue /*skip file errors */);
 
       for(size_t src_image_cnt=0;src_image_cnt<srcimgItems.size();src_image_cnt++){
@@ -404,7 +404,7 @@ namespace dcmqi {
                 frameData[framePixelCnt] = 0;
             }
 
-            OFVector<DcmDataset*> siVector;
+            OFVector<DcmItem*> siVector;
             if(referencesGeometryCheck){
               for(size_t derImageInstanceNum=0;
                   derImageInstanceNum<slice2derimg[sliceNumber].size();
@@ -699,16 +699,16 @@ namespace dcmqi {
   }
 
   template DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation<ShortImageType>(
-      vector<DcmDataset*> dcmDatasets,
+      vector<DcmItem*> dcmDatasets,
       vector<ShortImageType::ConstPointer> segmentations,
       const string& metaData,
       bool skipEmptySlices,
       bool useLabelIDAsSegmentNumber,
       bool referencesGeometryCheck);
- 
+
   using VectorImageAdapter = itk::VectorImageToImageAdaptor<short, 3U>;
   template DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation<VectorImageAdapter>(
-      vector<DcmDataset*> dcmDatasets,
+      vector<DcmItem*> dcmDatasets,
       vector<VectorImageAdapter::ConstPointer> segmentations,
       const string& metaData,
       bool skipEmptySlices,

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 namespace dcmqi {
 
-  DcmDataset* ParaMapConverter::itkimage2paramap(const FloatImageType::Pointer &parametricMapImage, vector<DcmDataset*> dcmDatasets,
+  DcmDataset* ParaMapConverter::itkimage2paramap(const FloatImageType::Pointer &parametricMapImage, vector<DcmItem*> dcmDatasets,
                                          const string &metaData) {
 
     MinMaxCalculatorType::Pointer calculator = MinMaxCalculatorType::New();
@@ -67,7 +67,7 @@ namespace dcmqi {
 
     DPMParametricMapIOD* pMapDoc = OFget<DPMParametricMapIOD>(&obj);
 
-    DcmDataset* srcDataset = NULL;
+    DcmItem* srcDataset = NULL;
     if(dcmDatasets.size()){
       srcDataset = dcmDatasets[0];
     }
@@ -296,7 +296,7 @@ namespace dcmqi {
 
     for (unsigned long sliceNumber = 0; result.good() && (sliceNumber < inputSize[2]); sliceNumber++) {
 
-      OFVector<DcmDataset*> siVector;
+      OFVector<DcmItem*> siVector;
       for(size_t derImageInstanceNum=0;
           derImageInstanceNum<slice2derimg[sliceNumber].size();
           derImageInstanceNum++){


### PR DESCRIPTION
Bump DCMTK version to latest DCMTK release 3.6.9.

This also allows to import dataset references from DcmItem instead of DcmDataset which is easier to use when importing from memory.

Put this into a pull request to build run the tests on various platforms before merging into master.