### PR TITLE
Build and publish an arm64 Linux package

### DIFF
--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -13,9 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  deployments: write
-  packages: write
+# Permissions are declared per job. A job-level block replaces the workflow-level one
+# rather than merging with it, so a workflow-level block here would have had no effect
+# on either job below -- and the macOS and Windows workflows already declare none.
 
 jobs:
   build-linux:

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -131,3 +131,218 @@ jobs:
             build/dcmqi-build/dcmqi-*-linux.tar.gz \
             --clobber
         fi
+
+  # The arm64 package is built natively rather than through docker/Makefile: the dockcross
+  # images that drive the x86_64 build are themselves amd64-only cross toolchains, so they
+  # cannot run on an arm64 host and cannot execute the binaries they produce. Building
+  # inside the official manylinux image on an arm64 runner keeps the tests native while
+  # holding the glibc floor of the shipped binaries at 2.28 (AlmaLinux 8), well below the
+  # runner's own Ubuntu 24.04. Building bare on the runner would raise that floor to 2.39
+  # and make the package unusable on most current distributions.
+  #
+  # manylinux_2_28 is also the oldest image usable here: a container job runs JS actions
+  # (checkout, cache, upload-artifact) on the node binary the runner injects, and that
+  # needs glibc >= 2.28. The older manylinux2014 image would give a 2.17 floor but cannot
+  # run those actions at all.
+  #
+  # This job intentionally does not build or publish the qiicr/dcmqi docker image; that
+  # image remains x86_64-only and is handled by build-linux above.
+  build-linux-arm64:
+
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+
+    container: quay.io/pypa/manylinux_2_28_aarch64
+
+    permissions:
+      contents: write
+      actions: write
+      packages: write
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    # The container runs as root while the checkout is owned by the runner user, which
+    # makes git refuse to read the repository; `git describe` is used when publishing.
+    - name: "Mark workspace as a safe git directory"
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    # cmake and git ship with the manylinux image, ninja does not. cmake is pinned below
+    # 4.0 because the superbuild's external projects (DCMTK, ITK, zlib) still declare
+    # cmake_minimum_required values that CMake 4 rejects.
+    - name: "Install build tools"
+      run: |
+        set -euo pipefail
+        PYTHON=/opt/python/cp312-cp312/bin/python
+        if [ ! -x "$PYTHON" ]; then
+          # Fall back to the newest CPython in the image if the pinned one is ever dropped.
+          PYTHON=$(ls -1 /opt/python/cp3*-cp3*/bin/python | sort -V | tail -n 1)
+        fi
+        "$PYTHON" -m pip install --no-cache-dir "cmake<4" ninja jsondiff
+        echo "PYTHON=$PYTHON" >> "$GITHUB_ENV"
+        echo "$(dirname "$PYTHON")" >> "$GITHUB_PATH"
+
+    - name: "Report toolchain"
+      run: |
+        cmake --version
+        ninja --version
+        gcc --version
+        "$PYTHON" --version
+
+    # Same layout and caching strategy as the macOS build: DCMTK/ITK need both their source
+    # and build trees, zlib only its install tree.
+    - name: "Prepare cache directories"
+      run: |
+        mkdir -p ${{ github.workspace }}/dcmqi-build/DCMTK-build
+        mkdir -p ${{ github.workspace }}/dcmqi-build/DCMTK
+        mkdir -p ${{ github.workspace }}/dcmqi-build/ITK
+        mkdir -p ${{ github.workspace }}/dcmqi-build/ITK-build
+        mkdir -p ${{ github.workspace }}/dcmqi-build/zlib-install
+
+    - name: Check for cached DCMTK, ITK and ZLIB
+      id: cache-dcmtk-itk-zlib
+      uses: actions/cache/restore@v6
+      env:
+        cache-name: cache-dcmtk-itk-zlib-v2
+      with:
+        path: |
+          ${{ github.workspace }}/dcmqi-build/DCMTK
+          ${{ github.workspace }}/dcmqi-build/DCMTK-build
+          ${{ github.workspace }}/dcmqi-build/ITK
+          ${{ github.workspace }}/dcmqi-build/ITK-build
+          ${{ github.workspace }}/dcmqi-build/zlib-install
+        key: ${{ runner.os }}-arm64-manylinux_2_28-build-${{ env.cache-name }}-${{ hashFiles('CMakeExternals/DCMTK.cmake','CMakeExternals/ITK.cmake', 'CMakeExternals/zlib.cmake') }}
+
+    - name: Report cache status
+      run: |
+        if [ "${{ steps.cache-dcmtk-itk-zlib.outputs.cache-hit }}" == "true" ]; then
+          echo "✓ Cache hit! Using cached DCMTK, ITK, and zlib"
+          echo "Cache key: ${{ steps.cache-dcmtk-itk-zlib.outputs.cache-primary-key }}"
+          du -sh ${{ github.workspace }}/dcmqi-build/DCMTK* ${{ github.workspace }}/dcmqi-build/ITK* ${{ github.workspace }}/dcmqi-build/zlib-install 2>/dev/null || true
+        else
+          echo "✗ Cache miss. Will build DCMTK, ITK, and zlib from source"
+        fi
+
+    - name: Validate restored cache
+      id: validate-cache
+      run: |
+        CACHE_OK=false
+
+        if [ "${{ steps.cache-dcmtk-itk-zlib.outputs.cache-hit }}" == "true" ]; then
+          CACHE_OK=true
+
+          if [ ! -f "$GITHUB_WORKSPACE/dcmqi-build/ITK-build/ITKConfig.cmake" ]; then
+            echo "Missing ITK config: $GITHUB_WORKSPACE/dcmqi-build/ITK-build/ITKConfig.cmake"
+            CACHE_OK=false
+          fi
+
+          # ITKConfig.cmake is written at configure time, but the static libraries only
+          # appear once ITK has finished compiling. A cache saved from a half-built ITK
+          # has the config but no libs, passing the check above yet failing later at link
+          # ("libITKCommon-*.a ... missing and no known rule to make it"). Require a real
+          # library so such a partial cache is rejected and rebuilt cleanly instead.
+          if ! ls "$GITHUB_WORKSPACE"/dcmqi-build/ITK-build/lib/libITKCommon-*.a >/dev/null 2>&1; then
+            echo "Missing ITK libraries: $GITHUB_WORKSPACE/dcmqi-build/ITK-build/lib/libITKCommon-*.a (cached ITK build is incomplete)"
+            CACHE_OK=false
+          fi
+
+          if [ ! -f "$GITHUB_WORKSPACE/dcmqi-build/DCMTK-build/DCMTKConfig.cmake" ]; then
+            echo "Missing DCMTK config: $GITHUB_WORKSPACE/dcmqi-build/DCMTK-build/DCMTKConfig.cmake"
+            CACHE_OK=false
+          fi
+
+          if [ ! -d "$GITHUB_WORKSPACE/dcmqi-build/zlib-install/include" ] || [ ! -d "$GITHUB_WORKSPACE/dcmqi-build/zlib-install/lib" ]; then
+            echo "Missing zlib install directories: $GITHUB_WORKSPACE/dcmqi-build/zlib-install/include and/or $GITHUB_WORKSPACE/dcmqi-build/zlib-install/lib"
+            CACHE_OK=false
+          fi
+        fi
+
+        echo "cache_ok=$CACHE_OK" >> "$GITHUB_OUTPUT"
+        echo "Validated cache usability: $CACHE_OK"
+
+    - name: "Configure dcmqi w/ cached DCMTK/ITK/ZLIB"
+      if: ${{ steps.cache-dcmtk-itk-zlib.outputs.cache-hit == 'true' && steps.validate-cache.outputs.cache_ok == 'true' }}
+      run: |
+        cd ${{ github.workspace }}/dcmqi-build && cmake -G Ninja ${{ github.workspace }} -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE:FILEPATH=$PYTHON -DDCMTK_DIR=${{ github.workspace }}/dcmqi-build/DCMTK-build -DITK_DIR=${{ github.workspace }}/dcmqi-build/ITK-build -DZLIB_ROOT=${{ github.workspace }}/dcmqi-build/zlib-install
+
+    - name: "Configure dcmqi w/o cached DCMTK/ITK/ZLIB"
+      if: ${{ steps.cache-dcmtk-itk-zlib.outputs.cache-hit != 'true' || steps.validate-cache.outputs.cache_ok != 'true' }}
+      run: |
+        cd ${{ github.workspace }}/dcmqi-build && cmake -G Ninja ${{ github.workspace }} -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE:FILEPATH=$PYTHON
+
+    - name: "Build dcmqi"
+      id: build
+      run: |
+        cd ${{ github.workspace }}/dcmqi-build && ninja
+
+    # The dciodvfy (dicom3tools) and ajv tests are skipped here, exactly as they are on
+    # macOS: both are optional and CMake drops them when the executables are absent.
+    - name: "Test dcmqi"
+      run: |
+        cd ${{ github.workspace }}/dcmqi-build/dcmqi-build
+        ctest -j4 -D ExperimentalTest -VV --no-compress-output
+
+    - name: "Package dcmqi"
+      run: |
+        cd ${{ github.workspace }}/dcmqi-build/dcmqi-build && ninja package
+
+    - name: "Upload package as artifact"
+      id: upload-artifact
+      uses: actions/upload-artifact@v7
+      continue-on-error: true
+      with:
+        name: dcmqi-linux-arm64-package
+        path: ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-linux-arm64*.tar.gz
+
+    - name: "Upload package as artifact (retry)"
+      if: steps.upload-artifact.outcome == 'failure'
+      uses: actions/upload-artifact@v7
+      with:
+        name: dcmqi-linux-arm64-package
+        path: ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-linux-arm64*.tar.gz
+
+    # Save the dependency cache only when the build step itself succeeded. This keeps the
+    # original intent -- cache the deps even if a *later* step (test, package) fails -- while
+    # never snapshotting a half-built tree when the build is cancelled (e.g. by the
+    # cancel-in-progress concurrency rule) or fails partway. A partial cache would poison
+    # every subsequent run: once it exists the restore above is a hit, so this save is
+    # skipped and the broken entry is never overwritten. `!cancelled()` keeps this step
+    # eligible after a failed test/package; `steps.build.outcome` does the real gating.
+    - name: Save DCMTK, ITK and ZLIB cache
+      if: ${{ !cancelled() && steps.build.outcome == 'success' && steps.cache-dcmtk-itk-zlib.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v6
+      with:
+        path: |
+          ${{ github.workspace }}/dcmqi-build/DCMTK
+          ${{ github.workspace }}/dcmqi-build/DCMTK-build
+          ${{ github.workspace }}/dcmqi-build/ITK
+          ${{ github.workspace }}/dcmqi-build/ITK-build
+          ${{ github.workspace }}/dcmqi-build/zlib-install
+        key: ${{ steps.cache-dcmtk-itk-zlib.outputs.cache-primary-key }}
+
+    - name: "Publish linux-arm64 package"
+      # Publish tagged (stable) releases only. The rolling "latest" prerelease is
+      # (re)created by the finalize-latest workflow once all platforms finish building.
+      # The repository-owner check prevents forks from publishing packages even if the
+      # owner's token would have sufficient privileges.
+      if: ${{ (github.event_name == 'release') && (github.repository_owner == 'QIICR') }}
+      env:
+        GH_TOKEN: ${{ secrets.GA_TOKEN }}
+      run: |
+        set -euo pipefail
+        TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
+        if [ -n "$TAG" ] && [ "$TAG" != "latest" ]; then
+          # Unlike the GitHub-hosted images, the manylinux container has no GitHub CLI, so
+          # fetch the static arm64 build to keep this step identical to the other platforms.
+          gh_version=$(curl -sSL https://api.github.com/repos/cli/cli/releases/latest \
+            | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | head -n 1)
+          curl -sSL "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_arm64.tar.gz" \
+            | tar -xz -C /tmp
+          export PATH="/tmp/gh_${gh_version}_linux_arm64/bin:$PATH"
+
+          gh release upload "$TAG" \
+            ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-linux-arm64.tar.gz \
+            --clobber
+        fi

--- a/.github/workflows/cmake-linux.yml
+++ b/.github/workflows/cmake-linux.yml
@@ -193,13 +193,19 @@ jobs:
 
     # Same layout and caching strategy as the macOS build: DCMTK/ITK need both their source
     # and build trees, zlib only its install tree.
+    #
+    # Paths below are deliberately workspace-relative, and the shell steps use
+    # $GITHUB_WORKSPACE rather than the ${{ github.workspace }} expression the other jobs use.
+    # In a container job the two disagree: the expression is evaluated on the host and yields
+    # /home/runner/work/..., while the repository is mounted inside the container at /__w/....
+    # Using the expression here silently operates on an empty host path.
     - name: "Prepare cache directories"
       run: |
-        mkdir -p ${{ github.workspace }}/dcmqi-build/DCMTK-build
-        mkdir -p ${{ github.workspace }}/dcmqi-build/DCMTK
-        mkdir -p ${{ github.workspace }}/dcmqi-build/ITK
-        mkdir -p ${{ github.workspace }}/dcmqi-build/ITK-build
-        mkdir -p ${{ github.workspace }}/dcmqi-build/zlib-install
+        mkdir -p "$GITHUB_WORKSPACE"/dcmqi-build/DCMTK-build
+        mkdir -p "$GITHUB_WORKSPACE"/dcmqi-build/DCMTK
+        mkdir -p "$GITHUB_WORKSPACE"/dcmqi-build/ITK
+        mkdir -p "$GITHUB_WORKSPACE"/dcmqi-build/ITK-build
+        mkdir -p "$GITHUB_WORKSPACE"/dcmqi-build/zlib-install
 
     - name: Check for cached DCMTK, ITK and ZLIB
       id: cache-dcmtk-itk-zlib
@@ -208,11 +214,11 @@ jobs:
         cache-name: cache-dcmtk-itk-zlib-v2
       with:
         path: |
-          ${{ github.workspace }}/dcmqi-build/DCMTK
-          ${{ github.workspace }}/dcmqi-build/DCMTK-build
-          ${{ github.workspace }}/dcmqi-build/ITK
-          ${{ github.workspace }}/dcmqi-build/ITK-build
-          ${{ github.workspace }}/dcmqi-build/zlib-install
+          dcmqi-build/DCMTK
+          dcmqi-build/DCMTK-build
+          dcmqi-build/ITK
+          dcmqi-build/ITK-build
+          dcmqi-build/zlib-install
         key: ${{ runner.os }}-arm64-manylinux_2_28-build-${{ env.cache-name }}-${{ hashFiles('CMakeExternals/DCMTK.cmake','CMakeExternals/ITK.cmake', 'CMakeExternals/zlib.cmake') }}
 
     - name: Report cache status
@@ -220,7 +226,7 @@ jobs:
         if [ "${{ steps.cache-dcmtk-itk-zlib.outputs.cache-hit }}" == "true" ]; then
           echo "✓ Cache hit! Using cached DCMTK, ITK, and zlib"
           echo "Cache key: ${{ steps.cache-dcmtk-itk-zlib.outputs.cache-primary-key }}"
-          du -sh ${{ github.workspace }}/dcmqi-build/DCMTK* ${{ github.workspace }}/dcmqi-build/ITK* ${{ github.workspace }}/dcmqi-build/zlib-install 2>/dev/null || true
+          du -sh "$GITHUB_WORKSPACE"/dcmqi-build/DCMTK* "$GITHUB_WORKSPACE"/dcmqi-build/ITK* "$GITHUB_WORKSPACE"/dcmqi-build/zlib-install 2>/dev/null || true
         else
           echo "✗ Cache miss. Will build DCMTK, ITK, and zlib from source"
         fi
@@ -265,28 +271,28 @@ jobs:
     - name: "Configure dcmqi w/ cached DCMTK/ITK/ZLIB"
       if: ${{ steps.cache-dcmtk-itk-zlib.outputs.cache-hit == 'true' && steps.validate-cache.outputs.cache_ok == 'true' }}
       run: |
-        cd ${{ github.workspace }}/dcmqi-build && cmake -G Ninja ${{ github.workspace }} -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE:FILEPATH=$PYTHON -DDCMTK_DIR=${{ github.workspace }}/dcmqi-build/DCMTK-build -DITK_DIR=${{ github.workspace }}/dcmqi-build/ITK-build -DZLIB_ROOT=${{ github.workspace }}/dcmqi-build/zlib-install
+        cd "$GITHUB_WORKSPACE"/dcmqi-build && cmake -G Ninja "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE:FILEPATH="$PYTHON" -DDCMTK_DIR="$GITHUB_WORKSPACE"/dcmqi-build/DCMTK-build -DITK_DIR="$GITHUB_WORKSPACE"/dcmqi-build/ITK-build -DZLIB_ROOT="$GITHUB_WORKSPACE"/dcmqi-build/zlib-install
 
     - name: "Configure dcmqi w/o cached DCMTK/ITK/ZLIB"
       if: ${{ steps.cache-dcmtk-itk-zlib.outputs.cache-hit != 'true' || steps.validate-cache.outputs.cache_ok != 'true' }}
       run: |
-        cd ${{ github.workspace }}/dcmqi-build && cmake -G Ninja ${{ github.workspace }} -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE:FILEPATH=$PYTHON
+        cd "$GITHUB_WORKSPACE"/dcmqi-build && cmake -G Ninja "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE:STRING=Release -DPython3_EXECUTABLE:FILEPATH="$PYTHON"
 
     - name: "Build dcmqi"
       id: build
       run: |
-        cd ${{ github.workspace }}/dcmqi-build && ninja
+        cd "$GITHUB_WORKSPACE"/dcmqi-build && ninja
 
     # The dciodvfy (dicom3tools) and ajv tests are skipped here, exactly as they are on
     # macOS: both are optional and CMake drops them when the executables are absent.
     - name: "Test dcmqi"
       run: |
-        cd ${{ github.workspace }}/dcmqi-build/dcmqi-build
+        cd "$GITHUB_WORKSPACE"/dcmqi-build/dcmqi-build
         ctest -j4 -D ExperimentalTest -VV --no-compress-output
 
     - name: "Package dcmqi"
       run: |
-        cd ${{ github.workspace }}/dcmqi-build/dcmqi-build && ninja package
+        cd "$GITHUB_WORKSPACE"/dcmqi-build/dcmqi-build && ninja package
 
     - name: "Upload package as artifact"
       id: upload-artifact
@@ -294,14 +300,14 @@ jobs:
       continue-on-error: true
       with:
         name: dcmqi-linux-arm64-package
-        path: ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-linux-arm64*.tar.gz
+        path: dcmqi-build/dcmqi-build/dcmqi-*-linux-arm64*.tar.gz
 
     - name: "Upload package as artifact (retry)"
       if: steps.upload-artifact.outcome == 'failure'
       uses: actions/upload-artifact@v7
       with:
         name: dcmqi-linux-arm64-package
-        path: ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-linux-arm64*.tar.gz
+        path: dcmqi-build/dcmqi-build/dcmqi-*-linux-arm64*.tar.gz
 
     # Save the dependency cache only when the build step itself succeeded. This keeps the
     # original intent -- cache the deps even if a *later* step (test, package) fails -- while
@@ -315,11 +321,11 @@ jobs:
       uses: actions/cache/save@v6
       with:
         path: |
-          ${{ github.workspace }}/dcmqi-build/DCMTK
-          ${{ github.workspace }}/dcmqi-build/DCMTK-build
-          ${{ github.workspace }}/dcmqi-build/ITK
-          ${{ github.workspace }}/dcmqi-build/ITK-build
-          ${{ github.workspace }}/dcmqi-build/zlib-install
+          dcmqi-build/DCMTK
+          dcmqi-build/DCMTK-build
+          dcmqi-build/ITK
+          dcmqi-build/ITK-build
+          dcmqi-build/zlib-install
         key: ${{ steps.cache-dcmtk-itk-zlib.outputs.cache-primary-key }}
 
     - name: "Publish linux-arm64 package"
@@ -336,13 +342,17 @@ jobs:
         if [ -n "$TAG" ] && [ "$TAG" != "latest" ]; then
           # Unlike the GitHub-hosted images, the manylinux container has no GitHub CLI, so
           # fetch the static arm64 build to keep this step identical to the other platforms.
-          gh_version=$(curl -sSL https://api.github.com/repos/cli/cli/releases/latest \
-            | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | head -n 1)
-          curl -sSL "https://github.com/cli/cli/releases/download/v${gh_version}/gh_${gh_version}_linux_arm64.tar.gz" \
+          # The version is pinned rather than discovered, as ninja is in the macOS build:
+          # it keeps the step reproducible and avoids an unauthenticated API call subject to
+          # the low anonymous rate limit. --proto pins the transfer, and every redirect, to
+          # https so a redirect cannot silently downgrade the download.
+          GH_CLI_VERSION=2.97.0
+          curl -sSL --proto '=https' --proto-redir '=https' \
+            "https://github.com/cli/cli/releases/download/v${GH_CLI_VERSION}/gh_${GH_CLI_VERSION}_linux_arm64.tar.gz" \
             | tar -xz -C /tmp
-          export PATH="/tmp/gh_${gh_version}_linux_arm64/bin:$PATH"
+          export PATH="/tmp/gh_${GH_CLI_VERSION}_linux_arm64/bin:$PATH"
 
           gh release upload "$TAG" \
-            ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-linux-arm64.tar.gz \
+            "$GITHUB_WORKSPACE"/dcmqi-build/dcmqi-build/dcmqi-*-linux-arm64.tar.gz \
             --clobber
         fi

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -110,16 +110,6 @@ jobs:
             CACHE_OK=false
           fi
 
-          # ITKConfig.cmake is written at configure time, but the static libraries only
-          # appear once ITK has finished compiling. A cache saved from a half-built ITK
-          # has the config but no libs, passing the check above yet failing later at link
-          # ("libITKCommon-*.a ... missing and no known rule to make it"). Require a real
-          # library so such a partial cache is rejected and rebuilt cleanly instead.
-          if ! ls "$GITHUB_WORKSPACE"/dcmqi-build/ITK-build/lib/libITKCommon-*.a >/dev/null 2>&1; then
-            echo "Missing ITK libraries: $GITHUB_WORKSPACE/dcmqi-build/ITK-build/lib/libITKCommon-*.a (cached ITK build is incomplete)"
-            CACHE_OK=false
-          fi
-
           if [ ! -f "$GITHUB_WORKSPACE/dcmqi-build/DCMTK-build/DCMTKConfig.cmake" ]; then
             echo "Missing DCMTK config: $GITHUB_WORKSPACE/dcmqi-build/DCMTK-build/DCMTKConfig.cmake"
             CACHE_OK=false
@@ -149,7 +139,6 @@ jobs:
 
     # Build dcmqi
     - name: "Build dcmqi"
-      id: build
       run: |
         cd ${{ github.workspace }}/dcmqi-build && ninja
 
@@ -180,13 +169,7 @@ jobs:
         name: dcmqi-macos-${{ matrix.arch }}-package
         path: ${{ github.workspace }}/dcmqi-build/dcmqi-build/dcmqi-*-mac*.tar.gz
 
-    # Save the dependency cache only when the build step itself succeeded. This keeps the
-    # original intent -- cache the deps even if a *later* step (test, package) fails -- while
-    # never snapshotting a half-built tree when the build is cancelled (e.g. by the
-    # cancel-in-progress concurrency rule) or fails partway. A partial cache used to poison
-    # every subsequent run: once it exists, the restore below is a hit, so this save is
-    # skipped and the broken entry is never overwritten. `!cancelled()` keeps this step
-    # eligible after a failed test/package; `steps.build.outcome` does the real gating.
+    # Save cache even if a later step (test, package) failed, so deps don't need rebuilding next run
     - name: Save DCMTK, ITK and ZLIB cache
       if: always() && steps.cache-dcmtk-itk-zlib.outputs.cache-hit != 'true'
       uses: actions/cache/save@v6

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -17,35 +17,13 @@ jobs:
 
   build-windows:
 
-    runs-on: ${{ matrix.runner }}
+    runs-on: windows-2022
     timeout-minutes: 360
 
     permissions:
       contents: write
       actions: write
       packages: write
-
-    strategy:
-      # Keep building the other architecture when one fails, as on macOS.
-      fail-fast: false
-      matrix:
-        include:
-          # "win64" has always meant x86_64 and is left unqualified so existing download
-          # URLs keep working; see CPACK_SYSTEM_NAME in CMakeLists.txt.
-          - arch: x64
-            runner: windows-2022
-            cmake_platform: x64
-            msbuild_arch: x64
-            python_version: '3.10.11'
-            package_name: win64
-          - arch: arm64
-            runner: windows-11-arm
-            cmake_platform: ARM64
-            msbuild_arch: arm64
-            # python.org publishes Windows arm64 builds starting with 3.11, so the arm64
-            # runner cannot use the 3.10 pinned for x64.
-            python_version: '3.12'
-            package_name: win-arm64
 
     steps:
       - uses: actions/checkout@v7
@@ -54,11 +32,11 @@ jobs:
       - uses: microsoft/setup-msbuild@v3
         with:
           vs-version: '17'
-          msbuild-architecture: ${{ matrix.msbuild_arch }}
+          msbuild-architecture: x64
 
       - uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: '3.10.11'
 
       - name: Install prerequisite python packages
         run: |
@@ -81,9 +59,9 @@ jobs:
             ${{ github.workspace }}\b\zlib-build
             ${{ github.workspace }}\b\zlib-install
             ${{ github.workspace }}\b\zlib-prefix
-          key: windows-${{ matrix.arch }}-deps-${{ hashFiles('CMakeExternals/*.cmake') }}
+          key: windows-deps-${{ hashFiles('CMakeExternals/*.cmake') }}
           restore-keys: |
-            windows-${{ matrix.arch }}-deps-
+            windows-deps-
 
       - name: Configure project
 
@@ -95,10 +73,9 @@ jobs:
           echo "Step 2"
           cd ${{ github.workspace }}\b
           echo "Step 3"
-          cmake -G "Visual Studio 17 2022" -A${{ matrix.cmake_platform }} -DBUILD_SHARED_LIBS:BOOL=OFF ${{ github.workspace }}
+          cmake -G "Visual Studio 17 2022" -Ax64 -DBUILD_SHARED_LIBS:BOOL=OFF ${{ github.workspace }}
 
       - name: Build dcmqi
-        id: build
         run: |
           cd ${{ github.workspace }}\b/
           cmake --build . --config Release -- /m
@@ -118,22 +95,17 @@ jobs:
         uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
-            name: dcmqi-windows-${{ matrix.arch }}-package
-            path: ${{ github.workspace }}\b\dcmqi-build\dcmqi-*-${{ matrix.package_name }}*.zip
+            name: dcmqi-build
+            path: ${{ github.workspace }}\b\dcmqi-build\dcmqi-*-win64*.zip
 
       - name: "Upload package as artifact (retry)"
         if: steps.upload-artifact.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-            name: dcmqi-windows-${{ matrix.arch }}-package
-            path: ${{ github.workspace }}\b\dcmqi-build\dcmqi-*-${{ matrix.package_name }}*.zip
+            name: dcmqi-build
+            path: ${{ github.workspace }}\b\dcmqi-build\dcmqi-*-win64*.zip
 
-      # Save the dependency cache only when the build step itself succeeded. This keeps the
-      # original intent -- cache the deps even if a *later* step (test, package) fails -- while
-      # never snapshotting a half-built tree when the build is cancelled (e.g. by the
-      # cancel-in-progress concurrency rule) or fails partway. This matters more here because of
-      # the restore-keys prefix fallback above: a partial saved under any windows-deps-* key
-      # would otherwise be resurrected on later runs and poison them.
+      # Save cache even if a later step (test, package) failed, so deps don't need rebuilding next run
       - name: Save build dependencies cache
         if: always() && steps.cache-build-deps.outputs.cache-hit != 'true'
         uses: actions/cache/save@v6
@@ -168,6 +140,6 @@ jobs:
           TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
           if [ -n "$TAG" ] && [ "$TAG" != "latest" ]; then
             gh release upload "$TAG" \
-              "${{ github.workspace }}/b/dcmqi-build"/dcmqi-*-${{ matrix.package_name }}.zip \
+              "${{ github.workspace }}/b/dcmqi-build"/dcmqi-*-win64.zip \
               --clobber
           fi

--- a/.github/workflows/cmake-win.yml
+++ b/.github/workflows/cmake-win.yml
@@ -17,13 +17,35 @@ jobs:
 
   build-windows:
 
-    runs-on: windows-2022
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 360
 
     permissions:
       contents: write
       actions: write
       packages: write
+
+    strategy:
+      # Keep building the other architecture when one fails, as on macOS.
+      fail-fast: false
+      matrix:
+        include:
+          # "win64" has always meant x86_64 and is left unqualified so existing download
+          # URLs keep working; see CPACK_SYSTEM_NAME in CMakeLists.txt.
+          - arch: x64
+            runner: windows-2022
+            cmake_platform: x64
+            msbuild_arch: x64
+            python_version: '3.10.11'
+            package_name: win64
+          - arch: arm64
+            runner: windows-11-arm
+            cmake_platform: ARM64
+            msbuild_arch: arm64
+            # python.org publishes Windows arm64 builds starting with 3.11, so the arm64
+            # runner cannot use the 3.10 pinned for x64.
+            python_version: '3.12'
+            package_name: win-arm64
 
     steps:
       - uses: actions/checkout@v7
@@ -32,11 +54,11 @@ jobs:
       - uses: microsoft/setup-msbuild@v3
         with:
           vs-version: '17'
-          msbuild-architecture: x64
+          msbuild-architecture: ${{ matrix.msbuild_arch }}
 
       - uses: actions/setup-python@v7
         with:
-          python-version: '3.10.11'
+          python-version: ${{ matrix.python_version }}
 
       - name: Install prerequisite python packages
         run: |
@@ -59,9 +81,9 @@ jobs:
             ${{ github.workspace }}\b\zlib-build
             ${{ github.workspace }}\b\zlib-install
             ${{ github.workspace }}\b\zlib-prefix
-          key: windows-deps-${{ hashFiles('CMakeExternals/*.cmake') }}
+          key: windows-${{ matrix.arch }}-deps-${{ hashFiles('CMakeExternals/*.cmake') }}
           restore-keys: |
-            windows-deps-
+            windows-${{ matrix.arch }}-deps-
 
       - name: Configure project
 
@@ -73,7 +95,7 @@ jobs:
           echo "Step 2"
           cd ${{ github.workspace }}\b
           echo "Step 3"
-          cmake -G "Visual Studio 17 2022" -Ax64 -DBUILD_SHARED_LIBS:BOOL=OFF ${{ github.workspace }}
+          cmake -G "Visual Studio 17 2022" -A${{ matrix.cmake_platform }} -DBUILD_SHARED_LIBS:BOOL=OFF ${{ github.workspace }}
 
       - name: Build dcmqi
         id: build
@@ -96,15 +118,15 @@ jobs:
         uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
-            name: dcmqi-build
-            path: ${{ github.workspace }}\b\dcmqi-build\dcmqi-*-win64*.zip
+            name: dcmqi-windows-${{ matrix.arch }}-package
+            path: ${{ github.workspace }}\b\dcmqi-build\dcmqi-*-${{ matrix.package_name }}*.zip
 
       - name: "Upload package as artifact (retry)"
         if: steps.upload-artifact.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-            name: dcmqi-build
-            path: ${{ github.workspace }}\b\dcmqi-build\dcmqi-*-win64*.zip
+            name: dcmqi-windows-${{ matrix.arch }}-package
+            path: ${{ github.workspace }}\b\dcmqi-build\dcmqi-*-${{ matrix.package_name }}*.zip
 
       # Save the dependency cache only when the build step itself succeeded. This keeps the
       # original intent -- cache the deps even if a *later* step (test, package) fails -- while
@@ -146,6 +168,6 @@ jobs:
           TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
           if [ -n "$TAG" ] && [ "$TAG" != "latest" ]; then
             gh release upload "$TAG" \
-              "${{ github.workspace }}/b/dcmqi-build"/dcmqi-*-win64.zip \
+              "${{ github.workspace }}/b/dcmqi-build"/dcmqi-*-${{ matrix.package_name }}.zip \
               --clobber
           fi

--- a/.github/workflows/finalize-latest.yml
+++ b/.github/workflows/finalize-latest.yml
@@ -13,11 +13,10 @@ name: Finalize latest prerelease
 #     directories never accumulate.
 # This mirrors what scikit-ci-addons' publish_github_release used to do for us.
 #
-# A delete+recreate must not run inside the six parallel build jobs (linux, linux-arm64,
-# mac-arm64, mac-x86_64, win64, win-arm64) or they would wipe each other's assets, so it
-# lives here as a single coordinator that runs after the builds. GITHUB_TOKEN is used on
-# purpose: release/tag events it creates do not trigger other workflows, so there is no
-# build loop.
+# A delete+recreate must not run inside the five parallel build jobs (linux, linux-arm64,
+# mac-arm64, mac-x86_64, win) or they would wipe each other's assets, so it lives here as
+# a single coordinator that runs after the builds. GITHUB_TOKEN is used on purpose:
+# release/tag events it creates do not trigger other workflows, so there is no build loop.
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/finalize-latest.yml
+++ b/.github/workflows/finalize-latest.yml
@@ -13,10 +13,11 @@ name: Finalize latest prerelease
 #     directories never accumulate.
 # This mirrors what scikit-ci-addons' publish_github_release used to do for us.
 #
-# A delete+recreate must not run inside the four parallel build jobs (linux, mac-arm64,
-# mac-x86_64, win) or they would wipe each other's assets, so it lives here as a single
-# coordinator that runs after the builds. GITHUB_TOKEN is used on purpose: release/tag
-# events it creates do not trigger other workflows, so there is no build loop.
+# A delete+recreate must not run inside the six parallel build jobs (linux, linux-arm64,
+# mac-arm64, mac-x86_64, win64, win-arm64) or they would wipe each other's assets, so it
+# lives here as a single coordinator that runs after the builds. GITHUB_TOKEN is used on
+# purpose: release/tag events it creates do not trigger other workflows, so there is no
+# build loop.
 on:
   workflow_run:
     workflows:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -437,6 +437,11 @@ else()
     endif()
   elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
     # Same rationale as Linux: "win64" keeps meaning x86_64.
+    #
+    # CI does not build Windows arm64 yet -- ITK's vendored GDCM does not compile for ARM64
+    # with MSVC -- but an ARM64 target is 64-bit, so without this branch such a build would
+    # silently produce a package named "win64" holding arm64 binaries. The check costs
+    # nothing and keeps a local ARM64 build honestly labelled.
     if(_target_is_arm64)
       set(CPACK_SYSTEM_NAME "win-arm64")
     elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,12 +412,34 @@ else()
   set(CPACK_PACKAGE_VERSION_MAJOR ${DCMQI_VERSION_MAJOR})
   set(CPACK_PACKAGE_VERSION_MINOR ${DCMQI_VERSION_MINOR})
   set(CPACK_PACKAGE_VERSION_PATCH ${DCMQI_VERSION_PATCH})
+  # Normalized name of the architecture being built for. Visual Studio generators encode
+  # the target in the generator platform (-A), which is authoritative when it differs from
+  # the host, so it takes precedence over CMAKE_SYSTEM_PROCESSOR where it is set.
+  set(_target_arch "${CMAKE_SYSTEM_PROCESSOR}")
+  if(CMAKE_GENERATOR_PLATFORM)
+    set(_target_arch "${CMAKE_GENERATOR_PLATFORM}")
+  endif()
+  string(TOLOWER "${_target_arch}" _target_arch)
+  set(_target_is_arm64 FALSE)
+  if(_target_arch STREQUAL "arm64" OR _target_arch STREQUAL "aarch64")
+    set(_target_is_arm64 TRUE)
+  endif()
   if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     set(CPACK_SYSTEM_NAME "mac-${CMAKE_SYSTEM_PROCESSOR}")
   elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    set(CPACK_SYSTEM_NAME "linux")
+    # The x86_64 package has always been published without an architecture suffix. It is
+    # deliberately left that way so existing download URLs keep working; only the newer
+    # architectures are qualified.
+    if(_target_is_arm64)
+      set(CPACK_SYSTEM_NAME "linux-arm64")
+    else()
+      set(CPACK_SYSTEM_NAME "linux")
+    endif()
   elseif(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    # Same rationale as Linux: "win64" keeps meaning x86_64.
+    if(_target_is_arm64)
+      set(CPACK_SYSTEM_NAME "win-arm64")
+    elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
       set(CPACK_SYSTEM_NAME win64)
     else()
       set(CPACK_SYSTEM_NAME win32)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,6 +40,20 @@ source of truth.
      `CHANGELOG.md` and sets it as the release body. (If no matching section exists, that
      workflow fails loudly — go back to step 1.)
 
+   Six packages are attached, one per platform/architecture:
+
+   | Asset | Platform | Built by |
+   | --- | --- | --- |
+   | `dcmqi-X.Y.Z-linux.tar.gz` | Linux x86_64 | `cmake-linux` |
+   | `dcmqi-X.Y.Z-linux-arm64.tar.gz` | Linux arm64 | `cmake-linux` |
+   | `dcmqi-X.Y.Z-mac-x86_64.tar.gz` | macOS x86_64 | `cmake-macos` |
+   | `dcmqi-X.Y.Z-mac-arm64.tar.gz` | macOS arm64 | `cmake-macos` |
+   | `dcmqi-X.Y.Z-win64.zip` | Windows x86_64 | `cmake-win` |
+   | `dcmqi-X.Y.Z-win-arm64.zip` | Windows arm64 | `cmake-win` |
+
+   The two x86_64 names are unqualified for historical reasons and must stay that way so
+   existing download URLs keep working; see `CPACK_SYSTEM_NAME` in `CMakeLists.txt`.
+
 You can leave the release body empty when publishing; the workflow fills it in. To
 preview what it will post: `python tools/changelog/generate_changelog.py --extract vX.Y.Z`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,7 +40,7 @@ source of truth.
      `CHANGELOG.md` and sets it as the release body. (If no matching section exists, that
      workflow fails loudly — go back to step 1.)
 
-   Six packages are attached, one per platform/architecture:
+   Five packages are attached, one per platform/architecture:
 
    | Asset | Platform | Built by |
    | --- | --- | --- |
@@ -49,10 +49,15 @@ source of truth.
    | `dcmqi-X.Y.Z-mac-x86_64.tar.gz` | macOS x86_64 | `cmake-macos` |
    | `dcmqi-X.Y.Z-mac-arm64.tar.gz` | macOS arm64 | `cmake-macos` |
    | `dcmqi-X.Y.Z-win64.zip` | Windows x86_64 | `cmake-win` |
-   | `dcmqi-X.Y.Z-win-arm64.zip` | Windows arm64 | `cmake-win` |
 
    The two x86_64 names are unqualified for historical reasons and must stay that way so
    existing download URLs keep working; see `CPACK_SYSTEM_NAME` in `CMakeLists.txt`.
+
+   There is no Windows arm64 package yet: ITK's vendored GDCM does not compile for ARM64
+   with MSVC (`gdcmFilename.cxx` includes `<windows.h>` inside `namespace gdcm`, so the
+   `_Interlocked*` wrappers `winbase.h` declares on ARM64 land in that namespace and
+   collide). `CPACK_SYSTEM_NAME` below already names such a package correctly, so adding
+   the build job is all that remains once ITK carries the fix.
 
 You can leave the release body empty when publishing; the workflow fills it in. To
 preview what it will post: `python tools/changelog/generate_changelog.py --extract vX.Y.Z`.


### PR DESCRIPTION
Adds a `build-linux-arm64` job so releases carry a `dcmqi-<version>-linux-arm64.tar.gz`. Requested in [ImagingDataCommons/dcmqi-python-distributions#44](https://github.com/ImagingDataCommons/dcmqi-python-distributions/issues/44) — 3D Slicer has Linux arm64 users who currently have to build from source because no wheel exists for their platform.

## What this does

- **`.github/workflows/cmake-linux.yml`** — new `build-linux-arm64` job on the native `ubuntu-24.04-arm` runner, inside a `quay.io/pypa/manylinux_2_28_aarch64` container so the binaries carry the same glibc floor as the x86_64 package. Mirrors the existing macOS job's cache/validate/configure/build/test/package/publish shape.
- **`CMakeLists.txt`** — `CPACK_SYSTEM_NAME` gains an arm64 branch. The x86_64 names stay unqualified (`linux`, `win64`) so existing download URLs keep working.
- **`finalize-latest.yml`**, **`RELEASE.md`** — documentation kept in step with the new asset.

## Container paths

The job deliberately uses `$GITHUB_WORKSPACE` in shell steps and workspace-relative paths in action inputs, rather than the `${{ github.workspace }}` expression the other jobs use. In a `container:` job the two disagree: the expression is evaluated on the *host* and yields `/home/runner/work/...`, while the repository is mounted inside the container at `/__w/...`. The first push here used the expression and failed with `The source directory "/home/runner/work/dcmqi/dcmqi" does not appear to contain CMakeLists.txt` — the `mkdir -p` steps had quietly created the empty host path. There is a comment on the job saying so.

## Windows arm64 is not included

It was in the first version of this PR and had to come out. ITK's vendored GDCM does not compile for ARM64 with MSVC ([failing job](https://github.com/QIICR/dcmqi/actions/runs/31502233286/job/93815265949)):

```
winbase.h(9858,23): error C2664: 'unsigned int gdcm::_InterlockedIncrement(volatile unsigned int *)':
  cannot convert argument 1 from 'volatile long *' to 'volatile unsigned int *'
```

plus ~11 more (`_InterlockedDecrement`, `_InterlockedExchange`, `_InterlockedExchangeAdd`, `_InterlockedCompareExchange`). Note the namespace. [`gdcmFilename.cxx`](https://github.com/Slicer/ITK/blob/20d9dc0c6b9de7e65aeb69d1d2fe6674939c0954/Modules/ThirdParty/GDCM/src/gdcm/Source/Common/gdcmFilename.cxx#L100) includes `<windows.h>` at line 100, inside `namespace gdcm` (lines 20–187). On x64 the `_Interlocked*` functions are intrinsics and `winbase.h` declares nothing; on ARM64 it declares real inline wrappers, which then land in `namespace gdcm` and shadow the intrinsics with the wrong signature.

`-DModule_ITKIOGDCM:BOOL=OFF` does not help — dcmqi's sources never reference GDCM, but `ITKReview` (turned on explicitly in `CMakeExternals/ITK.cmake`) hard-`DEPENDS` on `ITKIOGDCM`, which `PRIVATE_DEPENDS` on `ITKGDCM`.

The fix is one line in the right place, but it belongs upstream in GDCM or the Slicer/ITK fork pinned here, not in a `PATCH_COMMAND` against third-party source in our superbuild. Windows arm64 follows once ITK carries it. `CPACK_SYSTEM_NAME` already handles the naming, so only the build job will be needed — it is retained deliberately, because an ARM64 target is 64-bit and a local build would otherwise emit a package called `win64` full of arm64 binaries.

## Relationship to #555

This branch originally carried part of #555's `cmake-macos.yml` / `cmake-win.yml` changes but not its `if:` fix, which left both files with a comment promising the cache save was gated on build success while the condition was still `always()`. Those files are now reverted to `master` here; #555 has all of it, correctly. The two PRs no longer overlap.

## Testing

`build-linux-arm64` passes end to end, 15m46s with a cold cache. All other jobs unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
