### PR TITLE
CI: fix finalize-latest workflow_run trigger ("Unknown event" startup failures)

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI Linux
+name: CI Linux
 
 on:
   push:

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI macOS
+name: CI macOS
 
 on:
   push:

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI Windows
+name: CI Windows
 
 on:
   push:

--- a/.github/workflows/finalize-latest.yml
+++ b/.github/workflows/finalize-latest.yml
@@ -20,9 +20,9 @@ name: Finalize latest prerelease
 on:
   workflow_run:
     workflows:
-      - "C/C++ CI Linux"
-      - "C/C++ CI macOS"
-      - "C/C++ CI Windows"
+      - "CI Linux"
+      - "CI macOS"
+      - "CI Windows"
     types:
       - completed
 


### PR DESCRIPTION
## Problem

After #542 merged, every build completion on `master` produced an `(Unknown event)` **startup_failure** run (the "unknown event" entries cluttering the Actions tab). GitHub reported:

> Encountered an issue parsing workflow trigger(s) "c/c++ ci linux, c/c++ ci macos, c/c++ ci windows" in a workflow ".github/workflows/finalize-latest.yml".

## Cause

`workflow_run.workflows` matches each entry as a **glob pattern**, where `*`, `+`, `?`, `!` are metacharacters ([docs: filter pattern cheat sheet](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet), [community #50835](https://github.com/orgs/community/discussions/50835)). The `+` in `C/C++ CI ...` made GitHub try to parse `++` as glob quantifiers, so the trigger failed to compile and finalize never actually ran.

## Fix

Drop the special characters: rename the build workflows to **`CI Linux`**, **`CI macOS`**, **`CI Windows`** and update the `workflow_run` trigger to match. (Escaping the `+` would also work, but the plain names are less fragile.)

Safe because:
- The workflow **file names** are unchanged (`cmake-*.yml`), so the finalize script's `gh run list --workflow cmake-linux.yml ...` is unaffected.
- PR **status checks key off job names** (`build-linux`, `build-macos`, `build-windows`, `publish-windows`), not the workflow name.
- No required status checks are enabled on `master`, and no README badges / other files reference the old names (grep-verified).

## After merge

The startup failures stop, and finalize will run for real on the next `master` merge. The **first** successful finalize run will also self-heal the `latest` git tag, which is currently still pinned to the February commit `8a44eab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)