### PR TITLE
CI: don't cache half-built deps from cancelled/failed builds

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -110,6 +110,16 @@ jobs:
             CACHE_OK=false
           fi
 
+          # ITKConfig.cmake is written at configure time, but the static libraries only
+          # appear once ITK has finished compiling. A cache saved from a half-built ITK
+          # has the config but no libs, passing the check above yet failing later at link
+          # ("libITKCommon-*.a ... missing and no known rule to make it"). Require a real
+          # library so such a partial cache is rejected and rebuilt cleanly instead.
+          if ! ls "$GITHUB_WORKSPACE"/dcmqi-build/ITK-build/lib/libITKCommon-*.a >/dev/null 2>&1; then
+            echo "Missing ITK libraries: $GITHUB_WORKSPACE/dcmqi-build/ITK-build/lib/libITKCommon-*.a (cached ITK build is incomplete)"
+            CACHE_OK=false
+          fi
+
           if [ ! -f "$GITHUB_WORKSPACE/dcmqi-build/DCMTK-build/DCMTKConfig.cmake" ]; then
             echo "Missing DCMTK config: $GITHUB_WORKSPACE/dcmqi-build/DCMTK-build/DCMTKConfig.cmake"
             CACHE_OK=false
@@ -139,6 +149,7 @@ jobs:
 
     # Build dcmqi
     - name: "Build dcmqi"
+      id: build
       run: |
         cd ${{ github.workspace }}/dcmqi-build && ninja
 
@@ -169,9 +180,15 @@ jobs:
         name: dcmqi-macos-${{ matrix.arch }}-package
         path: ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac*.tar.gz
 
-    # Save cache even if a later step (test, package) failed, so deps don't need rebuilding next run
+    # Save the dependency cache only when the build step itself succeeded. This keeps the
+    # original intent -- cache the deps even if a *later* step (test, package) fails -- while
+    # never snapshotting a half-built tree when the build is cancelled (e.g. by the
+    # cancel-in-progress concurrency rule) or fails partway. A partial cache used to poison
+    # every subsequent run: once it exists, the restore below is a hit, so this save is
+    # skipped and the broken entry is never overwritten. `!cancelled()` keeps this step
+    # eligible after a failed test/package; `steps.build.outcome` does the real gating.
     - name: Save DCMTK, ITK and ZLIB cache
-      if: always() && steps.cache-dcmtk-itk-zlib.outputs.cache-hit != 'true'
+      if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.cache-dcmtk-itk-zlib.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v5
       with:
         path: |

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -76,6 +76,7 @@ jobs:
           cmake -G "Visual Studio 17 2022" -Ax64 -DBUILD_SHARED_LIBS:BOOL=OFF ${{ github.workspace }}
 
       - name: Build dcmqi
+        id: build
         run: |
           cd ${{ github.workspace }}\b/
           cmake --build . --config Release -- /m
@@ -105,9 +106,14 @@ jobs:
             name: dcmqi-build
             path: ${{ github.workspace }}\b\dcmqi-build\dcmqi-*-win64*.zip
 
-      # Save cache even if a later step (test, package) failed, so deps don't need rebuilding next run
+      # Save the dependency cache only when the build step itself succeeded. This keeps the
+      # original intent -- cache the deps even if a *later* step (test, package) fails -- while
+      # never snapshotting a half-built tree when the build is cancelled (e.g. by the
+      # cancel-in-progress concurrency rule) or fails partway. This matters more here because of
+      # the restore-keys prefix fallback above: a partial saved under any windows-deps-* key
+      # would otherwise be resurrected on later runs and poison them.
       - name: Save build dependencies cache
-        if: always() && steps.cache-build-deps.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.cache-build-deps.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5
         with:
           path: |


### PR DESCRIPTION
## Problem

The v1.5.6 release builds failed on macOS (and were one step from the same fate on Windows) with:

```
ninja: error: '.../ITK-build/lib/libITKCommon-5.4.a', needed by 'GenerateCLP/bin/GenerateCLP',
missing and no known rule to make it
```

Root cause was a **poisoned dependency cache**, not anything in the release. The macOS and Windows workflows save the DCMTK/ITK/zlib cache with:

```yaml
if: always() && steps.<restore>.outputs.cache-hit != 'true'
```

`always()` also evaluates true when a job is **cancelled**. The `cancel-in-progress` concurrency rule cancels superseded `master` pushes mid-build, and the cancelled job still ran the save step — archiving a **half-built tree**. A half-compiled ITK has `ITKConfig.cmake` (written at configure time) but not its `libITKCommon-*.a` (written later during compilation), so the archive is a valid cache of a broken tree.

Verified from the step record of a cancelled run (`28198907054`, job `83532943609`): `Build dcmqi` → `cancelled` at 20:38:15, `Test`/`Package`/`Upload` → `skipped`, but **`Save DCMTK, ITK and ZLIB cache` → success at 20:38:18** — the exact `created_at` of the resulting 57.7 MB partial cache (a complete one is ~785 MB).

It was self-perpetuating: once a partial exists, later runs get a cache **hit**, which (a) restores the broken tree and (b) satisfies `cache-hit != 'true'` so the save step is skipped — nothing ever overwrites the bad entry.

## Fix

Gate the save on the **build step having actually succeeded**:

```yaml
if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.<restore>.outputs.cache-hit != 'true' }}
```

- Preserves the original intent (the old comment): still caches deps when a *later* step (`test`, `package`) fails — `!cancelled()` keeps the step eligible after such a failure.
- Never snapshots a tree from a **cancelled** or **failed** build — `steps.build.outcome == 'success'` is the real gate.

Also hardens the macOS **Validate restored cache** step to require a real ITK library (`libITKCommon-*.a`), not just `ITKConfig.cmake` — exactly the gap that let the partial pass validation and then fail at link. Any partial that slips through is now rejected and rebuilt cleanly.

**Linux** uses the combined `actions/cache` action, whose post-save does not run on cancellation, so it never exhibited this and is left unchanged.

## Notes for reviewer / follow-up

- The poisoned macOS caches were already deleted manually and v1.5.6 was re-run successfully — this PR prevents recurrence.
- A lurking 69.7 MB partial cache under the `windows-deps-*` key should still be deleted manually (its `restore-keys` prefix fallback means it can be resurrected on a future Windows run); this PR stops new ones being created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)