### PR TITLE
Guard DCMTK zlib/deflate support

### DIFF
--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -83,14 +83,22 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DBUILD_SHARED_LIBS:BOOL=OFF
       -DDCMTK_WITH_DOXYGEN:BOOL=OFF
       # Build DCMTK against the bundled (symbol-prefixed) zlib, the same one ITK
-      # uses. DCMTK_WITH_ZLIB=ON only *requests* zlib; DCMTK then runs its own
-      # find_package(ZLIB). Without these hints it fell back to a system zlib,
-      # which exists on macOS/Linux runners but not on Windows - so the Windows
-      # release silently built without zlib and could not read/write Deflated
-      # Explicit VR Little Endian datasets ("Unsupported compression or
-      # encryption"). Passing the bundled zlib makes deflate support consistent
-      # across platforms (see apps/seg/Testing deflate round-trip tests).
+      # uses, so Deflated Explicit VR Little Endian SEG/PMAP datasets can be read
+      # and written. Two things are needed:
+      #   1. DCMTK_USE_FIND_PACKAGE=ON. On MSVC/Windows DCMTK defaults this to
+      #      OFF and instead globs a pre-built "support libraries" directory for
+      #      zlib_d.lib/zlib_o.lib (DCMTK's CMake/3rdparty.cmake). Our superbuild
+      #      does not ship that layout, so DCMTK silently disabled zlib
+      #      ("ZLIB support will be disabled because zlib directory was not
+      #      specified") and the 1.5.5 Windows release could not load deflated
+      #      SEGs ("Unsupported compression or encryption"). macOS/Linux already
+      #      default this ON, which is why they were unaffected. Forcing it ON
+      #      makes DCMTK use find_package(ZLIB) on every platform.
+      #   2. The ZLIB_* hints below point that find_package(ZLIB) at the bundled
+      #      zlib instead of a system one, keeping deflate support consistent
+      #      across platforms (see apps/seg/Testing deflate round-trip tests).
       -DDCMTK_WITH_ZLIB:BOOL=ON
+      -DDCMTK_USE_FIND_PACKAGE:BOOL=ON
       -DZLIB_ROOT:PATH=${ZLIB_ROOT}
       -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
       -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}

--- a/CMakeExternals/DCMTK.cmake
+++ b/CMakeExternals/DCMTK.cmake
@@ -4,7 +4,7 @@
 
 set(proj DCMTK)
 
-set(${proj}_DEPENDENCIES "")
+set(${proj}_DEPENDENCIES zlib)
 
 ExternalProject_Include_Dependencies(${proj}
   PROJECT_VAR proj
@@ -82,7 +82,18 @@ if(NOT DEFINED DCMTK_DIR AND NOT ${CMAKE_PROJECT_NAME}_USE_SYSTEM_${proj})
       -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
       -DBUILD_SHARED_LIBS:BOOL=OFF
       -DDCMTK_WITH_DOXYGEN:BOOL=OFF
+      # Build DCMTK against the bundled (symbol-prefixed) zlib, the same one ITK
+      # uses. DCMTK_WITH_ZLIB=ON only *requests* zlib; DCMTK then runs its own
+      # find_package(ZLIB). Without these hints it fell back to a system zlib,
+      # which exists on macOS/Linux runners but not on Windows - so the Windows
+      # release silently built without zlib and could not read/write Deflated
+      # Explicit VR Little Endian datasets ("Unsupported compression or
+      # encryption"). Passing the bundled zlib makes deflate support consistent
+      # across platforms (see apps/seg/Testing deflate round-trip tests).
       -DDCMTK_WITH_ZLIB:BOOL=ON
+      -DZLIB_ROOT:PATH=${ZLIB_ROOT}
+      -DZLIB_INCLUDE_DIR:PATH=${ZLIB_INCLUDE_DIR}
+      -DZLIB_LIBRARY:FILEPATH=${ZLIB_LIBRARY}
       -DDCMTK_WITH_OPENSSL:BOOL=OFF # see github issue #25
       -DDCMTK_WITH_PNG:BOOL=OFF # see github issue #25
       -DDCMTK_WITH_TIFF:BOOL=OFF  # see github issue #25

--- a/apps/seg/Testing/CMakeLists.txt
+++ b/apps/seg/Testing/CMakeLists.txt
@@ -265,6 +265,49 @@ dcmqi_add_test(
     ${itk2dcm}_makeSEG
   )
 
+# ------------------------------------------------------------------------------
+# Deflate (Deflated Explicit VR Little Endian, 1.2.840.10008.1.2.1.99) round-trip.
+#
+# Reading or writing a deflated dataset requires DCMTK to have been built with
+# zlib. This pair is a regression guard for builds where it was not: the dcmqi
+# 1.5.5 Windows release shipped a DCMTK without zlib (the superbuild requested
+# DCMTK_WITH_ZLIB=ON but never handed DCMTK the bundled zlib, and the Windows
+# runner has no system zlib), so loading a deflated SEG failed at load time with
+#   "Unsupported compression or encryption".
+# macOS/Linux happened to find a system zlib, hence the platform-dependent break.
+#
+# makeSEG_deflate writes the same liver segmentation as makeSEG but with
+# --compress deflate; makeNRRD_deflate reads it back and must reproduce the
+# liver_seg.nrrd baseline. On a zlib-less DCMTK the write step already fails,
+# so this whole chain goes red there and green once zlib is wired into DCMTK.
+dcmqi_add_test(
+  NAME ${itk2dcm}_makeSEG_deflate
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:${itk2dcm}>
+    --inputMetadata ${CMAKE_SOURCE_DIR}/doc/examples/seg-example.json
+    --inputImageList ${BASELINE}/liver_seg.nrrd
+    --inputDICOMDirectory ${DICOM_DIR}
+    --outputDICOM ${MODULE_TEMP_DIR}/liver-deflate.dcm
+    --compress deflate
+  )
+
+dcmqi_add_test(
+  NAME ${dcm2itk}_makeNRRD_deflate
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:${dcm2itk}Test>
+    --compare ${BASELINE}/liver_seg.nrrd
+    ${MODULE_TEMP_DIR}/makeNRRD_deflate-1.nrrd
+    ${dcm2itk}Test
+    --inputDICOM ${MODULE_TEMP_DIR}/liver-deflate.dcm
+    --outputDirectory ${MODULE_TEMP_DIR}
+    --outputType nrrd
+    --prefix makeNRRD_deflate
+  TEST_DEPENDS
+    ${itk2dcm}_makeSEG_deflate
+  )
+
+# ------------------------------------------------------------------------------
+
 dcmqi_add_test(
   NAME ${dcm2itk}_makeNRRD_from_labelmap_direct
   MODULE_NAME ${MODULE_NAME}


### PR DESCRIPTION
## Background

A user reported that the dcmqi **1.5.5 Windows** release fails to load a (MOOSE-generated) DICOM SEG, while the **macOS** release reads the same file fine:

```
Loading DICOM SEG file ...clin_ct_cardiac_8.dcm
Condition failed: Unsupported compression or encryption in segimage2itkimage.cxx:67
```

The file is stored in **Deflated Explicit VR Little Endian** (`1.2.840.10008.1.2.1.99`) — the whole dataset is zlib-compressed, so it must be inflated at `loadFile` time. That requires DCMTK to have been built with zlib.

### Root cause
The superbuild requests `DCMTK_WITH_ZLIB=ON` but never hands DCMTK the bundled zlib (`CMakeExternals/DCMTK.cmake` has empty `DEPENDENCIES` and passes no `ZLIB_*`). DCMTK then runs its own `find_package(ZLIB)`:
- **macOS/Linux runners** have a system zlib → DCMTK gets deflate support → file loads. (Confirmed locally: the macOS DCMTK build cache resolved `ZLIB_LIBRARY_RELEASE` to the SDK's `libz.tbd`.)
- **Windows runner** has no system zlib → DCMTK silently builds without it → `EC_UnsupportedEncoding` ("Unsupported compression or encryption") on any deflated dataset.

## This PR (test only)

Adds a deflate round-trip regression test in `apps/seg/Testing/CMakeLists.txt`:
- `itkimage2segimage_makeSEG_deflate` — writes the liver SEG with `--compress deflate`.
- `segimage2itkimage_makeNRRD_deflate` — reads it back, compares to the `liver_seg.nrrd` baseline.

**Expected result:** passes on Linux/macOS, **fails on Windows** (the `--compress deflate` write step already fails without zlib). This is intentional — the test is pushed first to confirm the platform behavior in CI. The DCMTK-zlib fix will follow in this branch, after which the test should go green everywhere.

Draft until the fix is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)