### PR TITLE
CI: recreate "latest" prerelease via a dedicated finalize job

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -117,24 +117,17 @@ jobs:
         path: build/dcmqi-build/dcmqi-*-linux*.tar.gz
 
     - name: "Publish linux package"
-      # Only run if the event is not a pull request and the repository owner is QIICR.
-      # The latter is to prevent forks from publishing packages even if the owner's token
-      # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      # Publish tagged (stable) releases only. The rolling "latest" prerelease is
+      # (re)created by the finalize-latest workflow once all platforms finish building.
+      # The repository-owner check prevents forks from publishing packages even if the
+      # owner's token would have sufficient privileges.
+      if: ${{ (github.event_name == 'release') && (github.repository_owner == 'QIICR') }}
       env:
         GH_TOKEN: ${{ secrets.GA_TOKEN }}
       run: |
         TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
-        if [ -n "$TAG" ]; then
+        if [ -n "$TAG" ] && [ "$TAG" != "latest" ]; then
           gh release upload "$TAG" \
             build/dcmqi-build/dcmqi-*-linux.tar.gz \
             --clobber
-        else
-          gh release view latest --json assets --jq '.assets[].name' 2>/dev/null \
-            | grep "dcmqi-.*-linux-" \
-            | xargs -I{} gh release delete-asset latest "{}" --yes || true
-          gh release upload latest \
-            build/dcmqi-build/dcmqi-*-linux*.tar.gz \
-            --clobber
-          gh release edit latest --target $(git rev-parse HEAD)
         fi

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -183,25 +183,17 @@ jobs:
         key: ${{ steps.cache-dcmtk-itk-zlib.outputs.cache-primary-key }}
 
     - name: Publish package
-      # Only run if the event is not a pull request and the repository owner is QIICR.
-      # The latter is to prevent forks from publishing packages even if the owner's token
-      # would have sufficient privileges.
-      if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+      # Publish tagged (stable) releases only. The rolling "latest" prerelease is
+      # (re)created by the finalize-latest workflow once all platforms finish building.
+      # The repository-owner check prevents forks from publishing packages even if the
+      # owner's token would have sufficient privileges.
+      if: ${{ (github.event_name == 'release') && (github.repository_owner == 'QIICR') }}
       env:
         GH_TOKEN: ${{ secrets.GA_TOKEN }}
       run: |
         TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
-        if [ -n "$TAG" ]; then
+        if [ -n "$TAG" ] && [ "$TAG" != "latest" ]; then
           gh release upload "$TAG" \
             ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac-${{ matrix.arch }}.tar.gz \
             --clobber
-        else
-          # Clean old prerelease assets for this architecture, then upload new ones
-          gh release view latest --json assets --jq '.assets[].name' 2>/dev/null \
-            | grep "dcmqi-.*-mac-${{ matrix.arch }}-" \
-            | xargs -I{} gh release delete-asset latest "{}" --yes || true
-          gh release upload latest \
-            ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac*.tar.gz \
-            --clobber
-          gh release edit latest --target $(git rev-parse HEAD)
         fi

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -129,10 +129,11 @@ jobs:
 
     runs-on: windows-2022
     timeout-minutes: 10
-    # Only run if the event is not a pull request and the repository owner is QIICR.
-    # The latter is to prevent forks from publishing packages even if the owner's token
-    # would have sufficient privileges.
-    if: ${{ (github.event_name != 'pull_request') && (github.repository_owner == 'QIICR')}}
+    # Publish tagged (stable) releases only. The rolling "latest" prerelease is
+    # (re)created by the finalize-latest workflow once all platforms finish building.
+    # The repository-owner check prevents forks from publishing packages even if the
+    # owner's token would have sufficient privileges.
+    if: ${{ (github.event_name == 'release') && (github.repository_owner == 'QIICR') }}
 
     needs: build-windows
 
@@ -151,16 +152,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GA_TOKEN }}
         run: |
           TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
-          if [ -n "$TAG" ]; then
+          if [ -n "$TAG" ] && [ "$TAG" != "latest" ]; then
             gh release upload "$TAG" \
               "${{ github.workspace }}/b/dcmqi-build"/dcmqi-*-win64.zip \
               --clobber
-          else
-            gh release view latest --json assets --jq '.assets[].name' 2>/dev/null \
-              | grep "dcmqi-.*-win64-" \
-              | xargs -I{} gh release delete-asset latest "{}" --yes || true
-            gh release upload latest \
-              "${{ github.workspace }}/b/dcmqi-build"/dcmqi-*-win64*.zip \
-              --clobber
-            gh release edit latest --target $(git rev-parse HEAD)
           fi

--- a/.github/workflows/finalize-latest.yml
+++ b/.github/workflows/finalize-latest.yml
@@ -1,0 +1,103 @@
+name: Finalize latest prerelease
+
+# Recreates the rolling "latest" prerelease after the per-platform CI builds finish on
+# master. The platform workflows only upload build artifacts; this job gathers them and
+# (re)creates the "latest" release in one place.
+#
+# Why recreate instead of editing the existing release:
+#   * The Releases page sorts by created_at, which cannot be PATCHed. Deleting and
+#     recreating resets created_at so "latest" returns to the top of the list.
+#   * It moves the "latest" git tag to the current commit (plain `gh release edit
+#     --target` does not move an existing tag).
+#   * It keeps only the current commit's assets, so stale tarballs left in cached build
+#     directories never accumulate.
+# This mirrors what scikit-ci-addons' publish_github_release used to do for us.
+#
+# A delete+recreate must not run inside the four parallel build jobs (linux, mac-arm64,
+# mac-x86_64, win) or they would wipe each other's assets, so it lives here as a single
+# coordinator that runs after the builds. GITHUB_TOKEN is used on purpose: release/tag
+# events it creates do not trigger other workflows, so there is no build loop.
+on:
+  workflow_run:
+    workflows:
+      - "C/C++ CI Linux"
+      - "C/C++ CI macOS"
+      - "C/C++ CI Windows"
+    types:
+      - completed
+
+# Serialize per commit so the three build completions don't recreate the release at once.
+concurrency:
+  group: finalize-latest-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    name: Recreate latest prerelease
+    # Only for successful master-push builds in the QIICR repo. Tagged (stable) releases
+    # are published by the build workflows themselves and must not be touched here.
+    if: >-
+      github.repository_owner == 'QIICR' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # manage the "latest" release and its tag
+      actions: read      # list sibling build runs and download their artifacts
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      SHA: ${{ github.event.workflow_run.head_sha }}
+      # Workflow files whose artifacts together make up a complete "latest" release.
+      BUILD_WORKFLOWS: "cmake-linux.yml cmake-macos.yml cmake-win.yml"
+    steps:
+      - name: Collect platform packages for this commit
+        id: collect
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # This workflow fires once per build-workflow completion. Only proceed once all
+          # three have a successful run for this commit; earlier firings defer.
+          for wf in $BUILD_WORKFLOWS; do
+            run_id=$(gh run list --workflow "$wf" --branch master --event push --limit 50 \
+              --json databaseId,headSha,conclusion \
+              --jq "[.[] | select(.headSha == \"$SHA\" and .conclusion == \"success\")][0].databaseId")
+            if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+              echo "::notice::$wf has no successful run for $SHA yet; deferring to a later build completion."
+              echo "ready=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Downloading artifacts from $wf run $run_id"
+            gh run download "$run_id" --dir dist
+          done
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Recreate the latest prerelease
+        if: steps.collect.outputs.ready == 'true'
+        run: |
+          set -euo pipefail
+          SHORT=${SHA:0:7}
+          # Keep only packages built from this exact commit. The date+sha suffix comes from
+          # cmake/dcmqiVersion.cmake (rev-parse --short=7), e.g. dcmqi-1.5.4-linux-20260618-b4b9fe5.tar.gz.
+          ASSETS=()
+          while IFS= read -r f; do
+            ASSETS+=("$f")
+          done < <(find dist -type f \( -name "*-$SHORT.tar.gz" -o -name "*-$SHORT.zip" \) | sort)
+          if [ "${#ASSETS[@]}" -eq 0 ]; then
+            echo "::error::No packages matching commit $SHORT were found under dist/."
+            find dist -type f || true
+            exit 1
+          fi
+          echo "Publishing ${#ASSETS[@]} asset(s) for $SHORT:"
+          printf '  %s\n' "${ASSETS[@]}"
+
+          NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
+          # Delete the existing prerelease and its tag, then recreate both at this commit.
+          # Reusing the "latest" tag keeps the .../releases/download/latest/... URLs stable.
+          gh release delete latest --yes --cleanup-tag || true
+          gh release create latest "${ASSETS[@]}" \
+            --prerelease \
+            --target "$SHA" \
+            --title "Latest (updated on $NOW)" \
+            --notes "Continuous build from commit \`$SHORT\` on $NOW."


### PR DESCRIPTION
## Problem

The [`latest` prerelease](https://github.com/QIICR/dcmqi/releases/tag/latest) looked frozen since February:

- Its **title** (`Latest (updated on 2026-02-25 …)`) and **date** never changed, so on the Releases page it sits **below** the tagged releases and looks abandoned.
- A **stale Linux tarball** (`…-cf08f32.tar.gz`) lingered alongside the current one.

Root cause: on 2026-02-25 the publishing logic was switched from scikit-ci-addons to `gh release edit latest --target HEAD`. That call:

- only updates `target_commitish`, which is **cosmetic for an existing tag** — the `latest` git tag is still stuck at the Feb commit (`8a44eab`);
- never refreshes the title/date, and **can't move the release to the top** because the Releases page sorts by `created_at`, which is not PATCH-able;
- combined with the cached Linux build dir + a loose upload glob, re-uploads old tarballs.

## Fix

A single coordinator workflow, `finalize-latest.yml`, triggered by `workflow_run` after the three platform builds finish on `master`:

1. Waits until **all three** platforms have a successful run for the merged commit, then downloads their build artifacts.
2. Keeps **only assets built from that commit** (matched on the `-<short7sha>` suffix), dropping stale tarballs.
3. **Deletes and recreates** the `latest` release + tag. Recreating resets `created_at` (→ back to the **top** of the Releases page), **moves the tag** to `HEAD`, and refreshes the title/notes. Reusing the same `latest` tag keeps the `…/releases/download/latest/…` URLs stable.
4. Uses **`GITHUB_TOKEN`** so the recreate can't re-trigger the build workflows (no loop).

The three platform workflows now publish **tagged/stable releases only** (`if: github.event_name == 'release'`, plus a `"$TAG" != "latest"` guard).

### Why a separate job

A delete+recreate can't live in the four parallel build jobs (linux, mac-arm64, mac-x86_64, win) — whoever recreated last would wipe the others' assets. So it runs once, after the builds, as a coordinator.

## Dry run

Ran the finalize logic against the current master commit (`b4b9fe5`) — found all 3 runs, downloaded artifacts, and the asset filter behaved correctly:

```
matched 4 asset(s):
  dcmqi-1.5.4-win64-20260618-b4b9fe5.zip
  dcmqi-1.5.4-linux-20260618-b4b9fe5.tar.gz
  dcmqi-1.5.4-mac-arm64-20260618-b4b9fe5.tar.gz
  dcmqi-1.5.4-mac-x86_64-20260618-b4b9fe5.tar.gz
dropped (not this commit):
  dcmqi-1.5.4-linux-20260529-cf08f32.tar.gz
```

(The destructive `gh release delete/create` commands were printed, not executed.)

## Notes for review

- `workflow_run` only activates once this file is on `master`. The **first** finalize run will self-heal the `latest` tag (currently stuck at the Feb commit).
- If any platform build fails, finalize defers and `latest` keeps the last good build.
- Couldn't exercise the live `workflow_run` trigger locally; suggest watching the next master merge after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)