### PR TITLE
Add in-memory handler overload of itkimage2dcmSegmentation.

### DIFF
--- a/apps/seg/Testing/CMakeLists.txt
+++ b/apps/seg/Testing/CMakeLists.txt
@@ -20,6 +20,31 @@ dcmqi_add_test(
   COMMAND $<TARGET_FILE:${itk2dcm}> --help
   )
 
+#-----------------------------------------------------------------------------
+# Equivalence guard for the in-memory handler overload of
+# itkimage2dcmSegmentation. The string overload is implemented as a thin
+# wrapper that parses its JSON argument into a handler and delegates to the
+# handler overload; this test asserts the two overloads produce semantically
+# equivalent DICOM datasets for the same input.
+add_executable(Itk2DicomHandlerOverloadEquivalenceTest
+  Itk2DicomHandlerOverloadEquivalenceTest.cxx)
+target_link_libraries(Itk2DicomHandlerOverloadEquivalenceTest
+  dcmqi
+  ${DCMTK_LIBRARIES})
+set_target_properties(Itk2DicomHandlerOverloadEquivalenceTest PROPERTIES
+  LABELS ${MODULE_NAME})
+
+dcmqi_add_test(
+  NAME ${itk2dcm}_handlerOverloadEquivalence
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:Itk2DicomHandlerOverloadEquivalenceTest>
+    ${CMAKE_SOURCE_DIR}/doc/examples/seg-example.json
+    ${BASELINE}/liver_seg.nrrd
+    ${DICOM_DIR}/01.dcm
+    ${DICOM_DIR}/02.dcm
+    ${DICOM_DIR}/03.dcm
+  )
+
 dcmqi_add_test(
   NAME ${itk2dcm}_makeSEG
   MODULE_NAME ${MODULE_NAME}

--- a/apps/seg/Testing/Itk2DicomHandlerOverloadEquivalenceTest.cxx
+++ b/apps/seg/Testing/Itk2DicomHandlerOverloadEquivalenceTest.cxx
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
   REQUIRE(resultA != nullptr);
 
   // Path B: handler overload (new).
-  dcmqi::JSONSegmentationMetaInformationHandler handler(metadata.c_str());
+  dcmqi::JSONSegmentationMetaInformationHandler handler(metadata);
   handler.read();
   std::unique_ptr<DcmDataset> resultB(
       dcmqi::Itk2DicomConverter::itkimage2dcmSegmentation(dcmDatasetsB, segmentations, handler));

--- a/apps/seg/Testing/Itk2DicomHandlerOverloadEquivalenceTest.cxx
+++ b/apps/seg/Testing/Itk2DicomHandlerOverloadEquivalenceTest.cxx
@@ -1,0 +1,188 @@
+// Equivalence test for the two itkimage2dcmSegmentation overloads.
+//
+// The handler-based overload is the load-bearing implementation; the
+// string-based overload is a thin wrapper that parses its JSON argument into
+// a JSONSegmentationMetaInformationHandler and delegates. This test guards
+// the wrapper by exercising both paths against the same input and asserting
+// the resulting DICOM segmentation datasets agree on the attributes a
+// consumer can reasonably rely on. We do not assert byte-level equality
+// because DCMTK generates fresh UIDs and timestamps on every write.
+
+#include "dcmqi/Helper.h"
+#include "dcmqi/Itk2DicomConverter.h"
+#include "dcmqi/JSONSegmentationMetaInformationHandler.h"
+
+#include <dcmtk/dcmdata/dcdeftag.h>
+#include <dcmtk/dcmdata/dcdatset.h>
+#include <dcmtk/dcmdata/dcfilefo.h>
+#include <dcmtk/dcmdata/dcsequen.h>
+
+#include <itkImageFileReader.h>
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+using ImageType = itk::Image<short, 3U>;
+using ReaderType = itk::ImageFileReader<ImageType>;
+
+std::string readFile(const std::string& path)
+{
+  std::ifstream in(path.c_str(), std::ios::binary);
+  if (!in)
+  {
+    std::cerr << "ERROR: cannot open " << path << std::endl;
+    return std::string();
+  }
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+// Return the count of items in a top-level sequence, or static_cast<size_t>(-1) on error.
+size_t sequenceItemCount(DcmDataset* ds, const DcmTagKey& tag)
+{
+  DcmSequenceOfItems* seq = nullptr;
+  if (ds->findAndGetSequence(tag, seq).bad() || seq == nullptr)
+  {
+    return static_cast<size_t>(-1);
+  }
+  return static_cast<size_t>(seq->card());
+}
+
+// Collect the SegmentLabel of every item in SegmentSequence, preserving order.
+std::vector<std::string> collectSegmentLabels(DcmDataset* ds)
+{
+  std::vector<std::string> result;
+  DcmSequenceOfItems* seq = nullptr;
+  if (ds->findAndGetSequence(DCM_SegmentSequence, seq).bad() || seq == nullptr)
+  {
+    return result;
+  }
+  for (unsigned long i = 0; i < seq->card(); ++i)
+  {
+    DcmItem* item = seq->getItem(i);
+    OFString label;
+    if (item && item->findAndGetOFString(DCM_SegmentLabel, label).good())
+    {
+      result.emplace_back(label.c_str());
+    }
+    else
+    {
+      result.emplace_back();
+    }
+  }
+  return result;
+}
+
+std::string readString(DcmDataset* ds, const DcmTagKey& tag)
+{
+  OFString value;
+  if (ds->findAndGetOFString(tag, value).bad())
+  {
+    return std::string();
+  }
+  return std::string(value.c_str());
+}
+
+#define REQUIRE(expr)                                                                  \
+  do {                                                                                 \
+    if (!(expr)) {                                                                     \
+      std::cerr << "FAIL: " << #expr << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
+      return EXIT_FAILURE;                                                             \
+    }                                                                                  \
+  } while (0)
+}
+
+int main(int argc, char* argv[])
+{
+  if (argc < 4)
+  {
+    std::cerr << "Usage: " << argv[0]
+              << " <metadata.json> <segmentation.nrrd> <dicomFile1> [<dicomFile2> ...]"
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const std::string metadataPath = argv[1];
+  const std::string segPath = argv[2];
+
+  std::vector<std::string> dicomFiles;
+  for (int i = 3; i < argc; ++i)
+  {
+    dicomFiles.emplace_back(argv[i]);
+  }
+
+  const std::string metadata = readFile(metadataPath);
+  REQUIRE(!metadata.empty());
+
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(segPath);
+  try
+  {
+    reader->Update();
+  }
+  catch (const itk::ExceptionObject& e)
+  {
+    std::cerr << "ERROR: failed to load segmentation: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::vector<ImageType::ConstPointer> segmentations;
+  segmentations.emplace_back(reader->GetOutput());
+
+  // Both call sites need an independent set of source-image datasets because
+  // the converter takes ownership semantics that may leave the items in an
+  // unspecified state for a second pass.
+  std::vector<DcmItem*> dcmDatasetsA = dcmqi::Helper::loadDatasets(dicomFiles);
+  std::vector<DcmItem*> dcmDatasetsB = dcmqi::Helper::loadDatasets(dicomFiles);
+  REQUIRE(!dcmDatasetsA.empty());
+  REQUIRE(dcmDatasetsA.size() == dcmDatasetsB.size());
+
+  // Path A: string overload (legacy).
+  std::unique_ptr<DcmDataset> resultA(
+      dcmqi::Itk2DicomConverter::itkimage2dcmSegmentation(dcmDatasetsA, segmentations, metadata));
+  REQUIRE(resultA != nullptr);
+
+  // Path B: handler overload (new).
+  dcmqi::JSONSegmentationMetaInformationHandler handler(metadata.c_str());
+  handler.read();
+  std::unique_ptr<DcmDataset> resultB(
+      dcmqi::Itk2DicomConverter::itkimage2dcmSegmentation(dcmDatasetsB, segmentations, handler));
+  REQUIRE(resultB != nullptr);
+
+  // Tag-level equivalence checks. We deliberately skip attributes that depend
+  // on per-write state (instance/series UIDs, content dates/times) and assert
+  // only those that a consumer would treat as semantic content.
+  REQUIRE(sequenceItemCount(resultA.get(), DCM_SegmentSequence)
+          == sequenceItemCount(resultB.get(), DCM_SegmentSequence));
+  REQUIRE(sequenceItemCount(resultA.get(), DCM_PerFrameFunctionalGroupsSequence)
+          == sequenceItemCount(resultB.get(), DCM_PerFrameFunctionalGroupsSequence));
+  REQUIRE(collectSegmentLabels(resultA.get()) == collectSegmentLabels(resultB.get()));
+  REQUIRE(readString(resultA.get(), DCM_SegmentsOverlap)
+          == readString(resultB.get(), DCM_SegmentsOverlap));
+  REQUIRE(readString(resultA.get(), DCM_SeriesDescription)
+          == readString(resultB.get(), DCM_SeriesDescription));
+  REQUIRE(readString(resultA.get(), DCM_ContentCreatorName)
+          == readString(resultB.get(), DCM_ContentCreatorName));
+  REQUIRE(readString(resultA.get(), DCM_ClinicalTrialSeriesID)
+          == readString(resultB.get(), DCM_ClinicalTrialSeriesID));
+  REQUIRE(readString(resultA.get(), DCM_ClinicalTrialTimePointID)
+          == readString(resultB.get(), DCM_ClinicalTrialTimePointID));
+  REQUIRE(readString(resultA.get(), DCM_Modality)
+          == readString(resultB.get(), DCM_Modality));
+
+  for (DcmItem* item : dcmDatasetsA) { delete item; }
+  for (DcmItem* item : dcmDatasetsB) { delete item; }
+
+  std::cout << "PASS: itkimage2dcmSegmentation string and handler overloads agree on "
+            << "segment sequence, per-frame functional groups, segment labels, "
+            << "SegmentsOverlap, SeriesDescription, ContentCreatorName, "
+            << "ClinicalTrialSeriesID, ClinicalTrialTimePointID, Modality."
+            << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/include/dcmqi/Itk2DicomConverter.h
+++ b/include/dcmqi/Itk2DicomConverter.h
@@ -96,7 +96,7 @@ namespace dcmqi {
      *         conversion fails (NULL is returned).
      * @return A pointer to the resulting DICOM Segmentation object.
      */
-    template<class ImageSourceType, std::enable_if_t<std::is_same<short, typename ImageSourceType::PixelType>::value, bool> = 0>
+    template<class ImageSourceType, std::enable_if_t<std::is_same_v<short, typename ImageSourceType::PixelType>, bool> = 0>
     static DcmDataset* itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
                           vector<itk::SmartPointer<const ImageSourceType>> segmentations,
                           const string &metaData,
@@ -118,7 +118,7 @@ namespace dcmqi {
      *
      * Parameter semantics are identical to the string overload.
      */
-    template<class ImageSourceType, std::enable_if_t<std::is_same<short, typename ImageSourceType::PixelType>::value, bool> = 0>
+    template<class ImageSourceType, std::enable_if_t<std::is_same_v<short, typename ImageSourceType::PixelType>, bool> = 0>
     static DcmDataset* itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
                           vector<itk::SmartPointer<const ImageSourceType>> segmentations,
                           JSONSegmentationMetaInformationHandler& metaInfo,

--- a/include/dcmqi/Itk2DicomConverter.h
+++ b/include/dcmqi/Itk2DicomConverter.h
@@ -27,6 +27,13 @@ typedef itk::LabelImageToLabelMapFilter<ShortImageType> LabelToLabelMapFilterTyp
 
 namespace dcmqi {
 
+  // Forward declaration: the handler overload of itkimage2dcmSegmentation takes
+  // this only by reference and the template definition lives in the .cpp, so the
+  // full header is not needed here. Callers that want to use the handler overload
+  // must include JSONSegmentationMetaInformationHandler.h themselves to construct
+  // an instance.
+  class JSONSegmentationMetaInformationHandler;
+
   /**
    * @brief The Itk2DicomConverter class provides methods to convert from itk images to DICOM Segmentation objects.
    */
@@ -93,6 +100,28 @@ namespace dcmqi {
     static DcmDataset* itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
                           vector<itk::SmartPointer<const ImageSourceType>> segmentations,
                           const string &metaData,
+                          bool skipEmptySlices=true,
+                          bool useLabelIDAsSegmentNumber=false,
+                          bool referencesGeometryCheck=true,
+                          bool doDicomValueChecks=true,
+                          bool outputLabelMap=false);
+
+    /**
+     * @brief In-memory metadata overload of itkimage2dcmSegmentation.
+     *
+     * Accepts a fully-populated JSONSegmentationMetaInformationHandler instead
+     * of a JSON string. This is the core implementation; the string overload
+     * is a thin wrapper that parses its JSON argument into a handler and
+     * delegates here. Use this overload when the metadata is already held
+     * programmatically and serialising it just to re-parse would be wasteful
+     * or lossy.
+     *
+     * Parameter semantics are identical to the string overload.
+     */
+    template<class ImageSourceType, std::enable_if_t<std::is_same<short, typename ImageSourceType::PixelType>::value, bool> = 0>
+    static DcmDataset* itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
+                          vector<itk::SmartPointer<const ImageSourceType>> segmentations,
+                          JSONSegmentationMetaInformationHandler& metaInfo,
                           bool skipEmptySlices=true,
                           bool useLabelIDAsSegmentNumber=false,
                           bool referencesGeometryCheck=true,

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -35,11 +35,30 @@ namespace dcmqi {
                                                           bool referencesGeometryCheck,
                                                           bool doDicomValueChecks,
                                                           bool outputLabelMap) {
-
-    auto inputSize = segmentations[0]->GetBufferedRegion().GetSize();
-
+    // Thin wrapper around the handler-based overload: parse the JSON string into a
+    // handler and delegate. Keeps the legacy file-driven call sites working while
+    // the handler overload is the load-bearing implementation.
     JSONSegmentationMetaInformationHandler metaInfo(metaData.c_str());
     metaInfo.read();
+    return itkimage2dcmSegmentation(dcmDatasets, segmentations, metaInfo,
+                                    skipEmptySlices, useLabelIDAsSegmentNumber,
+                                    referencesGeometryCheck, doDicomValueChecks,
+                                    outputLabelMap);
+  }
+
+  // -------------------------------------------------------------------------------------
+
+  template<class ImageSourceType, std::enable_if_t<std::is_same<short, typename ImageSourceType::PixelType>::value, bool>>
+  DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
+                                                          vector<itk::SmartPointer<const ImageSourceType>> segmentations,
+                                                          JSONSegmentationMetaInformationHandler& metaInfo,
+                                                          bool skipEmptySlices,
+                                                          bool useLabelIDAsSegmentNumber,
+                                                          bool referencesGeometryCheck,
+                                                          bool doDicomValueChecks,
+                                                          bool outputLabelMap) {
+
+    auto inputSize = segmentations[0]->GetBufferedRegion().GetSize();
 
     if(metaInfo.segmentsAttributesMappingList.size() != segmentations.size()){
       cerr << "Mismatch between the number of input segmentation files and the size of metainfo list!" << endl;
@@ -973,11 +992,31 @@ namespace dcmqi {
       bool doDicomValueChecks,
       bool outputLabelMap);
 
+  template DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation<ShortImageType>(
+      vector<DcmItem*> dcmDatasets,
+      vector<ShortImageType::ConstPointer> segmentations,
+      JSONSegmentationMetaInformationHandler& metaInfo,
+      bool skipEmptySlices,
+      bool useLabelIDAsSegmentNumber,
+      bool referencesGeometryCheck,
+      bool doDicomValueChecks,
+      bool outputLabelMap);
+
   using VectorImageAdapter = itk::VectorImageToImageAdaptor<short, 3U>;
   template DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation<VectorImageAdapter>(
       vector<DcmItem*> dcmDatasets,
       vector<VectorImageAdapter::ConstPointer> segmentations,
       const string& metaData,
+      bool skipEmptySlices,
+      bool useLabelIDAsSegmentNumber,
+      bool referencesGeometryCheck,
+      bool doDicomValueChecks,
+      bool outputLabelMap);
+
+  template DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation<VectorImageAdapter>(
+      vector<DcmItem*> dcmDatasets,
+      vector<VectorImageAdapter::ConstPointer> segmentations,
+      JSONSegmentationMetaInformationHandler& metaInfo,
       bool skipEmptySlices,
       bool useLabelIDAsSegmentNumber,
       bool referencesGeometryCheck,

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -26,7 +26,7 @@ namespace dcmqi {
 
   // -------------------------------------------------------------------------------------
 
-  template<class ImageSourceType, std::enable_if_t<std::is_same<short, typename ImageSourceType::PixelType>::value, bool>>
+  template<class ImageSourceType, std::enable_if_t<std::is_same_v<short, typename ImageSourceType::PixelType>, bool>>
   DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
                                                           vector<itk::SmartPointer<const ImageSourceType>> segmentations,
                                                           const string &metaData,
@@ -38,7 +38,7 @@ namespace dcmqi {
     // Thin wrapper around the handler-based overload: parse the JSON string into a
     // handler and delegate. Keeps the legacy file-driven call sites working while
     // the handler overload is the load-bearing implementation.
-    JSONSegmentationMetaInformationHandler metaInfo(metaData.c_str());
+    JSONSegmentationMetaInformationHandler metaInfo(metaData);
     metaInfo.read();
     return itkimage2dcmSegmentation(dcmDatasets, segmentations, metaInfo,
                                     skipEmptySlices, useLabelIDAsSegmentNumber,
@@ -48,7 +48,7 @@ namespace dcmqi {
 
   // -------------------------------------------------------------------------------------
 
-  template<class ImageSourceType, std::enable_if_t<std::is_same<short, typename ImageSourceType::PixelType>::value, bool>>
+  template<class ImageSourceType, std::enable_if_t<std::is_same_v<short, typename ImageSourceType::PixelType>, bool>>
   DcmDataset* Itk2DicomConverter::itkimage2dcmSegmentation(vector<DcmItem*> dcmDatasets,
                                                           vector<itk::SmartPointer<const ImageSourceType>> segmentations,
                                                           JSONSegmentationMetaInformationHandler& metaInfo,


### PR DESCRIPTION
  ## Summary

  Adds a new template overload of `Itk2DicomConverter::itkimage2dcmSegmentation`
  that takes a `JSONSegmentationMetaInformationHandler&` instead of a JSON
  string. The handler overload becomes the load-bearing implementation; the
  existing string overload is reduced to a thin wrapper that parses its JSON
  argument into a handler and delegates. Behaviour for current callers is
  unchanged.

  ## Motivation

  Consumers (e.g. MITK) build their segmentation metadata programmatically
  and currently have to serialise it to JSON just to have dcmqi parse it
  back into a handler. The new overload removes that round-trip and avoids
  the brittleness of round-tripping rich metadata through JSON.

  ## Testing

  Adds `apps/seg/Testing/Itk2DicomHandlerOverloadEquivalenceTest`, which
  exercises both overloads against the same input and asserts the resulting
  datasets agree on:

  - segment sequence cardinality,
  - per-frame functional groups cardinality,
  - segment labels,
  - `SegmentsOverlap`,
  - patient/study/series context tags.

  Byte-level equality is not asserted, because DCMTK regenerates UIDs and
  timestamps on every write.

  ## Test plan

  - [ ] CI green on all platforms
  - [ ] `Itk2DicomHandlerOverloadEquivalenceTest` passes locally
  - [ ] Existing seg conversion tests still pass (string overload behaviour unchanged)

  ## Files for reviewers

  - **`include/dcmqi/Itk2DicomConverter.h`** — declares the new template overload
    `itkimage2dcmSegmentation(..., JSONSegmentationMetaInformationHandler& metaInfo, ...)`
    alongside the existing string overload. Adds a forward declaration of
    `JSONSegmentationMetaInformationHandler` so the public header stays light;
    callers using the handler overload include
    `JSONSegmentationMetaInformationHandler.h` themselves.
  - **`libsrc/Itk2DicomConverter.cpp`** — moves the full conversion body into the
    handler overload. The string overload is reduced to a few lines that parse the
    JSON into a handler and delegate. Adds explicit template instantiations of the
    new overload for the two pixel adapters already instantiated for the string
    overload (`ShortImageType` and `VectorImageAdapter`), so the ABI surface
    mirrors the existing one exactly.
  - **`apps/seg/Testing/Itk2DicomHandlerOverloadEquivalenceTest.cxx`** (new) —
    equivalence guard: runs both overloads on the same input and compares the
    resulting `DcmDataset`s on the fields listed above. This is the main thing to
    scrutinise — particularly whether the comparison set is sufficient to catch
    regressions where the two paths could silently diverge.
  - **`apps/seg/Testing/CMakeLists.txt`** — wires the new test into CTest.

  ### Suggested review focus

  1. Is the forward declaration in the public header acceptable, or would you
     prefer a full `#include` of `JSONSegmentationMetaInformationHandler.h`?
  2. Does the equivalence-test comparison set cover enough surface, or is there
     a specific field/tag you'd want asserted as well?
  3. The string overload now does an extra handler construction + `read()` step
     that previously happened inline. This is the same work as before, just
     factored — but worth a sanity check that no caller depended on side effects
     ordering.