### PR TITLE
CI: inline Windows publish + harden "latest" tag move

### DIFF
--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -125,28 +125,14 @@ jobs:
             ${{ github.workspace }}\b\zlib-prefix
           key: ${{ steps.cache-build-deps.outputs.cache-primary-key }}
 
-  publish-windows:
-
-    runs-on: windows-2022
-    timeout-minutes: 10
-    # Publish tagged (stable) releases only. The rolling "latest" prerelease is
-    # (re)created by the finalize-latest workflow once all platforms finish building.
-    # The repository-owner check prevents forks from publishing packages even if the
-    # owner's token would have sufficient privileges.
-    if: ${{ (github.event_name == 'release') && (github.repository_owner == 'QIICR') }}
-
-    needs: build-windows
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@v8
-        with:
-          name: dcmqi-build
-          path: ${{ github.workspace }}\b\dcmqi-build
-
       - name: Publish package
+        # Publish tagged (stable) releases only, inline like the Linux/macOS builds, so
+        # there is no separate publish job that shows up "skipped" on every master push.
+        # The package built above is still on disk, so no artifact download is needed.
+        # The rolling "latest" prerelease is (re)created by the finalize-latest workflow
+        # once all platforms finish building. The repository-owner check prevents forks
+        # from publishing packages even if the owner's token would have sufficient privileges.
+        if: ${{ (github.event_name == 'release') && (github.repository_owner == 'QIICR') }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GA_TOKEN }}

--- a/.github/workflows/finalize-latest.yml
+++ b/.github/workflows/finalize-latest.yml
@@ -93,9 +93,18 @@ jobs:
           printf '  %s\n' "${ASSETS[@]}"
 
           NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
-          # Delete the existing prerelease and its tag, then recreate both at this commit.
-          # Reusing the "latest" tag keeps the .../releases/download/latest/... URLs stable.
-          gh release delete latest --yes --cleanup-tag || true
+          # Move the rolling "latest" tag to this commit, then replace the release.
+          #
+          # The tag is moved via the git refs API (PATCH, or POST the first time it is
+          # created) rather than `gh release delete --cleanup-tag`, which deletes the ref and
+          # immediately recreates the same one; that delete/recreate race intermittently
+          # returns "HTTP 403: Resource not accessible by integration" on create.
+          # Reusing the "latest" tag keeps the .../releases/download/latest/... URLs stable,
+          # and the release's created_at follows the target commit's date, so it sorts to the top.
+          gh api -X PATCH "repos/$GH_REPO/git/refs/tags/latest" -f sha="$SHA" -F force=true >/dev/null 2>&1 \
+            || gh api -X POST "repos/$GH_REPO/git/refs" -f ref="refs/tags/latest" -f sha="$SHA" >/dev/null
+          # Delete only the release (keep the tag we just moved), then recreate it at this commit.
+          gh release delete latest --yes || true
           gh release create latest "${ASSETS[@]}" \
             --prerelease \
             --target "$SHA" \


### PR DESCRIPTION
Two small, independent cleanups to the release CI, following up on the
finalize-latest work.

### 1. Inline the Windows publish step (`cmake-win.yml`)
The Windows stable-release publish lived in its own `publish-windows` job gated to `release` events, so on every master push it appeared as a **skipped job tile** in the Actions UI. Linux and macOS already publish inline as a step, where the skip is invisible.

Moved the Windows publish into `build-windows` the same way. The packaged `.zip` is still on disk from the package step, so the `download-artifact` (and the extra checkout) the separate job required are gone too. All three platforms are now symmetric.

### 2. Move the `latest` tag via the refs API instead of `--cleanup-tag` (`finalize-latest.yml`)
The finalize job reset the rolling `latest` prerelease with:

```
gh release delete latest --yes --cleanup-tag
gh release create latest ... --target $SHA
```

`--cleanup-tag` deletes the git ref and the create immediately recreates the **same** tag. That delete/recreate race intermittently fails with **`HTTP 403: Resource not accessible by integration`** on the create — observed once on commit `2cc1288`; it self-healed on the next commit, which is why `latest` currently looks fine.

Now the tag is moved **atomically** through the git refs API (`PATCH`, or `POST` the first time it is created), and only the *release* is deleted before being recreated:

```
gh api -X PATCH repos/$GH_REPO/git/refs/tags/latest -f sha=$SHA -F force=true \
  || gh api -X POST repos/$GH_REPO/git/refs -f ref=refs/tags/latest -f sha=$SHA
gh release delete latest --yes        # release only; keep the tag we just moved
gh release create latest ... --target $SHA
```

The `latest` tag and the `…/releases/download/latest/…` URLs stay stable, and `created_at` still follows the target commit's date so `latest` keeps sorting to the top.

### Not changed
The finalize workflow firing ~3× per commit is **by design** — it triggers on completion of all three CI workflows and the earlier firings defer (the recreate step is skipped) until all platform artifacts exist. That is correct and cheap, so it's left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)