### PR TITLE
Add segment for background if required.

### DIFF
--- a/include/dcmqi/Bin2Label.h
+++ b/include/dcmqi/Bin2Label.h
@@ -221,6 +221,17 @@ protected:
 
     OFCondition createFrameContentFG(Uint32 outputFrameNum, OFVector<OverlapUtil::LogicalFrame>::iterator logicalFrame, FGFrameContent*& frameContent);
 
+    /** Check whether any frame in the output segmentation contains pixel value 0.
+     *  If so, add a background segment with Segment Number 0 using Property Type
+     *  Code (DCM, 125040, "Background").
+     *  The alternative would be to use Pixel Padding Value which is also
+     *  foreseen for Labelmaps but is expected, for now, that the background
+     *  segment is better supported by consuming applications.
+     *
+     *  @return EC_Normal if successful or no background segment needed, error otherwise
+     */
+    OFCondition addBackgroundSegmentIfNeeded();
+
 private:
 
     // Disable copy constructor and assignment operator

--- a/include/dcmqi/Bin2Label.h
+++ b/include/dcmqi/Bin2Label.h
@@ -151,7 +151,7 @@ protected:
     static OFCondition copyCommonModules(DcmSegmentation* src, DcmSegmentation* dest);
     OFCondition createFramesWithMetadata(DcmSegmentation* src);
     OFCondition copySegments(DcmSegmentation* src, DcmSegmentation* dest);
-    OFBool checkCIELabColorsPresent();
+    OFBool ensureCIELabColorsPresent();
     OFCondition createPaletteColorLUT();
     OFCondition loadInput();
     OFCondition addSourceSegmentationToDerivationImageFG(DcmSegmentation* src, DcmSegmentation* dest);

--- a/include/dcmqi/Bin2Label.h
+++ b/include/dcmqi/Bin2Label.h
@@ -279,6 +279,33 @@ private:
             return OFTrue;
         }
 
+        /** Prepend a color entry at index 0, shifting existing entries right.
+         *  @return OFTrue on success, OFFalse on memory allocation failure.
+         */
+        OFBool prepend(Uint16 L, Uint16 a, Uint16 b)
+        {
+            size_t newSize = m_numSegments + 1;
+            Uint16* newL = new Uint16[newSize];
+            Uint16* newA = new Uint16[newSize];
+            Uint16* newB = new Uint16[newSize];
+            if (!newL || !newA || !newB)
+            {
+                delete[] newL; delete[] newA; delete[] newB;
+                return OFFalse;
+            }
+            newL[0] = L; newA[0] = a; newB[0] = b;
+            for (size_t i = 0; i < m_numSegments; i++)
+            {
+                newL[i + 1] = m_L[i];
+                newA[i + 1] = m_a[i];
+                newB[i + 1] = m_b[i];
+            }
+            delete[] m_L; delete[] m_a; delete[] m_b;
+            m_L = newL; m_a = newA; m_b = newB;
+            m_numSegments = newSize;
+            return OFTrue;
+        }
+
         ~CIELabColor()
         {
             clear();

--- a/libsrc/Bin2Label.cpp
+++ b/libsrc/Bin2Label.cpp
@@ -217,6 +217,13 @@ OFCondition DcmBinToLabelConverter::convert(const ConversionFlags& convFlags)
         result = createFramesWithMetadata(m_inputSeg);
     }
 
+    // Add background segment (number 0) if any pixel value 0 exists in the output frames
+    // (required by Sup 243, Section C.8.20.2.3.3)
+    if (result.good())
+    {
+        result = addBackgroundSegmentIfNeeded();
+    }
+
     // Create palette color lookup table if necessary
     if (result.good() && (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE))
     {
@@ -794,6 +801,69 @@ OFCondition DcmBinToLabelConverter::createPaletteColorLUT()
     if (result.good())
     {
         DCMSEG_DEBUG("Successfully created palette color lookup table and ICC profile for output segmentation");
+    }
+    return result;
+}
+
+
+OFCondition DcmBinToLabelConverter::addBackgroundSegmentIfNeeded()
+{
+    if (!m_outputSeg)
+        return EC_IllegalParameter;
+
+    // Check whether any frame contains pixel value 0
+    OFBool hasZeroPixel = OFFalse;
+    size_t numFrames = m_outputSeg->getNumberOfFrames();
+    for (size_t f = 0; f < numFrames && !hasZeroPixel; f++)
+    {
+        const DcmIODTypes::FrameBase* frame = m_outputSeg->getFrame(f);
+        if (frame == NULL)
+            continue;
+        const size_t numPixels = frame->getLengthInBytes() / frame->bytesPerPixel();
+        for (size_t p = 0; p < numPixels; p++)
+        {
+            if (frame->bytesPerPixel() == 1)
+            {
+                Uint8 val = 0;
+                frame->getUint8AtIndex(val, p);
+                if (val == 0) { hasZeroPixel = OFTrue; break; }
+            }
+            else
+            {
+                Uint16 val = 0;
+                frame->getUint16AtIndex(val, p);
+                if (val == 0) { hasZeroPixel = OFTrue; break; }
+            }
+        }
+    }
+
+    if (!hasZeroPixel)
+        return EC_Normal;
+
+    // Create background segment with Segment Number 0
+    DCMSEG_DEBUG("Pixel value 0 found in output frames, adding background segment (number 0)");
+    DcmSegment* bgSeg = NULL;
+    CodeSequenceMacro bgCode("125040", "DCM", "Background");
+    OFCondition result = DcmSegment::create(bgSeg,
+                                            "Background",
+                                            bgCode,  /* category */
+                                            bgCode,  /* type */
+                                            DcmSegTypes::SAT_AUTOMATIC,
+                                            "dcmqi");
+    if (result.good() && bgSeg)
+    {
+        Uint16 segNum = 0;
+        result = m_outputSeg->addSegment(bgSeg, segNum);
+        if (result.bad())
+        {
+            DCMSEG_ERROR("Failed to add background segment: " << result.text());
+            delete bgSeg;
+        }
+    }
+    else
+    {
+        DCMSEG_ERROR("Failed to create background segment: " << result.text());
+        delete bgSeg;
     }
     return result;
 }

--- a/libsrc/Bin2Label.cpp
+++ b/libsrc/Bin2Label.cpp
@@ -258,13 +258,6 @@ OFCondition DcmBinToLabelConverter::copySegments(DcmSegmentation* src, DcmSegmen
             DcmSegment* clonedSegment = srcSegment->second->clone(dest);
             if (clonedSegment)
             {
-                // If we write palette color model, we need to make sure that the
-                // Recommended Display CIELab Value Macro will not be written
-                // for each segment, as this is not allowed in labelmaps with PALETTE color model.
-                if (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE)
-                {
-                    clonedSegment->getIODRules()->deleteRule(DCM_RecommendedDisplayCIELabValue);
-                }
                 Uint16 segNumber = srcSegment->first;
                 result = dest->addSegment(clonedSegment, segNumber);
                 if (result.bad())
@@ -703,13 +696,16 @@ OFCondition DcmBinToLabelConverter::createPaletteColorLUT()
     DCMSEG_DEBUG("Creating palette color lookup table for output segmentation");
     IODPaletteColorLUTModule& lutModule = m_outputSeg->getPaletteColorLUT();
     OFCondition result;
-    // Create LUT from CIELab colors stored during segment copying
+    // Create LUT from CIELab colors stored during segment copying.
+    // If a background segment (number 0) was added, the LUT starts at pixel
+    // value 0 (black for background); otherwise it starts at pixel value 1.
     size_t numSegments = m_outputSeg->getNumberOfSegments();
+    Uint16 firstPixelMapped = (m_outputSeg->getSegment(0) != NULL) ? 0 : 1;
     if (m_cielabColors.m_numSegments == numSegments)
     {
-        result = lutModule.setRedPaletteColorLookupTableDescriptor(numSegments, 1, (m_use16Bit ? 16 : 8));
-        if (result.good()) result = lutModule.setGreenPaletteColorLookupTableDescriptor(numSegments, 1, (m_use16Bit ? 16 : 8));
-        if (result.good()) result = lutModule.setBluePaletteColorLookupTableDescriptor(numSegments, 1, (m_use16Bit ? 16 : 8));
+        result = lutModule.setRedPaletteColorLookupTableDescriptor(numSegments, firstPixelMapped, (m_use16Bit ? 16 : 8));
+        if (result.good()) result = lutModule.setGreenPaletteColorLookupTableDescriptor(numSegments, firstPixelMapped, (m_use16Bit ? 16 : 8));
+        if (result.good()) result = lutModule.setBluePaletteColorLookupTableDescriptor(numSegments, firstPixelMapped, (m_use16Bit ? 16 : 8));
         if (result.good())
         {
             Uint16 maxRange = (m_use16Bit ? 65535 : 255);
@@ -852,12 +848,32 @@ OFCondition DcmBinToLabelConverter::addBackgroundSegmentIfNeeded()
                                             "dcmqi");
     if (result.good() && bgSeg)
     {
+        // Set Recommended Display CIELab Value to black
+        // (CIELab L*=0, a*=0, b*=0 → DICOM 0, 32768, 32768)
+        result = bgSeg->setRecommendedDisplayCIELabValue(0, 32768, 32768);
+        if (result.bad())
+        {
+            DCMSEG_ERROR("Failed to set CIELab color for background segment: " << result.text());
+            delete bgSeg;
+            return result;
+        }
         Uint16 segNum = 0;
         result = m_outputSeg->addSegment(bgSeg, segNum);
         if (result.bad())
         {
             DCMSEG_ERROR("Failed to add background segment: " << result.text());
             delete bgSeg;
+        }
+        else if (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE)
+        {
+            // In PALETTE mode the per-segment CIELab macro must not be written,
+            // but the color must still be present in the palette LUT so pixel
+            // value 0 maps to black.
+            if (!m_cielabColors.prepend(0, 32768, 32768))
+            {
+                DCMSEG_ERROR("Failed to prepend background color for palette LUT");
+                result = EC_MemoryExhausted;
+            }
         }
     }
     else

--- a/libsrc/Bin2Label.cpp
+++ b/libsrc/Bin2Label.cpp
@@ -114,7 +114,7 @@ OFCondition DcmBinToLabelConverter::convert(const ConversionFlags& convFlags)
     // if they are not found, random colors are generated if forcePalette is set.
     // The call only fails (if not on hard errors) if forcePalette is not set and CIELab
     // colors are missing.
-    if ( (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE) && !checkCIELabColorsPresent() )
+    if ( (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE) && !ensureCIELabColorsPresent() )
     {
         DCMSEG_ERROR("Cannot convert to PALETTE color model since not all segments contain Recommended Display CIELab Value Macro");
         return SG_EC_CannotConvertMissingCIELab;
@@ -258,6 +258,7 @@ OFCondition DcmBinToLabelConverter::copySegments(DcmSegmentation* src, DcmSegmen
             DcmSegment* clonedSegment = srcSegment->second->clone(dest);
             if (clonedSegment)
             {
+                clonedSegment->getIODRules()->deleteRule(DCM_RecommendedDisplayCIELabValue);
                 Uint16 segNumber = srcSegment->first;
                 result = dest->addSegment(clonedSegment, segNumber);
                 if (result.bad())
@@ -266,6 +267,7 @@ OFCondition DcmBinToLabelConverter::copySegments(DcmSegmentation* src, DcmSegmen
                     delete clonedSegment;
                     break;
                 }
+
             }
             else
             {
@@ -543,7 +545,7 @@ E_TransferSyntax DcmBinToLabelConverter::getInputTransferSyntax() const
 }
 
 
-OFBool DcmBinToLabelConverter::checkCIELabColorsPresent()
+OFBool DcmBinToLabelConverter::ensureCIELabColorsPresent()
 {
     size_t numSegments = m_inputSeg->getNumberOfSegments();
     OFBool result = OFTrue;
@@ -848,14 +850,17 @@ OFCondition DcmBinToLabelConverter::addBackgroundSegmentIfNeeded()
                                             "dcmqi");
     if (result.good() && bgSeg)
     {
-        // Set Recommended Display CIELab Value to black
+        // Set Recommended Display CIELab Value to black if not in PALETTE mode, as required by Sup 243
         // (CIELab L*=0, a*=0, b*=0 → DICOM 0, 32768, 32768)
-        result = bgSeg->setRecommendedDisplayCIELabValue(0, 32768, 32768);
-        if (result.bad())
+        if (m_convFlags.m_outputColorModel != DcmSegTypes::SLCM_PALETTE)
         {
-            DCMSEG_ERROR("Failed to set CIELab color for background segment: " << result.text());
-            delete bgSeg;
-            return result;
+            result = bgSeg->setRecommendedDisplayCIELabValue(0, 32768, 32768);
+            if (result.bad())
+            {
+                DCMSEG_ERROR("Failed to set CIELab color for background segment: " << result.text());
+                delete bgSeg;
+                return result;
+            }
         }
         Uint16 segNum = 0;
         result = m_outputSeg->addSegment(bgSeg, segNum);

--- a/libsrc/Dicom2ItkConverterLabel.cpp
+++ b/libsrc/Dicom2ItkConverterLabel.cpp
@@ -41,15 +41,15 @@ OFCondition Dicom2ItkConverterLabel::dcmSegmentation2itkimage(const bool mergeSe
     // while the ITK images are made accessible through the begin()/next() iterators only.
     // createMetaInfo() requires groups of non-overlapping segments, but for labelmaps we know that
     // all segments are non-overlapping, so we can just create one group with all segments in it.
-    size_t numSegs = m_segDoc->getNumberOfSegments();
     OFVector<Uint32> segs;
-    for (size_t i = 1; i <= numSegs; ++i)
+    OFMap<Uint16, DcmSegment*>::const_iterator segIt = m_segDoc->getSegments().begin();
+    while (segIt != m_segDoc->getSegments().end())
     {
-        segs.push_back(i);
+        segs.push_back(segIt->first);
+        ++segIt;
     }
     m_segmentGroups.clear();
     m_segmentGroups.push_back(segs);
-    std::cout << "All " << numSegs << " segments will be put into one group for the metadata creation" << std::endl;
 
     // Now we are ready to create the meta information.
     // It is available directly after this call in m_metaInfo.


### PR DESCRIPTION
When converting DICOM binary segmentations to DICOM labelmaps, some pixels are likely not covered from any of the the segments. Since the pixels are initially set to 0, all non-covered pixels will be "background" and must be marked as such.

This is done by scanning all pixels after conversion and if a 0 is found, a segment using codes for denoting "background" will be inserted automatically.

The alternative would be to set Pixel Padding Value. This could be introduced as an option later, but for now the background segment seems to be better supported by consuming applications.