### PR TITLE
Document labelmap segment numbering and background

### DIFF
--- a/apps/seg/itkimage2segimage.xml
+++ b/apps/seg/itkimage2segimage.xml
@@ -89,7 +89,7 @@
       <channel>output</channel>
       <longflag>useLabelIDAsSegmentNumber</longflag>
       <default>false</default>
-      <description>Use label IDs from ITK images as Segment Numbers in DICOM. Only works if label IDs are consecutively numbered starting from 1, otherwise conversion will fail.</description>
+      <description>Use label IDs from the input ITK images as Segment Numbers in the DICOM output, instead of numbering segments sequentially from 1 in the order they are processed. For binary segmentations the label IDs must be consecutive starting from 1, otherwise conversion fails. For labelmap segmentations (--segmentationType labelmap) any unique positive label IDs are accepted, including gaps; a label ID used by more than one input segment fails.</description>
     </boolean>
 
     <boolean>

--- a/doc/examples/README.md
+++ b/doc/examples/README.md
@@ -8,6 +8,8 @@ The most common confusion about the format of the JSON file for segmentation con
 
 Remember that you can always use the [`dcmqi` webapp](http://qiicr.org/dcmqi/#/seg) to prepare JSON files for your conversion task, or to build intuition about how things work.
 
+For notes on the conversion tools themselves — for example how Segment Numbers are assigned and how the labelmap background is handled — see [itkimage2segimage.md](../itkimage2segimage.md) (ITK → DICOM) and [segimage2itkimage.md](../segimage2itkimage.md) (DICOM → ITK).
+
 * `seg-example.json`: the most basic example where the input segmentation being converted is stored in a single file, and the file contains a single label
 * `seg-example_multiple_segments_single_input_file.json`: single segmentation file as input, with multiple labels in the input file. This is reflected in the `segmentAttributes` field, which contains outer array with a single entry, and the inner array containing 3 entries corresponding to the 3 labels in the input segmentation.
 * `seg-example_multiple_segments.json`: this is an example of parameterization where each of the segmentation labels is saved in a separate file: outer array contains 3 entries, and each of the innner arrays has just one entry.

--- a/doc/itkimage2segimage.md
+++ b/doc/itkimage2segimage.md
@@ -1,0 +1,134 @@
+# itkimage2segimage
+
+`itkimage2segimage` converts one or more research-format segmentations (ITK
+images such as NRRD, NIfTI or MetaImage) together with a JSON metadata file
+into a DICOM Segmentation object. It can produce either a DICOM **binary**
+Segmentation (the default) or a DICOM **Labelmap** Segmentation
+(`--segmentationType labelmap`, per DICOM Supplement 243). The JSON file
+describes the per-segment metadata (codes, labels, colors, …); its structure is
+documented in [doc/examples](examples/README.md).
+
+This page collects behavioral and implementation notes that are not obvious
+from the `--help` output.
+
+## Implementation notes
+
+### Segment numbering and `--useLabelIDAsSegmentNumber`
+
+Every segment in a DICOM Segmentation has a **Segment Number** — a positive
+integer that identifies it within the object. When building a segmentation,
+`itkimage2segimage` must decide which Segment Number each input label receives.
+The `--useLabelIDAsSegmentNumber` option controls that decision.
+
+The input label value `0` is treated specially and is **never** turned into a
+numbered foreground segment, regardless of this option (the flag never even
+sees it). What happens to it depends on the output type:
+
+- In a **labelmap** segmentation, value `0` becomes the background — it is
+  given Segment Number 0, coded as Background (DCM, 125040), and Pixel Padding
+  Value (0028,0120) is set to `0` — whenever value `0` occurs in the pixel
+  data.
+- In a **binary** segmentation there is no background segment at all; label-`0`
+  pixels simply do not belong to any segment.
+
+**Default (option off).** Segments are numbered **sequentially from 1** in the
+order they are processed: input files are taken in the order given on the
+command line, and the labels within each file in ascending order. The first
+segment encountered becomes Segment Number 1, the second becomes 2, and so on.
+The original label IDs from your ITK image are *not* carried over — they only
+determine processing order, not the resulting numbers.
+
+**Option on.** The input label ID is used **directly** as the Segment Number,
+so the numbering you chose in your ITK image is preserved in the DICOM object.
+The behaviour differs between the two output types because the two DICOM
+representations are different.
+
+#### Binary segmentations (default output)
+
+In a binary segmentation each segment is stored as its own bit-plane, and the
+Segment Number is just an identifier that the frames refer to. With the option
+on, the segments are renumbered to match the input label IDs and the Segment
+Sequence is re-sorted by those numbers (the per-frame references are updated to
+stay consistent).
+
+Because binary Segment Numbers must, by the DICOM standard, start at 1 and
+increase by 1 without gaps, this option works **only if your label IDs are
+exactly 1, 2, 3, … N**. If they contain gaps or do not start at 1, the
+conversion fails. Within that constraint the option effectively *reorders* the
+segments so that Segment Number = label ID.
+
+This has a visible effect only when the input order differs from the label-ID
+order — for example when segmentation files are passed in a different order
+than their labels. If you provide a single file, or files already in label-ID
+order, the output is identical whether the option is on or off.
+
+*Example:* two files passed as `spine` (label 2), then `liver` (label 1).
+
+- Off → Segment 1 = spine, Segment 2 = liver (processing order).
+- On → Segment 1 = liver, Segment 2 = spine (label-ID order).
+
+#### Labelmap segmentations (`--segmentationType labelmap`)
+
+In a labelmap each pixel directly stores the Segment Number of the segment at
+that location, so **Segment Number = pixel value**. With the option on, each
+input label ID becomes both the Segment Number and the pixel value used for
+that segment, so the pixel values in the DICOM labelmap are exactly the label
+values from your ITK image.
+
+Labelmaps do **not** require consecutive numbering, so **gaps are allowed**:
+label IDs `{1, 5, 100}` are accepted and produce pixel values `1`, `5`, `100`.
+The only requirements are that each label ID is positive and **unique across
+the whole input** — a label ID used by more than one input segment is rejected,
+because two segments cannot share one pixel value. (The bit depth, 8- or
+16-bit, is chosen from the largest label ID, not the number of segments.)
+
+With the option off, a labelmap is still produced correctly, but its pixel
+values are renumbered `1 … N` and no longer match your original label IDs.
+
+#### When to use it
+
+Turn the option on when you need the DICOM Segment Numbers — and, for
+labelmaps, the pixel values — to match the label IDs of your input image, most
+importantly to keep label IDs stable across an `ITK → DICOM → ITK` round-trip
+(reading a segmentation back assigns each ITK label from the Segment Number).
+Leave it off if you only care that the segments are present and any consistent
+numbering is acceptable. For labelmaps it is the only way to preserve
+non-consecutive label IDs; for binary segmentations it is a no-op unless your
+input ordering differs from the label-ID order.
+
+### Labelmap background and Pixel Padding Value
+
+A labelmap must describe every pixel value it uses with a Segment Sequence
+item. The value left over where no foreground segment is present — pixel value
+`0`, coming either from input label `0` or from areas (and whole slices) that no
+segment covers — is treated as the **background**.
+
+When pixel value `0` occurs in a labelmap, `itkimage2segimage` designates it as
+the background and writes:
+
+- a segment with **Segment Number 0**, label `Background`, Segmented Property
+  Category Code (SCT, 309825002, "Spatial and Relational Concept"), Type Code
+  (DCM, 125040, "Background"), algorithm type `MANUAL`, and a black Recommended
+  Display CIELab value; and
+- **Pixel Padding Value (0028,0120) = 0** in the General Equipment Module.
+
+Pixel Padding Value is the indicator, per the DICOM standard, that the
+corresponding Segment Number is to be treated as background — a segment merely
+*typed* as Background but without a matching Pixel Padding Value is just a
+regular segment. dcmqi therefore always writes the two together, so they cannot
+disagree. (This follows the discussion in
+[Slicer/Slicer#9163](https://github.com/Slicer/Slicer/pull/9163).)
+
+If every pixel is covered by a foreground segment — a "total segmentation",
+where value `0` never occurs — no background segment and no Pixel Padding Value
+are written.
+
+Binary segmentations never receive a background segment or a Pixel Padding
+Value: there is no background concept (label-`0` pixels simply belong to no
+segment), and Pixel Padding Value is not permitted for a non-labelmap
+Segmentation.
+
+When converting back with [`segimage2itkimage`](segimage2itkimage.md), the
+segment designated as background by Pixel Padding Value is *not* listed in the
+output JSON metadata (its pixels are still written to the output image), so the
+background does not appear as a spurious segment.

--- a/doc/segimage2itkimage.md
+++ b/doc/segimage2itkimage.md
@@ -1,0 +1,60 @@
+# segimage2itkimage
+
+`segimage2itkimage` converts a DICOM Segmentation object back into one or more
+research-format images (ITK images such as NRRD or NIfTI) together with a JSON
+metadata file describing the segments. It reads both **binary** and **labelmap**
+(`SOP Class` Label Map Segmentation, per DICOM Supplement 243) Segmentations.
+
+This page collects behavioral and implementation notes that are not obvious
+from the `--help` output. They concern labelmap input; see also the
+write-direction notes in [itkimage2segimage.md](itkimage2segimage.md).
+
+## Implementation notes
+
+### Labelmap background and Pixel Padding Value
+
+In a labelmap, the segment designated as **background** is identified by Pixel
+Padding Value (0028,0120): the value it holds is the Segment Number treated as
+background (see [itkimage2segimage.md](itkimage2segimage.md) for how this is
+written). On reading, that segment is handled specially:
+
+- It is **omitted from the JSON metadata** — the background does not appear as a
+  segment in the segment list. Its pixels are still written to the output image
+  unchanged (for a typical file the background value is `0`, which is also the
+  image's zero/empty value).
+- If Pixel Padding Value designates a **non-zero** value, a warning is logged:
+  the segment is still omitted from the JSON, but its pixels keep that non-zero
+  value in the output image, and consuming applications may not recognize them
+  as background.
+
+Pixel Padding Value is the *only* indicator used. A segment merely **typed** as
+Background (DCM, 125040) but **not** designated by Pixel Padding Value is treated
+as an ordinary segment: it is kept in the JSON metadata, and a warning is logged
+to point out the discrepancy. This mirrors the write side, where the two are
+always emitted together.
+
+### Missing frames in sparse labelmaps
+
+A labelmap need not encode a frame for every slice position of the volume it
+spans (`itkimage2segimage`, for instance, omits slices that contain no segment
+unless `--skip 0` is given). The output ITK image is a dense grid, so every
+position must hold a value; `segimage2itkimage` reconstructs the grid from the
+frame positions that *are* present and fills the rest:
+
+- Positions missing at the **borders** of the volume are not reconstructed at
+  all — the grid simply shrinks to span the encoded frames (the outermost
+  encoded frame becomes the first/last slice). World coordinates of the encoded
+  data are preserved, but the grid no longer matches the original input volume.
+- Positions missing in the **interior** are filled. The fill value is the Pixel
+  Padding Value if present, otherwise `0`. Filling with the background value
+  means these positions read back as background, which is normally what was
+  intended.
+
+If there is **no** Pixel Padding Value, interior frames are missing, **and** a
+real segment occupies pixel value `0`, the missing positions are still filled
+with `0`, but a warning is logged: the filled-in positions then cannot be
+distinguished from that segment in the output image.
+
+A Pixel Padding Value that does not fit the pixel data (a value greater than 255
+in an 8-bit labelmap) is ignored, with a warning, and the fill value falls back
+to `0`.


### PR DESCRIPTION
Add end-user notes for the segmentation conversion tools, covering behavior that is not obvious from --help:

- doc/itkimage2segimage.md: how Segment Numbers are assigned (--useLabelIDAsSegmentNumber; consecutive 1..N for binary, gaps allowed for labelmap) and how the labelmap background is written (Background segment plus Pixel Padding Value).
- doc/segimage2itkimage.md: how the Pixel Padding Value background is omitted from the JSON on read, and how missing frames in sparse labelmaps are filled.

Also correct the --useLabelIDAsSegmentNumber description in itkimage2segimage.xml, which claimed label IDs must always be consecutive (no longer true for labelmap output), and link both pages from doc/examples/README.md.