### PR TITLE
fix: actually gate the dependency cache save on a successful build

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -188,7 +188,7 @@ jobs:
     # skipped and the broken entry is never overwritten. `!cancelled()` keeps this step
     # eligible after a failed test/package; `steps.build.outcome` does the real gating.
     - name: Save DCMTK, ITK and ZLIB cache
-      if: always() && steps.cache-dcmtk-itk-zlib.outputs.cache-hit != 'true'
+      if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.cache-dcmtk-itk-zlib.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v6
       with:
         path: |

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -113,7 +113,7 @@ jobs:
       # the restore-keys prefix fallback above: a partial saved under any windows-deps-* key
       # would otherwise be resurrected on later runs and poison them.
       - name: Save build dependencies cache
-        if: always() && steps.cache-build-deps.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.cache-build-deps.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v6
         with:
           path: |


### PR DESCRIPTION
## Summary

Follow-up to #550. That PR added `id: build` to the macOS and Windows build steps and rewrote the comments above the cache-save steps to describe the save as conditional on the build succeeding — but the `if:` expressions were left as `always()`, so the change never took effect. `id: build` is currently unreferenced.

The result is that the behaviour #550 set out to prevent still happens: a build cancelled by the `cancel-in-progress` concurrency rule (which fires on every push to an open PR) or one that fails partway still saves a half-built DCMTK/ITK/zlib tree.

A partial entry is self-perpetuating — the restore is a hit on the next run, so the save step is skipped and the bad entry is never overwritten. On Windows the `restore-keys` prefix fallback makes it worse, since any `windows-deps-*` entry can be resurrected into a later run.

## Change

Two lines, applying the condition the existing comments already document:

```diff
-if: always() && steps.cache-...outputs.cache-hit != 'true'
+if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.cache-...outputs.cache-hit != 'true' }}
```

`!cancelled()` keeps the step eligible after a failed test or package step — the original intent, since the dependencies are complete by then — while `steps.build.outcome` does the real gating.

## Not included

`cmake-linux.yml` has the same exposure but a different shape: it uses the combined `actions/cache` action, whose save runs as a post step that no `if:` here can gate. Hardening it means splitting it into `restore`/`save` first, which seemed worth doing separately rather than folding into a two-line fix.

## Test plan

Not directly observable in CI (it changes what happens on cancellation), so verified by inspection: both jobs define `id: build` at the step this now references, and both workflows still parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)