### PR TITLE
Add direct ITK to DICOM Labelmap conversion

### DIFF
--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -47,10 +47,12 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
 
   ExternalProject_SetIfNotDefined(
     ${proj}_GIT_TAG
-    # DCMTK 3.7.0 ++ (December 2025).
+    # DCMTK 3.7.0 ++ (May 8th, 2026).
     # This is DCMTK version with some extra fixes on segmentations and parametric maps,
-    # which have been released a few days after DCMTK 3.7.0.
-    "3e85b37444107e93550167c2284e64b4881b0fcb"
+    # which have been released a few days after DCMTK 3.7.0, as well as performance
+    # optimizations for segmentation/parametric map. It also includes a simpler
+    # mechanism to add external modules to the DCMTK CMake build.
+    "2dd54ca1c28100b820ccf1383a0948e889246f96"
     QUIET
     )
 

--- a/apps/seg/Testing/CMakeLists.txt
+++ b/apps/seg/Testing/CMakeLists.txt
@@ -30,6 +30,68 @@ dcmqi_add_test(
     --outputDICOM ${MODULE_TEMP_DIR}/liver.dcm
   )
 
+dcmqi_add_test(
+  NAME ${itk2dcm}_makeSEG_labelmap
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:${itk2dcm}>
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/seg-example.json
+    --inputImageList ${BASELINE}/liver_seg.nrrd
+    --inputDICOMDirectory ${DICOM_DIR}
+    --outputDICOM ${MODULE_TEMP_DIR}/liver-labelmap-direct.dcm
+    --segmentationType labelmap
+  )
+
+# Multi-segment labelmap from two non-overlapping single-segment ITK inputs.
+# Verifies that segment numbering for foreground starts at 1 (regression guard
+# for the bug where the first foreground segment got number 0 and collided
+# with the implicit background pixel value).
+dcmqi_add_test(
+  NAME ${itk2dcm}_makeSEG_labelmap_multi
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:${itk2dcm}>
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/seg-example_liver_spine.json
+    --inputImageList ${BASELINE}/liver_seg.nrrd,${BASELINE}/spine_seg.nrrd
+    --inputDICOMList ${DICOM_DIR}/01.dcm,${DICOM_DIR}/02.dcm,${DICOM_DIR}/03.dcm
+    --outputDICOM ${MODULE_TEMP_DIR}/liver_spine-labelmap.dcm
+    --segmentationType labelmap
+  )
+
+# Same as above but exercises --useLabelIDAsSegmentNumber together with
+# --segmentationType labelmap.
+dcmqi_add_test(
+  NAME ${itk2dcm}_makeSEG_labelmap_multi_labelID
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:${itk2dcm}>
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/seg-example_liver_spine.json
+    --inputImageList ${BASELINE}/liver_seg.nrrd,${BASELINE}/spine_seg.nrrd
+    --inputDICOMList ${DICOM_DIR}/01.dcm,${DICOM_DIR}/02.dcm,${DICOM_DIR}/03.dcm
+    --outputDICOM ${MODULE_TEMP_DIR}/liver_spine-labelmap-labelID.dcm
+    --segmentationType labelmap
+    --useLabelIDAsSegmentNumber
+  )
+
+# Overlap rejection: liver+spine+heart input. Of the three segments only
+# liver and heart actually overlap (522 pixels, verified by pixel-level
+# intersection of the input NRRDs); spine does not overlap with either.
+# In labelmap mode the converter must abort because labelmaps cannot
+# represent overlapping segments — each pixel value can encode only one
+# segment number. The expected error is
+#   "Cannot write labelmap SEG due to overlapping segments at slice ..."
+# Reuses the existing 3-segment metadata so no new JSON file is needed.
+# This is the ITK->labelmap counterpart of partial_overlaps_to_labelmap,
+# which exercises the same rejection in the DICOM->labelmap path.
+dcmqi_add_test(
+  NAME ${itk2dcm}_makeSEG_labelmap_overlap
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:${itk2dcm}>
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/seg-example_multiple_segments.json
+    --inputImageList ${BASELINE}/liver_seg.nrrd,${BASELINE}/spine_seg.nrrd,${BASELINE}/heart_seg.nrrd
+    --inputDICOMList ${DICOM_DIR}/01.dcm,${DICOM_DIR}/02.dcm,${DICOM_DIR}/03.dcm
+    --outputDICOM ${MODULE_TEMP_DIR}/liver_spine_heart-labelmap.dcm
+    --segmentationType labelmap
+  )
+set_tests_properties(${itk2dcm}_makeSEG_labelmap_overlap PROPERTIES WILL_FAIL TRUE)
+
 
 # ------------------------------------------------------------------------------
 
@@ -115,6 +177,16 @@ if(EXISTS ${DCIODVFY_EXECUTABLE})
       TEST_DEPENDS
         ${itk2dcm}_makeSEG_multiple_segment_files_reordered
     )
+    # Note: dciodvfy is intentionally not run on the labelmap outputs produced
+    # by ${itk2dcm}_makeSEG_labelmap{,_multi,_multi_labelID} or by the
+    # bin2labelsegimage labelmap producers. All labelmap segmentations emitted
+    # by dcmqi today fail dciodvfy with
+    #   Error - Missing attribute Type 2C Conditional Element=<PatientOrientation>
+    #           Module=<GeneralImage>
+    # which is a pre-existing compliance gap shared by every labelmap-emitting
+    # path (Itk2DicomConverter and Bin2Label). Once Patient Orientation is
+    # populated for labelmap output, add dciodvfy invocations for
+    # liver-labelmap-direct.dcm and liver_spine-labelmap.dcm here.
 else()
   message(STATUS "Skipping test '${itk2dcm}_dciodvfy': dciodvfy executable not found")
 endif()
@@ -145,6 +217,39 @@ dcmqi_add_test(
     --prefix makeNRRD
   TEST_DEPENDS
     ${itk2dcm}_makeSEG
+  )
+
+dcmqi_add_test(
+  NAME ${dcm2itk}_makeNRRD_from_labelmap_direct
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:${dcm2itk}Test>
+    --compare ${BASELINE}/liver_seg.nrrd
+    ${MODULE_TEMP_DIR}/makeNRRD_labelmap_direct-1.nrrd
+    ${dcm2itk}Test
+    --inputDICOM ${MODULE_TEMP_DIR}/liver-labelmap-direct.dcm
+    --outputDirectory ${MODULE_TEMP_DIR}
+    --outputType nrrd
+    --prefix makeNRRD_labelmap_direct
+  TEST_DEPENDS
+    ${itk2dcm}_makeSEG_labelmap
+  )
+
+# Roundtrip: multi-segment labelmap -> NRRD, compared against the merged
+# liver+spine baseline (two non-overlapping segments collapse into a single
+# output ITK image with labels 0/1/2).
+dcmqi_add_test(
+  NAME ${dcm2itk}_makeNRRD_from_labelmap_multi
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:${dcm2itk}Test>
+    --compare ${BASELINE}/liver_spine_seg.nrrd
+    ${MODULE_TEMP_DIR}/makeNRRD_labelmap_multi-1.nrrd
+    ${dcm2itk}Test
+    --inputDICOM ${MODULE_TEMP_DIR}/liver_spine-labelmap.dcm
+    --outputDirectory ${MODULE_TEMP_DIR}
+    --outputType nrrd
+    --prefix makeNRRD_labelmap_multi
+  TEST_DEPENDS
+    ${itk2dcm}_makeSEG_labelmap_multi
   )
 
 dcmqi_add_test(

--- a/apps/seg/itkimage2segimage.cxx
+++ b/apps/seg/itkimage2segimage.cxx
@@ -89,6 +89,16 @@ int main(int argc, char *argv[])
     }
   }
 
+  bool outputLabelMap = false;
+  if (segmentationType == "binary")
+    outputLabelMap = false;
+  else if (segmentationType == "labelmap")
+    outputLabelMap = true;
+  else {
+    cerr << "Error: --segmentationType must be either 'binary' or 'labelmap'" << endl;
+    return EXIT_FAILURE;
+  }
+
   if(metaRoot.isMember("segmentAttributesFileMapping")){
     if(metaRoot["segmentAttributesFileMapping"].size() != metaRoot["segmentAttributes"].size()){
       cerr << "Number of files in segmentAttributesFileMapping should match the number of entries in segmentAttributes!" << endl;
@@ -128,7 +138,8 @@ int main(int argc, char *argv[])
                                                                              skipEmptySlices,
                                                                              useLabelIDAsSegmentNumber,
                                                                              referencesGeometryCheck,
-                                                                             !noDicomValueChecks);
+                                                                             !noDicomValueChecks,
+                                                                             outputLabelMap);
 
     if (result == NULL){
       std::cerr << "ERROR: Conversion failed." << std::endl;

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -101,6 +101,17 @@
     </boolean>
 
     <string-enumeration>
+      <name>segmentationType</name>
+      <label>DICOM Segmentation Type</label>
+      <channel>output</channel>
+      <longflag>segmentationType</longflag>
+      <default>binary</default>
+      <element>binary</element>
+      <element>labelmap</element>
+      <description>Type of DICOM SEG object to create. Use binary for classic 1-bit segments (default), or labelmap for direct labelmap SEG output.</description>
+    </string-enumeration>
+
+    <string-enumeration>
       <name>compress</name>
       <label>Compress PixelData</label>
       <channel>input</channel>

--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -74,21 +74,22 @@
     </integer>
 
     <boolean>
+      <name>noDicomValueChecks</name>
+      <label>No DICOM Value Check</label>
+      <channel>input</channel>
+      <longflag>noDicomValueChecks</longflag>
+      <default>false</default>
+      <description>Bypass DICOM value checks when writing segmentation file. This can be useful for
+        debugging or when taking over attributes from non-compliant DICOM image files.</description>
+    </boolean>
+
+    <boolean>
       <name>useLabelIDAsSegmentNumber</name>
       <label>Use label ID as Segment Number</label>
       <channel>output</channel>
       <longflag>useLabelIDAsSegmentNumber</longflag>
       <default>false</default>
       <description>Use label IDs from ITK images as Segment Numbers in DICOM. Only works if label IDs are consecutively numbered starting from 1, otherwise conversion will fail.</description>
-    </boolean>
-
-    <boolean>
-      <name>noDicomValueChecks</name>
-      <label>No DICOM Value Check</label>
-      <channel>output</channel>
-      <longflag>noDicomValueChecks</longflag>
-      <default>false</default>
-      <description>Bypass DICOM value checks when writing segmentation file. This can be useful for debugging or when taking over attributes from non-compliant DICOM image files.</description>
     </boolean>
 
     <boolean>

--- a/doc/examples/seg-example_liver_spine.json
+++ b/doc/examples/seg-example_liver_spine.json
@@ -1,0 +1,61 @@
+{
+  "@schema": "https://raw.githubusercontent.com/qiicr/dcmqi/master/doc/schemas/seg-schema.json#",
+
+  "ContentCreatorName": "Doe^John",
+  "ClinicalTrialSeriesID": "Session1",
+  "ClinicalTrialTimePointID": "1",
+  "ClinicalTrialCoordinatingCenterName": "BWH",
+  "SeriesDescription": "Segmentation",
+  "SeriesNumber": "300",
+  "InstanceNumber": "1",
+
+  "segmentAttributes": [
+    [
+      {
+        "labelID": 1,
+        "SegmentDescription": "Liver Segmentation",
+        "SegmentLabel": "Liver",
+        "SegmentedPropertyCategoryCodeSequence": {
+          "CodeValue": "85756007",
+          "CodingSchemeDesignator": "SCT",
+          "CodeMeaning": "Tissue"
+        },
+        "SegmentedPropertyTypeCodeSequence": {
+          "CodeValue": "10200004",
+          "CodingSchemeDesignator": "SCT",
+          "CodeMeaning": "Liver"
+        },
+        "SegmentAlgorithmType": "SEMIAUTOMATIC",
+        "SegmentAlgorithmName": "SlicerEditor",
+        "recommendedDisplayRGBValue": [
+          220,
+          129,
+          101
+        ]
+      }
+    ],
+    [
+      {
+        "labelID": 2,
+        "SegmentDescription": "Anatomical Structure",
+        "SegmentLabel": "Thoracic spine",
+        "SegmentedPropertyTypeCodeSequence": {
+          "CodeMeaning": "Thoracic spine",
+          "CodingSchemeDesignator": "SCT",
+          "CodeValue": "122495006"
+        },
+        "SegmentedPropertyCategoryCodeSequence": {
+          "CodeMeaning": "Anatomical Structure",
+          "CodingSchemeDesignator": "SCT",
+          "CodeValue": "123037004"
+        },
+        "SegmentAlgorithmType": "MANUAL",
+        "recommendedDisplayRGBValue": [
+          226,
+          202,
+          134
+        ]
+      }
+    ]
+  ]
+}

--- a/include/dcmqi/Bin2Label.h
+++ b/include/dcmqi/Bin2Label.h
@@ -221,6 +221,17 @@ protected:
 
     OFCondition createFrameContentFG(Uint32 outputFrameNum, OFVector<OverlapUtil::LogicalFrame>::iterator logicalFrame, FGFrameContent*& frameContent);
 
+    /** Check whether any frame in the output segmentation contains pixel value 0.
+     *  If so, add a background segment with Segment Number 0 using Property Type
+     *  Code (DCM, 125040, "Background").
+     *  The alternative would be to use Pixel Padding Value which is also
+     *  foreseen for Labelmaps but is expected, for now, that the background
+     *  segment is better supported by consuming applications.
+     *
+     *  @return EC_Normal if successful or no background segment needed, error otherwise
+     */
+    OFCondition addBackgroundSegmentIfNeeded();
+
 private:
 
     // Disable copy constructor and assignment operator

--- a/include/dcmqi/Bin2Label.h
+++ b/include/dcmqi/Bin2Label.h
@@ -151,7 +151,7 @@ protected:
     static OFCondition copyCommonModules(DcmSegmentation* src, DcmSegmentation* dest);
     OFCondition createFramesWithMetadata(DcmSegmentation* src);
     OFCondition copySegments(DcmSegmentation* src, DcmSegmentation* dest);
-    OFBool checkCIELabColorsPresent();
+    OFBool ensureCIELabColorsPresent();
     OFCondition createPaletteColorLUT();
     OFCondition loadInput();
     OFCondition addSourceSegmentationToDerivationImageFG(DcmSegmentation* src, DcmSegmentation* dest);

--- a/include/dcmqi/Bin2Label.h
+++ b/include/dcmqi/Bin2Label.h
@@ -151,6 +151,21 @@ protected:
     static OFCondition copyCommonModules(DcmSegmentation* src, DcmSegmentation* dest);
     OFCondition createFramesWithMetadata(DcmSegmentation* src);
     OFCondition copySegments(DcmSegmentation* src, DcmSegmentation* dest);
+
+    /** Collect Recommended Display CIELab Value of each input segment into
+     *  m_cielabColors so it can later be used to build the Palette Color LUT.
+     *  Only relevant when the conversion target color model is PALETTE; for
+     *  MONOCHROME2 output the call is a no-op and returns OFTrue.
+     *
+     *  In PALETTE mode every input segment must either provide a Recommended
+     *  Display CIELab Value Macro or m_convFlags.m_forcePalette must be set so
+     *  that random colors are generated for missing segments. Otherwise this
+     *  method clears m_cielabColors and returns OFFalse.
+     *
+     *  @return OFTrue on success or no-op (non-PALETTE mode), OFFalse if a
+     *          required color is missing and m_forcePalette is not set, or on
+     *          memory allocation failure.
+     */
     OFBool ensureCIELabColorsPresent();
     OFCondition createPaletteColorLUT();
     OFCondition loadInput();
@@ -228,6 +243,13 @@ protected:
      *  foreseen for Labelmaps but is expected, for now, that the background
      *  segment is better supported by consuming applications.
      *
+     *  Implementation delegates the frame scan and segment creation to
+     *  ConverterBase::addBackgroundSegmentIfNeeded(); this wrapper additionally
+     *  prepends the matching black entry to m_cielabColors when the output
+     *  color model is PALETTE so that pixel value 0 maps to black in the
+     *  Palette Color LUT (the per-segment CIELab macro is not written in
+     *  PALETTE mode, per Sup 243).
+     *
      *  @return EC_Normal if successful or no background segment needed, error otherwise
      */
     OFCondition addBackgroundSegmentIfNeeded();
@@ -280,6 +302,14 @@ private:
         }
 
         /** Prepend a color entry at index 0, shifting existing entries right.
+         *  After this call m_numSegments is incremented by 1 and the values
+         *  (L, a, b) occupy index 0; previous index i is now at i+1. Used to
+         *  align the Palette Color LUT with a newly added background segment
+         *  (Segment Number 0) so that pixel value 0 maps to the prepended
+         *  color in the LUT.
+         *  @param  L  L* component, DICOM-encoded (0..65535 maps to 0..100).
+         *  @param  a  a* component, DICOM-encoded (0..65535 maps to -128..127).
+         *  @param  b  b* component, DICOM-encoded (0..65535 maps to -128..127).
          *  @return OFTrue on success, OFFalse on memory allocation failure.
          */
         OFBool prepend(Uint16 L, Uint16 a, Uint16 b)

--- a/include/dcmqi/Bin2Label.h
+++ b/include/dcmqi/Bin2Label.h
@@ -279,6 +279,33 @@ private:
             return OFTrue;
         }
 
+        /** Prepend a color entry at index 0, shifting existing entries right.
+         *  @return OFTrue on success, OFFalse on memory allocation failure.
+         */
+        OFBool prepend(Uint16 L, Uint16 a, Uint16 b)
+        {
+            size_t newSize = m_numSegments + 1;
+            Uint16* newL = new Uint16[newSize];
+            Uint16* newA = new Uint16[newSize];
+            Uint16* newB = new Uint16[newSize];
+            if (!newL || !newA || !newB)
+            {
+                delete[] newL; delete[] newA; delete[] newB;
+                return OFFalse;
+            }
+            newL[0] = L; newA[0] = a; newB[0] = b;
+            for (size_t i = 0; i < m_numSegments; i++)
+            {
+                newL[i + 1] = m_L[i];
+                newA[i + 1] = m_a[i];
+                newB[i + 1] = m_b[i];
+            }
+            delete[] m_L; delete[] m_a; delete[] m_b;
+            m_L = newL; m_a = newA; m_b = newB;
+            m_numSegments = newSize;
+            return OFTrue;
+        }
+
         ~CIELabColor()
         {
             clear();

--- a/include/dcmqi/ConverterBase.h
+++ b/include/dcmqi/ConverterBase.h
@@ -46,6 +46,45 @@ namespace dcmqi {
 
   class ConverterBase {
 
+  public:
+
+    /** Scan all frames of a labelmap segmentation document for any pixel value
+     *  of 0. If at least one such pixel is found, create and add a background
+     *  segment with Segment Number 0 using Property Type Code
+     *  (DCM, 125040, "Background"). Per Sup 243 every pixel value used in a
+     *  labelmap segmentation must have a corresponding Segment Sequence item;
+     *  this helper ensures that requirement is met for the implicit zero
+     *  background that ITK-style and binary-derived inputs typically produce.
+     *
+     *  If no zero pixel is found this is a no-op and EC_Normal is returned;
+     *  in that case *bgAdded (if provided) remains false. *bgAdded is also
+     *  reset to false on entry so callers do not need to pre-initialize it.
+     *
+     *  @param  segdoc          The segmentation document to add the background
+     *                          segment to. Must be a labelmap segmentation
+     *                          previously created by
+     *                          DcmSegmentation::createLabelmapSegmentation().
+     *                          Must not be NULL.
+     *  @param  setCIELabValue  If true, set the Recommended Display CIELab
+     *                          Value Macro on the background segment to black
+     *                          (DICOM-encoded 0, 32768, 32768). Pass false for
+     *                          PALETTE color model where the per-segment
+     *                          CIELab macro must not be written; the caller
+     *                          is then responsible for ensuring the Palette
+     *                          Color LUT entry for pixel value 0 is set.
+     *  @param  bgAdded         Optional out-parameter. If non-null, set to
+     *                          true iff a background segment was actually
+     *                          added (i.e. a zero pixel was present and
+     *                          DcmSegmentation::addSegment() succeeded).
+     *  @return EC_Normal on success (segment added) or no-op (no zero pixel),
+     *          EC_IllegalParameter if segdoc is NULL, otherwise the error
+     *          condition from DcmSegment::create() / addSegment() /
+     *          setRecommendedDisplayCIELabValue().
+     */
+    static OFCondition addBackgroundSegmentIfNeeded(DcmSegmentation* segdoc,
+                                                     bool setCIELabValue = true,
+                                                     bool* bgAdded = nullptr);
+
   protected:
     static IODGeneralEquipmentModule::EquipmentInfo getEquipmentInfo();
     static IODEnhGeneralEquipmentModule::EquipmentInfo getEnhEquipmentInfo();

--- a/include/dcmqi/Itk2DicomConverter.h
+++ b/include/dcmqi/Itk2DicomConverter.h
@@ -66,6 +66,27 @@ namespace dcmqi {
      *       will not fail if some of the DICOM attributes have invalid values
      *       (e.g., VR of Patients'Name is violated, wrong value multiplicity, etc.).
      *       However, the resulting DICOM object may not be compliant with the DICOM standard in this case.
+     * @param outputLabelMap If true, create a DICOM Labelmap Segmentation object
+     *       (SOP Class UID 1.2.840.10008.5.1.4.1.1.66.7, per Sup 243) directly
+     *       instead of a binary DICOM Segmentation object. Behavioral
+     *       differences when set to true:
+     *       - Output uses MONOCHROME2 photometric interpretation. Bit depth is
+     *         8-bit if the total number of metadata segments is <= 255, else
+     *         16-bit.
+     *       - Frames are organized via a Stack ID / In-Stack Position Number
+     *         dimension index instead of Referenced Segment Number / Image
+     *         Position (Patient).
+     *       - Each pixel value is the segment number of the segment present
+     *         at that location. Foreground segment numbers are assigned 1..N
+     *         (or taken from labelIDs if useLabelIDAsSegmentNumber is true);
+     *         pixel value 0 represents the absence of any foreground segment.
+     *       - If any frame contains pixel value 0 a Background segment with
+     *         Segment Number 0 (Property Type DCM 125040) is added
+     *         automatically so that every pixel value is covered by a Segment
+     *         Sequence item, as required by Sup 243.
+     *       - Segments must not overlap: if two foreground segments map to the
+     *         same pixel location with different segment numbers the
+     *         conversion fails (NULL is returned).
      * @return A pointer to the resulting DICOM Segmentation object.
      */
     template<class ImageSourceType, std::enable_if_t<std::is_same<short, typename ImageSourceType::PixelType>::value, bool> = 0>
@@ -75,7 +96,8 @@ namespace dcmqi {
                           bool skipEmptySlices=true,
                           bool useLabelIDAsSegmentNumber=false,
                           bool referencesGeometryCheck=true,
-                          bool doDicomValueChecks=true);
+                          bool doDicomValueChecks=true,
+                          bool outputLabelMap=false);
 
   protected:
 

--- a/libsrc/Bin2Label.cpp
+++ b/libsrc/Bin2Label.cpp
@@ -217,6 +217,13 @@ OFCondition DcmBinToLabelConverter::convert(const ConversionFlags& convFlags)
         result = createFramesWithMetadata(m_inputSeg);
     }
 
+    // Add background segment (number 0) if any pixel value 0 exists in the output frames
+    // (required by Sup 243, Section C.8.20.2.3.3)
+    if (result.good())
+    {
+        result = addBackgroundSegmentIfNeeded();
+    }
+
     // Create palette color lookup table if necessary
     if (result.good() && (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE))
     {
@@ -794,6 +801,69 @@ OFCondition DcmBinToLabelConverter::createPaletteColorLUT()
     if (result.good())
     {
         DCMSEG_DEBUG("Successfully created palette color lookup table and ICC profile for output segmentation");
+    }
+    return result;
+}
+
+
+OFCondition DcmBinToLabelConverter::addBackgroundSegmentIfNeeded()
+{
+    if (!m_outputSeg)
+        return EC_IllegalParameter;
+
+    // Check whether any frame contains pixel value 0
+    OFBool hasZeroPixel = OFFalse;
+    size_t numFrames = m_outputSeg->getNumberOfFrames();
+    for (size_t f = 0; f < numFrames && !hasZeroPixel; f++)
+    {
+        const DcmIODTypes::FrameBase* frame = m_outputSeg->getFrame(f);
+        if (frame == NULL)
+            continue;
+        const size_t numPixels = frame->getLengthInBytes() / frame->bytesPerPixel();
+        for (size_t p = 0; p < numPixels; p++)
+        {
+            if (frame->bytesPerPixel() == 1)
+            {
+                Uint8 val = 0;
+                frame->getUint8AtIndex(val, p);
+                if (val == 0) { hasZeroPixel = OFTrue; break; }
+            }
+            else
+            {
+                Uint16 val = 0;
+                frame->getUint16AtIndex(val, p);
+                if (val == 0) { hasZeroPixel = OFTrue; break; }
+            }
+        }
+    }
+
+    if (!hasZeroPixel)
+        return EC_Normal;
+
+    // Create background segment with Segment Number 0
+    DCMSEG_DEBUG("Pixel value 0 found in output frames, adding background segment (number 0)");
+    DcmSegment* bgSeg = NULL;
+    CodeSequenceMacro bgCode("125040", "DCM", "Background");
+    OFCondition result = DcmSegment::create(bgSeg,
+                                            "Background",
+                                            bgCode,  /* category */
+                                            bgCode,  /* type */
+                                            DcmSegTypes::SAT_AUTOMATIC,
+                                            "dcmqi");
+    if (result.good() && bgSeg)
+    {
+        Uint16 segNum = 0;
+        result = m_outputSeg->addSegment(bgSeg, segNum);
+        if (result.bad())
+        {
+            DCMSEG_ERROR("Failed to add background segment: " << result.text());
+            delete bgSeg;
+        }
+    }
+    else
+    {
+        DCMSEG_ERROR("Failed to create background segment: " << result.text());
+        delete bgSeg;
     }
     return result;
 }

--- a/libsrc/Bin2Label.cpp
+++ b/libsrc/Bin2Label.cpp
@@ -809,84 +809,23 @@ OFCondition DcmBinToLabelConverter::addBackgroundSegmentIfNeeded()
     if (!m_outputSeg)
         return EC_IllegalParameter;
 
-    // Check whether any frame contains pixel value 0
-    OFBool hasZeroPixel = OFFalse;
-    size_t numFrames = m_outputSeg->getNumberOfFrames();
-    for (size_t f = 0; f < numFrames && !hasZeroPixel; f++)
-    {
-        const DcmIODTypes::FrameBase* frame = m_outputSeg->getFrame(f);
-        if (frame == NULL)
-            continue;
-        const size_t numPixels = frame->getLengthInBytes() / frame->bytesPerPixel();
-        for (size_t p = 0; p < numPixels; p++)
-        {
-            if (frame->bytesPerPixel() == 1)
-            {
-                Uint8 val = 0;
-                frame->getUint8AtIndex(val, p);
-                if (val == 0) { hasZeroPixel = OFTrue; break; }
-            }
-            else
-            {
-                Uint16 val = 0;
-                frame->getUint16AtIndex(val, p);
-                if (val == 0) { hasZeroPixel = OFTrue; break; }
-            }
-        }
-    }
+    const bool isPalette = (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE);
+    bool bgAdded = false;
+    OFCondition result = ConverterBase::addBackgroundSegmentIfNeeded(m_outputSeg.get(), !isPalette, &bgAdded);
+    if (result.bad() || !bgAdded)
+        return result;
 
-    if (!hasZeroPixel)
-        return EC_Normal;
+    DCMSEG_DEBUG("Pixel value 0 found in output frames, added background segment (number 0)");
 
-    // Create background segment with Segment Number 0
-    DCMSEG_DEBUG("Pixel value 0 found in output frames, adding background segment (number 0)");
-    DcmSegment* bgSeg = NULL;
-    CodeSequenceMacro bgCode("125040", "DCM", "Background");
-    OFCondition result = DcmSegment::create(bgSeg,
-                                            "Background",
-                                            bgCode,  /* category */
-                                            bgCode,  /* type */
-                                            DcmSegTypes::SAT_AUTOMATIC,
-                                            "dcmqi");
-    if (result.good() && bgSeg)
+    // In PALETTE mode the per-segment CIELab macro must not be written,
+    // but the color must still be present in the palette LUT so pixel
+    // value 0 maps to black.
+    if (isPalette && !m_cielabColors.prepend(0, 32768, 32768))
     {
-        // Set Recommended Display CIELab Value to black if not in PALETTE mode, as required by Sup 243
-        // (CIELab L*=0, a*=0, b*=0 → DICOM 0, 32768, 32768)
-        if (m_convFlags.m_outputColorModel != DcmSegTypes::SLCM_PALETTE)
-        {
-            result = bgSeg->setRecommendedDisplayCIELabValue(0, 32768, 32768);
-            if (result.bad())
-            {
-                DCMSEG_ERROR("Failed to set CIELab color for background segment: " << result.text());
-                delete bgSeg;
-                return result;
-            }
-        }
-        Uint16 segNum = 0;
-        result = m_outputSeg->addSegment(bgSeg, segNum);
-        if (result.bad())
-        {
-            DCMSEG_ERROR("Failed to add background segment: " << result.text());
-            delete bgSeg;
-        }
-        else if (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE)
-        {
-            // In PALETTE mode the per-segment CIELab macro must not be written,
-            // but the color must still be present in the palette LUT so pixel
-            // value 0 maps to black.
-            if (!m_cielabColors.prepend(0, 32768, 32768))
-            {
-                DCMSEG_ERROR("Failed to prepend background color for palette LUT");
-                result = EC_MemoryExhausted;
-            }
-        }
+        DCMSEG_ERROR("Failed to prepend background color for palette LUT");
+        return EC_MemoryExhausted;
     }
-    else
-    {
-        DCMSEG_ERROR("Failed to create background segment: " << result.text());
-        delete bgSeg;
-    }
-    return result;
+    return EC_Normal;
 }
 
 

--- a/libsrc/Bin2Label.cpp
+++ b/libsrc/Bin2Label.cpp
@@ -258,7 +258,12 @@ OFCondition DcmBinToLabelConverter::copySegments(DcmSegmentation* src, DcmSegmen
             DcmSegment* clonedSegment = srcSegment->second->clone(dest);
             if (clonedSegment)
             {
-                clonedSegment->getIODRules()->deleteRule(DCM_RecommendedDisplayCIELabValue);
+                if (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE)
+                {
+                    // Remove CIELab color from segment since in PALETTE mode the color is defined
+                    // in an ICC profile and the palette color lookup table
+                    clonedSegment->getIODRules()->deleteRule(DCM_RecommendedDisplayCIELabValue);
+                }
                 Uint16 segNumber = srcSegment->first;
                 result = dest->addSegment(clonedSegment, segNumber);
                 if (result.bad())

--- a/libsrc/Bin2Label.cpp
+++ b/libsrc/Bin2Label.cpp
@@ -258,13 +258,6 @@ OFCondition DcmBinToLabelConverter::copySegments(DcmSegmentation* src, DcmSegmen
             DcmSegment* clonedSegment = srcSegment->second->clone(dest);
             if (clonedSegment)
             {
-                // If we write palette color model, we need to make sure that the
-                // Recommended Display CIELab Value Macro will not be written
-                // for each segment, as this is not allowed in labelmaps with PALETTE color model.
-                if (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE)
-                {
-                    clonedSegment->getIODRules()->deleteRule(DCM_RecommendedDisplayCIELabValue);
-                }
                 Uint16 segNumber = srcSegment->first;
                 result = dest->addSegment(clonedSegment, segNumber);
                 if (result.bad())
@@ -703,13 +696,16 @@ OFCondition DcmBinToLabelConverter::createPaletteColorLUT()
     DCMSEG_DEBUG("Creating palette color lookup table for output segmentation");
     IODPaletteColorLUTModule& lutModule = m_outputSeg->getPaletteColorLUT();
     OFCondition result;
-    // Create LUT from CIELab colors stored during segment copying
+    // Create LUT from CIELab colors stored during segment copying.
+    // If a background segment (number 0) was added, the LUT starts at pixel
+    // value 0 (black for background); otherwise it starts at pixel value 1.
     size_t numSegments = m_outputSeg->getNumberOfSegments();
+    Uint16 firstPixelMapped = (m_outputSeg->getSegment(0) != NULL) ? 0 : 1;
     if (m_cielabColors.m_numSegments == numSegments)
     {
-        result = lutModule.setRedPaletteColorLookupTableDescriptor(numSegments, 1, (m_use16Bit ? 16 : 8));
-        if (result.good()) result = lutModule.setGreenPaletteColorLookupTableDescriptor(numSegments, 1, (m_use16Bit ? 16 : 8));
-        if (result.good()) result = lutModule.setBluePaletteColorLookupTableDescriptor(numSegments, 1, (m_use16Bit ? 16 : 8));
+        result = lutModule.setRedPaletteColorLookupTableDescriptor(numSegments, firstPixelMapped, (m_use16Bit ? 16 : 8));
+        if (result.good()) result = lutModule.setGreenPaletteColorLookupTableDescriptor(numSegments, firstPixelMapped, (m_use16Bit ? 16 : 8));
+        if (result.good()) result = lutModule.setBluePaletteColorLookupTableDescriptor(numSegments, firstPixelMapped, (m_use16Bit ? 16 : 8));
         if (result.good())
         {
             Uint16 maxRange = (m_use16Bit ? 65535 : 255);
@@ -852,12 +848,32 @@ OFCondition DcmBinToLabelConverter::addBackgroundSegmentIfNeeded()
                                             "dcmqi");
     if (result.good() && bgSeg)
     {
+        // Set Recommended Display CIELab Value to black
+        // (CIELab L*=0, a*=0, b*=0 → DICOM 0, 32768, 32768)
+        result = bgSeg->setRecommendedDisplayCIELabValue(0, 32768, 32768);
+        if (result.bad())
+        {
+            DCMSEG_ERROR("Failed to set CIELab color for background segment: " << result.text());
+            delete bgSeg;
+            return result;
+        }
         Uint16 segNum = 0;
         result = m_outputSeg->addSegment(bgSeg, segNum);
         if (result.bad())
         {
             DCMSEG_ERROR("Failed to add background segment: " << result.text());
             delete bgSeg;
+        }
+        else if (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE)
+        {
+            // In PALETTE mode the per-segment CIELab macro must not be written,
+            // but the color must still be present in the palette LUT so pixel
+            // value 0 maps to black.
+            if (!m_cielabColors.prepend(0, 32768, 32768))
+            {
+                DCMSEG_ERROR("Failed to prepend background color for palette LUT");
+                result = EC_MemoryExhausted;
+            }
         }
     }
     else

--- a/libsrc/Bin2Label.cpp
+++ b/libsrc/Bin2Label.cpp
@@ -114,7 +114,7 @@ OFCondition DcmBinToLabelConverter::convert(const ConversionFlags& convFlags)
     // if they are not found, random colors are generated if forcePalette is set.
     // The call only fails (if not on hard errors) if forcePalette is not set and CIELab
     // colors are missing.
-    if ( (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE) && !checkCIELabColorsPresent() )
+    if ( (m_convFlags.m_outputColorModel == DcmSegTypes::SLCM_PALETTE) && !ensureCIELabColorsPresent() )
     {
         DCMSEG_ERROR("Cannot convert to PALETTE color model since not all segments contain Recommended Display CIELab Value Macro");
         return SG_EC_CannotConvertMissingCIELab;
@@ -258,6 +258,7 @@ OFCondition DcmBinToLabelConverter::copySegments(DcmSegmentation* src, DcmSegmen
             DcmSegment* clonedSegment = srcSegment->second->clone(dest);
             if (clonedSegment)
             {
+                clonedSegment->getIODRules()->deleteRule(DCM_RecommendedDisplayCIELabValue);
                 Uint16 segNumber = srcSegment->first;
                 result = dest->addSegment(clonedSegment, segNumber);
                 if (result.bad())
@@ -266,6 +267,7 @@ OFCondition DcmBinToLabelConverter::copySegments(DcmSegmentation* src, DcmSegmen
                     delete clonedSegment;
                     break;
                 }
+
             }
             else
             {
@@ -543,7 +545,7 @@ E_TransferSyntax DcmBinToLabelConverter::getInputTransferSyntax() const
 }
 
 
-OFBool DcmBinToLabelConverter::checkCIELabColorsPresent()
+OFBool DcmBinToLabelConverter::ensureCIELabColorsPresent()
 {
     size_t numSegments = m_inputSeg->getNumberOfSegments();
     OFBool result = OFTrue;
@@ -848,14 +850,17 @@ OFCondition DcmBinToLabelConverter::addBackgroundSegmentIfNeeded()
                                             "dcmqi");
     if (result.good() && bgSeg)
     {
-        // Set Recommended Display CIELab Value to black
+        // Set Recommended Display CIELab Value to black if not in PALETTE mode, as required by Sup 243
         // (CIELab L*=0, a*=0, b*=0 → DICOM 0, 32768, 32768)
-        result = bgSeg->setRecommendedDisplayCIELabValue(0, 32768, 32768);
-        if (result.bad())
+        if (m_convFlags.m_outputColorModel != DcmSegTypes::SLCM_PALETTE)
         {
-            DCMSEG_ERROR("Failed to set CIELab color for background segment: " << result.text());
-            delete bgSeg;
-            return result;
+            result = bgSeg->setRecommendedDisplayCIELabValue(0, 32768, 32768);
+            if (result.bad())
+            {
+                DCMSEG_ERROR("Failed to set CIELab color for background segment: " << result.text());
+                delete bgSeg;
+                return result;
+            }
         }
         Uint16 segNum = 0;
         result = m_outputSeg->addSegment(bgSeg, segNum);

--- a/libsrc/ConverterBase.cpp
+++ b/libsrc/ConverterBase.cpp
@@ -2,8 +2,94 @@
 // DCMQI includes
 #include "dcmqi/ConverterBase.h"
 
+// DCMTK includes
+#include <dcmtk/dcmseg/segment.h>
+
 
 namespace dcmqi {
+
+  OFCondition ConverterBase::addBackgroundSegmentIfNeeded(DcmSegmentation* segdoc,
+                                                           bool setCIELabValue,
+                                                           bool* bgAdded)
+  {
+    if (bgAdded)
+      *bgAdded = false;
+    if (!segdoc)
+      return EC_IllegalParameter;
+
+    // Check whether any frame contains pixel value 0
+    OFBool hasZeroPixel = OFFalse;
+    size_t numFrames = segdoc->getNumberOfFrames();
+    for (size_t f = 0; f < numFrames && !hasZeroPixel; f++)
+    {
+      const DcmIODTypes::FrameBase* frame = segdoc->getFrame(f);
+      if (frame == NULL)
+        continue;
+      const size_t numPixels = frame->getLengthInBytes() / frame->bytesPerPixel();
+      for (size_t p = 0; p < numPixels; p++)
+      {
+        if (frame->bytesPerPixel() == 1)
+        {
+          Uint8 val = 0;
+          frame->getUint8AtIndex(val, p);
+          if (val == 0) { hasZeroPixel = OFTrue; break; }
+        }
+        else
+        {
+          Uint16 val = 0;
+          frame->getUint16AtIndex(val, p);
+          if (val == 0) { hasZeroPixel = OFTrue; break; }
+        }
+      }
+    }
+
+    if (!hasZeroPixel)
+      return EC_Normal;
+
+    // Create background segment with Segment Number 0
+    DcmSegment* bgSeg = NULL;
+    CodeSequenceMacro bgCode("125040", "DCM", "Background");
+    OFCondition result = DcmSegment::create(bgSeg,
+                                            "Background",
+                                            bgCode,  /* category */
+                                            bgCode,  /* type */
+                                            DcmSegTypes::SAT_AUTOMATIC,
+                                            "dcmqi");
+    if (result.bad() || !bgSeg)
+    {
+      cerr << "ERROR: Failed to create background segment: " << result.text() << endl;
+      delete bgSeg;
+      return result;
+    }
+
+    // Set Recommended Display CIELab Value to black (DICOM-encoded 0, 32768, 32768
+    // for L*=0, a*=0, b*=0). Skipped in PALETTE mode where the per-segment CIELab
+    // macro must not be written; the LUT entry must instead be provided by the caller.
+    if (setCIELabValue)
+    {
+      result = bgSeg->setRecommendedDisplayCIELabValue(0, 32768, 32768);
+      if (result.bad())
+      {
+        cerr << "ERROR: Failed to set CIELab color for background segment: " << result.text() << endl;
+        delete bgSeg;
+        return result;
+      }
+    }
+
+    Uint16 segNum = 0;
+    result = segdoc->addSegment(bgSeg, segNum);
+    if (result.bad())
+    {
+      cerr << "ERROR: Failed to add background segment: " << result.text() << endl;
+      delete bgSeg;
+      return result;
+    }
+
+    if (bgAdded)
+      *bgAdded = true;
+    return EC_Normal;
+  }
+
 
   IODGeneralEquipmentModule::EquipmentInfo ConverterBase::getEquipmentInfo() {
     // TODO: change to following for most recent dcmtk

--- a/libsrc/Dicom2ItkConverterBase.cpp
+++ b/libsrc/Dicom2ItkConverterBase.cpp
@@ -199,7 +199,6 @@ OFCondition Dicom2ItkConverterBase::extractBasicSegmentationInfo()
     if (!firstFrame)
         return EC_IllegalParameter;
     m_bytesPerPixel = firstFrame->bytesPerPixel();
-    std::cout << "Bytes per pixel: " << static_cast<int>(m_bytesPerPixel) << std::endl;
     return result;
 }
 

--- a/libsrc/Dicom2ItkConverterLabel.cpp
+++ b/libsrc/Dicom2ItkConverterLabel.cpp
@@ -41,15 +41,15 @@ OFCondition Dicom2ItkConverterLabel::dcmSegmentation2itkimage(const bool mergeSe
     // while the ITK images are made accessible through the begin()/next() iterators only.
     // createMetaInfo() requires groups of non-overlapping segments, but for labelmaps we know that
     // all segments are non-overlapping, so we can just create one group with all segments in it.
-    size_t numSegs = m_segDoc->getNumberOfSegments();
     OFVector<Uint32> segs;
-    for (size_t i = 1; i <= numSegs; ++i)
+    OFMap<Uint16, DcmSegment*>::const_iterator segIt = m_segDoc->getSegments().begin();
+    while (segIt != m_segDoc->getSegments().end())
     {
-        segs.push_back(i);
+        segs.push_back(segIt->first);
+        ++segIt;
     }
     m_segmentGroups.clear();
     m_segmentGroups.push_back(segs);
-    std::cout << "All " << numSegs << " segments will be put into one group for the metadata creation" << std::endl;
 
     // Now we are ready to create the meta information.
     // It is available directly after this call in m_metaInfo.

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -33,7 +33,8 @@ namespace dcmqi {
                                                           bool skipEmptySlices,
                                                           bool useLabelIDAsSegmentNumber,
                                                           bool referencesGeometryCheck,
-                                                          bool doDicomValueChecks) {
+                                                          bool doDicomValueChecks,
+                                                          bool outputLabelMap) {
 
     auto inputSize = segmentations[0]->GetBufferedRegion().GetSize();
 
@@ -51,17 +52,46 @@ namespace dcmqi {
     // Map that will hold the mapping from segment number (as written to DICOM) and label ID
     // as it is found in the input image. This can be used later to re-map the segment numbers
     // to their original label IDs (see mapLabelIDsToSegmentNumbers() method).
+    // Segment numbers always start at 1; pixel value 0 in labelmap output is reserved for
+    // background per Sup 243, and a background segment with number 0 is added later if needed.
     map<Uint16,Uint16> segNum2Label;
+    Uint16 nextSegmentNumber = 1;
+
+    // For labelmap output, this map stores for every input file and label ID
+    // the resulting Segment Number used in output pixel data.
+    vector<map<short, Uint16> > fileLabelToSegmentNumber;
+    if (outputLabelMap)
+      fileLabelToSegmentNumber.resize(segmentations.size());
 
     /* Create new segmentation document */
     DcmSegmentation *segdoc = NULL;
 
-    DcmSegmentation::createBinarySegmentation(
-        segdoc,   // resulting segmentation
-        inputSize[1],    // rows
-        inputSize[0],    // columns
-        eq,     // equipment
-        ident);   // content identification
+    if (outputLabelMap)
+    {
+      size_t numSegmentsMetadata = 0;
+      for (size_t segFileNumber = 0; segFileNumber < metaInfo.segmentsAttributesMappingList.size(); segFileNumber++)
+      {
+        numSegmentsMetadata += metaInfo.segmentsAttributesMappingList[segFileNumber].size();
+      }
+      const bool use16Bit = numSegmentsMetadata > 255;
+      CHECK_COND(DcmSegmentation::createLabelmapSegmentation(
+          segdoc,
+          inputSize[1],
+          inputSize[0],
+          eq,
+          ident,
+          use16Bit,
+          DcmSegTypes::SLCM_MONOCHROME2));
+    }
+    else
+    {
+      CHECK_COND(DcmSegmentation::createBinarySegmentation(
+          segdoc,   // resulting segmentation
+          inputSize[1],    // rows
+          inputSize[0],    // columns
+          eq,     // equipment
+          ident));   // content identification
+    }
 
     // import Patient, Study and Frame of Reference; do not import Series
     // attributes
@@ -71,10 +101,18 @@ namespace dcmqi {
     char dimUID[128];
     dcmGenerateUniqueIdentifier(dimUID, QIICR_UID_ROOT);
     IODMultiframeDimensionModule &mfdim = segdoc->getDimensions();
-    CHECK_COND(mfdim.addDimensionIndex(DCM_ReferencedSegmentNumber, dimUID, DCM_SegmentIdentificationSequence,
-                       DcmTag(DCM_ReferencedSegmentNumber).getTagName()));
-    CHECK_COND(mfdim.addDimensionIndex(DCM_ImagePositionPatient, dimUID, DCM_PlanePositionSequence,
-                       DcmTag(DCM_ImagePositionPatient).getTagName()));
+    if (outputLabelMap)
+    {
+      CHECK_COND(mfdim.addDimensionIndex(DCM_StackID, dimUID, DCM_FrameContentSequence, "Stack ID"));
+      CHECK_COND(mfdim.addDimensionIndex(DCM_InStackPositionNumber, dimUID, DCM_FrameContentSequence, "In-Stack Position Number"));
+    }
+    else
+    {
+      CHECK_COND(mfdim.addDimensionIndex(DCM_ReferencedSegmentNumber, dimUID, DCM_SegmentIdentificationSequence,
+                         DcmTag(DCM_ReferencedSegmentNumber).getTagName()));
+      CHECK_COND(mfdim.addDimensionIndex(DCM_ImagePositionPatient, dimUID, DCM_PlanePositionSequence,
+                         DcmTag(DCM_ImagePositionPatient).getTagName()));
+    }
 
     /* Initialize shared functional groups */
     const unsigned frameSize = inputSize[0] * inputSize[1];
@@ -165,9 +203,21 @@ namespace dcmqi {
     }
 
     int uidfound = 0, uidnotfound = 0;
-    Uint8 *frameData = new Uint8[frameSize];
 
     bool hasDerivationImages = false;
+    bool hasDerivationImagesAny = false;
+    vector<vector<vector<int> > > slice2derimgPerFile;
+    if (referencesGeometryCheck)
+    {
+      slice2derimgPerFile.resize(segmentations.size());
+      for (size_t segFileNumber = 0; segFileNumber < segmentations.size(); segFileNumber++)
+      {
+        slice2derimgPerFile[segFileNumber] = getSliceMapForSegmentation2DerivationImage(dcmDatasets, segmentations[segFileNumber]);
+        for (vector<vector<int> >::const_iterator vI = slice2derimgPerFile[segFileNumber].begin(); vI != slice2derimgPerFile[segFileNumber].end(); ++vI)
+          if ((*vI).size() > 0)
+            hasDerivationImagesAny = true;
+      }
+    }
 
     FGPlanePosPatient* fgppp = FGPlanePosPatient::createMinimal("1","1","1");
     FGFrameContent* fgfc = new FGFrameContent();
@@ -179,7 +229,8 @@ namespace dcmqi {
 
       vector<vector<int> > slice2derimg;
       if(referencesGeometryCheck){
-        slice2derimg = getSliceMapForSegmentation2DerivationImage(dcmDatasets, segmentations[segFileNumber]);
+        slice2derimg = slice2derimgPerFile[segFileNumber];
+        hasDerivationImages = false;
         for(vector<vector<int> >::const_iterator vI=slice2derimg.begin();vI!=slice2derimg.end();++vI)
           if((*vI).size()>0)
             hasDerivationImages = true;
@@ -341,9 +392,19 @@ namespace dcmqi {
 
         CHECK_COND(segment->setRecommendedDisplayCIELabValue(cielab[0],cielab[1],cielab[2]));
 
-        Uint16 segmentNumber;
+        Uint16 segmentNumber = 0;
+        if (useLabelIDAsSegmentNumber)
+          segmentNumber = static_cast<Uint16>(label);
+        else
+          segmentNumber = nextSegmentNumber++;
         CHECK_COND(segdoc->addSegment(segment, segmentNumber /* returns logical segment number */));
         segNum2Label.insert(make_pair(segmentNumber, label));
+
+        if (outputLabelMap)
+        {
+          fileLabelToSegmentNumber[segFileNumber][label] = segmentNumber;
+          continue;
+        }
 
         // TODO: make it possible to skip empty frames (optional)
         // iterate over slices for an individual label and populate output frames
@@ -395,6 +456,7 @@ namespace dcmqi {
             sliceRegion.SetIndex(sliceIndex);
             sliceRegion.SetSize(sliceSize);
 
+            std::vector<Uint8> frameData(frameSize, 0);
             unsigned framePixelCnt = 0;
             itk::ImageRegionConstIteratorWithIndex<ImageSourceType> sliceIterator(segmentations[segFileNumber], sliceRegion);
             for(sliceIterator.GoToBegin();!sliceIterator.IsAtEnd();++sliceIterator,++framePixelCnt){
@@ -448,7 +510,7 @@ namespace dcmqi {
               }
             }
 
-            OFCondition frameAdded = segdoc->addFrame(frameData, segmentNumber, perFrameFGs);
+            OFCondition frameAdded = segdoc->addFrame(frameData.data(), segmentNumber, perFrameFGs);
             if(frameAdded.good()){
               framesAdded++;
             }
@@ -463,6 +525,198 @@ namespace dcmqi {
       }
     }
 
+    if (outputLabelMap)
+    {
+      const size_t numSegmentsMetadata = segNum2Label.size();
+      const bool labelMapUse16Bit = numSegmentsMetadata > 255;
+      unsigned outputFrameNumber = 1;
+
+      // Stack ID is invariant across all labelmap frames; set it once on the
+      // reused FGFrameContent instance.
+      CHECK_COND(fgfc->setStackID("Frame Position"));
+
+      // Releases the per-frame functional groups before bailing out on error.
+      auto releaseFGs = [&]() { delete fgfc; delete fgppp; delete fgder; fgfc = NULL; fgppp = NULL; fgder = NULL; };
+
+      for (unsigned sliceNumber = 0; sliceNumber < inputSize[2]; sliceNumber++)
+      {
+        std::vector<Uint8> frameData8;
+        std::vector<Uint16> frameData16;
+        if (labelMapUse16Bit)
+          frameData16.assign(frameSize, 0);
+        else
+          frameData8.assign(frameSize, 0);
+
+        bool frameHasForeground = false;
+
+        for (size_t segFileNumber = 0; segFileNumber < segmentations.size(); segFileNumber++)
+        {
+          typename ImageSourceType::RegionType sliceRegion;
+          typename ImageSourceType::IndexType sliceIndex;
+          typename ImageSourceType::SizeType sliceSize;
+
+          sliceIndex[0] = 0;
+          sliceIndex[1] = 0;
+          sliceIndex[2] = sliceNumber;
+
+          sliceSize[0] = inputSize[0];
+          sliceSize[1] = inputSize[1];
+          sliceSize[2] = 1;
+
+          sliceRegion.SetIndex(sliceIndex);
+          sliceRegion.SetSize(sliceSize);
+
+          unsigned framePixelCnt = 0;
+          itk::ImageRegionConstIteratorWithIndex<ImageSourceType> sliceIterator(segmentations[segFileNumber], sliceRegion);
+          for (sliceIterator.GoToBegin(); !sliceIterator.IsAtEnd(); ++sliceIterator, ++framePixelCnt)
+          {
+            short inputLabel = sliceIterator.Get();
+            if (inputLabel == 0)
+              continue;
+
+            map<short, Uint16>::const_iterator mappingIt = fileLabelToSegmentNumber[segFileNumber].find(inputLabel);
+            if (mappingIt == fileLabelToSegmentNumber[segFileNumber].end())
+            {
+              cerr << "ERROR: Failed to map input label " << inputLabel << " to output segment number!" << endl;
+              releaseFGs();
+              return NULL;
+            }
+
+            Uint16 segmentValue = mappingIt->second;
+            if (labelMapUse16Bit)
+            {
+              Uint16 currentValue = frameData16[framePixelCnt];
+              if (currentValue != 0 && currentValue != segmentValue)
+              {
+                cerr << "ERROR: Cannot write labelmap SEG due to overlapping segments at slice " << sliceNumber << "!" << endl;
+                releaseFGs();
+                return NULL;
+              }
+              frameData16[framePixelCnt] = segmentValue;
+            }
+            else
+            {
+              Uint8 segmentValue8 = static_cast<Uint8>(segmentValue);
+              Uint8 currentValue = frameData8[framePixelCnt];
+              if (currentValue != 0 && currentValue != segmentValue8)
+              {
+                cerr << "ERROR: Cannot write labelmap SEG due to overlapping segments at slice " << sliceNumber << "!" << endl;
+                releaseFGs();
+                return NULL;
+              }
+              frameData8[framePixelCnt] = segmentValue8;
+            }
+            frameHasForeground = true;
+          }
+        }
+
+        if (skipEmptySlices && !frameHasForeground)
+          continue;
+
+        CHECK_COND(fgfc->setInStackPositionNumber(outputFrameNumber));
+        CHECK_COND(fgfc->setDimensionIndexValues(1, 0));
+        CHECK_COND(fgfc->setDimensionIndexValues(outputFrameNumber, 1));
+
+        typename ImageSourceType::PointType sliceOriginPoint;
+        typename ImageSourceType::IndexType sliceOriginIndex;
+        sliceOriginIndex.Fill(0);
+        sliceOriginIndex[2] = sliceNumber;
+        segmentations[0]->TransformIndexToPhysicalPoint(sliceOriginIndex, sliceOriginPoint);
+        fgppp->setImagePositionPatient(
+            Helper::floatToStr(sliceOriginPoint[0]).c_str(),
+            Helper::floatToStr(sliceOriginPoint[1]).c_str(),
+            Helper::floatToStr(sliceOriginPoint[2]).c_str());
+
+        perFrameFGs.clear();
+        perFrameFGs.push_back(fgppp);
+        perFrameFGs.push_back(fgfc);
+
+        OFVector<DcmItem*> siVector;
+        if (referencesGeometryCheck && hasDerivationImagesAny && !slice2derimgPerFile.empty())
+        {
+          std::set<int> referencedDatasetIndexes;
+          for (size_t segFileNumber = 0; segFileNumber < slice2derimgPerFile.size(); segFileNumber++)
+          {
+            if (sliceNumber >= slice2derimgPerFile[segFileNumber].size())
+              continue;
+            for (size_t derImageInstanceNum = 0;
+                 derImageInstanceNum < slice2derimgPerFile[segFileNumber][sliceNumber].size();
+                 derImageInstanceNum++)
+            {
+              referencedDatasetIndexes.insert(slice2derimgPerFile[segFileNumber][sliceNumber][derImageInstanceNum]);
+            }
+          }
+
+          for (std::set<int>::const_iterator idxIt = referencedDatasetIndexes.begin(); idxIt != referencedDatasetIndexes.end(); ++idxIt)
+          {
+            siVector.push_back(dcmDatasets[*idxIt]);
+          }
+
+          if (siVector.size() > 0)
+          {
+            perFrameFGs.push_back(fgder);
+            DerivationImageItem* derimgItem;
+            DSRBasicCodedEntry code_seg = CODE_DCM_Segmentation_113076;
+            CHECK_COND(fgder->addDerivationImageItem(CodeSequenceMacro(code_seg.CodeValue,
+                                                                       code_seg.CodingSchemeDesignator,
+                                                                       code_seg.CodeMeaning),
+                                                     "",
+                                                     derimgItem));
+
+            DSRBasicCodedEntry code = CODE_DCM_SourceImageForImageProcessingOperation;
+            OFVector<SourceImageItem*> srcimgItems;
+            CHECK_COND(derimgItem->addSourceImageItems(siVector,
+                                                       CodeSequenceMacro(code.CodeValue,
+                                                                         code.CodingSchemeDesignator,
+                                                                         code.CodeMeaning),
+                                                       srcimgItems));
+
+            if (!srcimgItems.empty())
+            {
+              ImageSOPInstanceReferenceMacro& instRef = srcimgItems[0]->getImageSOPInstanceReference();
+              OFString instanceUID;
+              CHECK_COND(instRef.getReferencedSOPClassUID(classUID));
+              CHECK_COND(instRef.getReferencedSOPInstanceUID(instanceUID));
+
+              if (instanceUIDs.find(instanceUID) == instanceUIDs.end())
+              {
+                SOPInstanceReferenceMacro* refinstancesItem = new SOPInstanceReferenceMacro();
+                CHECK_COND(refinstancesItem->setReferencedSOPClassUID(classUID));
+                CHECK_COND(refinstancesItem->setReferencedSOPInstanceUID(instanceUID));
+                refinstances.push_back(refinstancesItem);
+                instanceUIDs.insert(instanceUID);
+                uidnotfound++;
+              }
+              else
+              {
+                uidfound++;
+              }
+            }
+          }
+        }
+
+        OFCondition frameAdded = labelMapUse16Bit
+            ? segdoc->addFrame(frameData16.data(), 0, perFrameFGs)
+            : segdoc->addFrame(frameData8.data(), 0, perFrameFGs);
+        if (frameAdded.good())
+        {
+          framesAdded++;
+          outputFrameNumber++;
+        }
+
+        if (referencesGeometryCheck && siVector.size() > 0)
+        {
+          fgder->clearData();
+        }
+      }
+    }
+
+    // For labelmap output, add background segment if pixel value 0 exists in any frame
+    if (outputLabelMap)
+    {
+      CHECK_COND(addBackgroundSegmentIfNeeded(segdoc));
+    }
+
     if(framesAdded == 0){
       cerr << "FATAL ERROR: No input labels found - input segmentation is empty!" << endl;
       cerr << "If you would like to encode background label, please see https://github.com/QIICR/dcmqi/issues/490" << endl;
@@ -475,8 +729,7 @@ namespace dcmqi {
 
     delete fgfc;
     delete fgppp;
-    if(referencesGeometryCheck)
-      delete fgder;
+    delete fgder;
 
     segdoc->getSeries().setSeriesNumber(metaInfo.getSeriesNumber().c_str());
 
@@ -547,7 +800,9 @@ namespace dcmqi {
 
     {
       string segmentsOverlap;
-      if(segmentations.size() == 1)
+      if (outputLabelMap)
+        segmentsOverlap = "NO";
+      else if(segmentations.size() == 1)
         segmentsOverlap = "NO";
       else
         segmentsOverlap = "UNDEFINED";
@@ -556,7 +811,14 @@ namespace dcmqi {
 
     if (useLabelIDAsSegmentNumber)
     {
-      mapLabelIDsToSegmentNumbers(segdocDataset.get(), segNum2Label);
+      if (!checkLabelNumbering(segNum2Label))
+      {
+        return NULL;
+      }
+      if (!outputLabelMap)
+      {
+        mapLabelIDsToSegmentNumbers(segdocDataset.get(), segNum2Label);
+      }
     }
 
     return segdocDataset.release();
@@ -708,7 +970,8 @@ namespace dcmqi {
       bool skipEmptySlices,
       bool useLabelIDAsSegmentNumber,
       bool referencesGeometryCheck,
-      bool doDicomValueChecks);
+      bool doDicomValueChecks,
+      bool outputLabelMap);
 
   using VectorImageAdapter = itk::VectorImageToImageAdaptor<short, 3U>;
   template DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation<VectorImageAdapter>(
@@ -718,5 +981,6 @@ namespace dcmqi {
       bool skipEmptySlices,
       bool useLabelIDAsSegmentNumber,
       bool referencesGeometryCheck,
-      bool doDicomValueChecks);
+      bool doDicomValueChecks,
+      bool outputLabelMap);
 }


### PR DESCRIPTION
Add direct ITK to DICOM Labelmap conversion.

Also includes PRs #534 and #535 (the latter being probably optional).

Extend itkimage2segimage with a --segmentationType option (default
"binary", preserving prior behavior) that, when set to "labelmap",
emits a DICOM Labelmap Segmentation (Sup 243) directly from an ITK
image. Previously the only way to produce a labelmap was to convert
to a binary Segmentation first and then run bin2labelsegimage;
this removes the intermediate step.

In labelmap mode foreground segments are numbered 1..N (or taken
from labelIDs when --useLabelIDAsSegmentNumber is set); pixel value
0 is reserved for the implicit background. If any frame contains
pixel 0 a Background segment (Property Type DCM 125040) is added
automatically so every pixel value is covered by a Segment Sequence
item, as required by Sup 243. Bit depth is 8-bit when the segment
count fits, else 16-bit. Overlapping foreground segments are
rejected because each labelmap pixel can carry only one segment
number.

The frame-scan + background-segment-creation logic that this new
path needs is identical to what Bin2Label already does for
binary->labelmap conversion. It is consolidated into a shared
ConverterBase::addBackgroundSegmentIfNeeded() helper, and
DcmBinToLabelConverter's member function becomes a thin wrapper
that delegates and adds the PALETTE-mode LUT prepend on top.

Also adds a 2-segment metadata example
(doc/examples/seg-example_liver_spine.json) used by new CTest
entries:
- itkimage2segimage_makeSEG_labelmap: single-segment conversion.
- itkimage2segimage_makeSEG_labelmap_multi: multi-segment
  conversion. Regression guard for segment numbering, which is
  not exercised by single-segment inputs.
- itkimage2segimage_makeSEG_labelmap_multi_labelID: same with
  --useLabelIDAsSegmentNumber.
- itkimage2segimage_makeSEG_labelmap_overlap: liver/heart pair
  overlaps on 522 pixels; conversion must fail (WILL_FAIL).
- segimage2itkimage_makeNRRD_from_labelmap_{direct,multi}:
  pixel-perfect round-trip back to NRRD against existing baselines.

dciodvfy is intentionally not run on the new labelmap outputs;
all labelmap segmentations emitted by dcmqi today (both Bin2Label
and this new path) fail dciodvfy because Type 2C PatientOrientation
is not populated under GeneralImage. This is a pre-existing
gap and is documented inline in the CMakeLists.