### PR TITLE
Factor source image handling out of the SEG converter and restructure it

### DIFF
--- a/apps/seg/Testing/CMakeLists.txt
+++ b/apps/seg/Testing/CMakeLists.txt
@@ -45,6 +45,33 @@ dcmqi_add_test(
     ${DICOM_DIR}/03.dcm
   )
 
+#-----------------------------------------------------------------------------
+# Regression test for the Common Instance Reference module
+# (https://github.com/QIICR/dcmqi/issues/554): when several source instances
+# map to the same segmentation frame, all of them must appear in the top-level
+# Referenced Instance Sequence, and instances must be grouped by the series
+# they actually belong to. The additional source instances (a same-plane
+# duplicate and one from a second series) are derived in memory from the
+# classic series, so no fixture files are needed.
+add_executable(CommonInstanceReferenceTest
+  CommonInstanceReferenceTest.cxx)
+target_link_libraries(CommonInstanceReferenceTest
+  dcmqi
+  ${DCMTK_LIBRARIES})
+set_target_properties(CommonInstanceReferenceTest PROPERTIES
+  LABELS ${MODULE_NAME})
+
+dcmqi_add_test(
+  NAME ${itk2dcm}_commonInstanceReference
+  MODULE_NAME ${MODULE_NAME}
+  COMMAND $<TARGET_FILE:CommonInstanceReferenceTest>
+    ${CMAKE_SOURCE_DIR}/doc/examples/seg-example.json
+    ${BASELINE}/liver_seg.nrrd
+    ${DICOM_DIR}/01.dcm
+    ${DICOM_DIR}/02.dcm
+    ${DICOM_DIR}/03.dcm
+  )
+
 dcmqi_add_test(
   NAME ${itk2dcm}_makeSEG
   MODULE_NAME ${MODULE_NAME}

--- a/apps/seg/Testing/CommonInstanceReferenceTest.cxx
+++ b/apps/seg/Testing/CommonInstanceReferenceTest.cxx
@@ -1,0 +1,254 @@
+// Regression test for the Common Instance Reference module of created
+// segmentations (https://github.com/QIICR/dcmqi/issues/554).
+//
+// Builds two constellations that the reference bookkeeping used to get wrong,
+// by deriving additional source instances from the given classic series in
+// memory (no fixture files needed):
+//
+//  1. A second instance with the same geometry as an existing one, so that two
+//     source instances match the same segmentation frame. Both must appear in
+//     the frame's Source Image Sequence AND in the top-level Referenced
+//     Instance Sequence; previously only the first one per frame reached the
+//     Common Instance Reference module.
+//  2. An instance from a second series of the same study. The Referenced
+//     Series Sequence must group instances by the series they actually belong
+//     to; previously all instances were attributed to the series of the first
+//     input dataset.
+//
+// Cross-study references (Studies Containing Other Referenced Instances
+// Sequence) are out of scope here and not supported yet.
+
+#include "dcmqi/Itk2DicomConverter.h"
+
+#include <dcmtk/dcmdata/dcdatset.h>
+#include <dcmtk/dcmdata/dcdeftag.h>
+#include <dcmtk/dcmdata/dcfilefo.h>
+#include <dcmtk/dcmdata/dcsequen.h>
+#include <dcmtk/dcmdata/dcuid.h>
+
+#include <itkImageFileReader.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+using ImageType = itk::Image<short, 3U>;
+using ReaderType = itk::ImageFileReader<ImageType>;
+
+#define REQUIRE(expr)                                                                  \
+  do {                                                                                 \
+    if (!(expr)) {                                                                     \
+      std::cerr << "FAIL: " << #expr << " at " << __FILE__ << ":" << __LINE__ << std::endl; \
+      return EXIT_FAILURE;                                                             \
+    }                                                                                  \
+  } while (0)
+
+std::string readFile(const std::string& path)
+{
+  std::ifstream in(path.c_str(), std::ios::binary);
+  if (!in)
+  {
+    std::cerr << "ERROR: cannot open " << path << std::endl;
+    return std::string();
+  }
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+DcmDataset* loadDataset(const std::string& path)
+{
+  DcmFileFormat ff;
+  if (ff.loadFile(path.c_str()).bad())
+  {
+    std::cerr << "ERROR: cannot read " << path << std::endl;
+    return nullptr;
+  }
+  return OFstatic_cast(DcmDataset*, ff.getDataset()->clone());
+}
+
+// Copy of the given dataset with a fresh SOP Instance UID and, if requested,
+// a fresh Series Instance UID; geometry and everything else stay identical.
+DcmDataset* deriveInstance(DcmDataset& original, OFString& sopInstanceUID,
+                           const bool newSeries, OFString& seriesInstanceUID)
+{
+  std::unique_ptr<DcmDataset> copy(OFstatic_cast(DcmDataset*, original.clone()));
+  char uid[100];
+  if (copy->putAndInsertString(DCM_SOPInstanceUID,
+                               dcmGenerateUniqueIdentifier(uid, SITE_INSTANCE_UID_ROOT)).bad())
+    return nullptr;
+  sopInstanceUID = uid;
+  if (newSeries)
+  {
+    if (copy->putAndInsertString(DCM_SeriesInstanceUID,
+                                 dcmGenerateUniqueIdentifier(uid, SITE_SERIES_UID_ROOT)).bad())
+      return nullptr;
+  }
+  copy->findAndGetOFString(DCM_SeriesInstanceUID, seriesInstanceUID);
+  return copy.release();
+}
+
+// Per frame of the segmentation, the SOP Instance UIDs its Derivation Image
+// FG references
+std::vector<std::set<OFString> > frameReferences(DcmDataset& seg)
+{
+  std::vector<std::set<OFString> > result;
+  DcmSequenceOfItems* perFrameSeq = nullptr;
+  if (seg.findAndGetSequence(DCM_PerFrameFunctionalGroupsSequence, perFrameSeq).bad() || !perFrameSeq)
+    return result;
+  for (unsigned long f = 0; f < perFrameSeq->card(); ++f)
+  {
+    std::set<OFString> refs;
+    DcmItem* derivationItem = nullptr;
+    if (perFrameSeq->getItem(f)->findAndGetSequenceItem(DCM_DerivationImageSequence, derivationItem, 0).good()
+        && derivationItem)
+    {
+      DcmSequenceOfItems* sourceImageSeq = nullptr;
+      if (derivationItem->findAndGetSequence(DCM_SourceImageSequence, sourceImageSeq).good() && sourceImageSeq)
+      {
+        for (unsigned long s = 0; s < sourceImageSeq->card(); ++s)
+        {
+          OFString uid;
+          if (sourceImageSeq->getItem(s)->findAndGetOFString(DCM_ReferencedSOPInstanceUID, uid).good())
+            refs.insert(uid);
+        }
+      }
+    }
+    result.push_back(refs);
+  }
+  return result;
+}
+}
+
+int main(int argc, char* argv[])
+{
+  if (argc != 6)
+  {
+    std::cerr << "Usage: " << argv[0]
+              << " <metadata.json> <segmentation.nrrd> <dicom1> <dicom2> <dicom3>" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const std::string metadata = readFile(argv[1]);
+  REQUIRE(!metadata.empty());
+
+  ReaderType::Pointer reader = ReaderType::New();
+  reader->SetFileName(argv[2]);
+  try
+  {
+    reader->Update();
+  }
+  catch (const itk::ExceptionObject& e)
+  {
+    std::cerr << "ERROR: failed to load segmentation: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::vector<ImageType::ConstPointer> segmentations;
+  segmentations.emplace_back(reader->GetOutput());
+
+  // the classic series (one study, one series)
+  std::vector<DcmItem*> datasets;
+  std::vector<OFString> uids;
+  OFString firstSeriesUID;
+  for (int i = 3; i < 6; ++i)
+  {
+    DcmDataset* ds = loadDataset(argv[i]);
+    REQUIRE(ds != nullptr);
+    OFString uid;
+    REQUIRE(ds->findAndGetOFString(DCM_SOPInstanceUID, uid).good());
+    if (i == 3)
+      REQUIRE(ds->findAndGetOFString(DCM_SeriesInstanceUID, firstSeriesUID).good());
+    datasets.push_back(ds);
+    uids.push_back(uid);
+  }
+
+  // a second instance on the plane of the first one, same series (issue #554)
+  OFString duplicateUID, duplicateSeriesUID;
+  DcmDataset* duplicate = deriveInstance(*OFstatic_cast(DcmDataset*, datasets[0]),
+                                         duplicateUID, false, duplicateSeriesUID);
+  REQUIRE(duplicate != nullptr);
+  REQUIRE(duplicateSeriesUID == firstSeriesUID);
+  datasets.push_back(duplicate);
+
+  // an instance on the plane of the second one, from a second series
+  OFString otherSeriesInstanceUID, otherSeriesUID;
+  DcmDataset* otherSeries = deriveInstance(*OFstatic_cast(DcmDataset*, datasets[1]),
+                                           otherSeriesInstanceUID, true, otherSeriesUID);
+  REQUIRE(otherSeries != nullptr);
+  REQUIRE(otherSeriesUID != firstSeriesUID);
+  datasets.push_back(otherSeries);
+
+  std::unique_ptr<DcmDataset> seg(
+      dcmqi::Itk2DicomConverter::itkimage2dcmSegmentation(datasets, segmentations, metadata,
+                                                          false /* skipEmptySlices */));
+  REQUIRE(seg != nullptr);
+
+  // Frame level: instances sharing a plane must be referenced together
+  const std::vector<std::set<OFString> > perFrame = frameReferences(*seg);
+  REQUIRE(!perFrame.empty());
+  std::set<OFString> frameUnion;
+  unsigned framesWithDuplicatePair = 0;
+  unsigned framesWithOtherSeriesPair = 0;
+  for (const std::set<OFString>& refs : perFrame)
+  {
+    frameUnion.insert(refs.begin(), refs.end());
+    REQUIRE(refs.count(uids[0]) == refs.count(duplicateUID));
+    REQUIRE(refs.count(uids[1]) == refs.count(otherSeriesInstanceUID));
+    if (refs.count(duplicateUID))
+      framesWithDuplicatePair++;
+    if (refs.count(otherSeriesInstanceUID))
+      framesWithOtherSeriesPair++;
+  }
+  REQUIRE(framesWithDuplicatePair > 0);
+  REQUIRE(framesWithOtherSeriesPair > 0);
+
+  // Common Instance Reference module: every instance referenced by any frame,
+  // grouped by the series it actually belongs to
+  DcmSequenceOfItems* refSeriesSeq = nullptr;
+  REQUIRE(seg->findAndGetSequence(DCM_ReferencedSeriesSequence, refSeriesSeq).good() && refSeriesSeq);
+  REQUIRE(refSeriesSeq->card() == 2);
+
+  std::set<OFString> cirUnion;
+  std::map<OFString, std::set<OFString> > seriesToInstances;
+  for (unsigned long s = 0; s < refSeriesSeq->card(); ++s)
+  {
+    OFString seriesUID;
+    REQUIRE(refSeriesSeq->getItem(s)->findAndGetOFString(DCM_SeriesInstanceUID, seriesUID).good());
+    DcmSequenceOfItems* refInstanceSeq = nullptr;
+    REQUIRE(refSeriesSeq->getItem(s)->findAndGetSequence(DCM_ReferencedInstanceSequence, refInstanceSeq).good()
+            && refInstanceSeq);
+    for (unsigned long r = 0; r < refInstanceSeq->card(); ++r)
+    {
+      OFString uid;
+      REQUIRE(refInstanceSeq->getItem(r)->findAndGetOFString(DCM_ReferencedSOPInstanceUID, uid).good());
+      seriesToInstances[seriesUID].insert(uid);
+      cirUnion.insert(uid);
+    }
+  }
+
+  // the actual issue-554 assertion: nothing referenced by a frame may be
+  // missing from the Common Instance Reference module (and vice versa)
+  REQUIRE(cirUnion == frameUnion);
+  REQUIRE(cirUnion.count(duplicateUID) == 1);
+
+  // series grouping
+  std::set<OFString> expectedFirstSeries = frameUnion;
+  expectedFirstSeries.erase(otherSeriesInstanceUID);
+  REQUIRE(seriesToInstances.count(firstSeriesUID) == 1);
+  REQUIRE(seriesToInstances.count(otherSeriesUID) == 1);
+  REQUIRE(seriesToInstances[firstSeriesUID] == expectedFirstSeries);
+  REQUIRE(seriesToInstances[otherSeriesUID] == std::set<OFString>{otherSeriesInstanceUID});
+
+  for (DcmItem* item : datasets) { delete item; }
+
+  std::cout << "PASS: instances sharing a frame are all present in the Common Instance "
+            << "Reference module, grouped by the series they belong to." << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/include/dcmqi/ConverterBase.h
+++ b/include/dcmqi/ConverterBase.h
@@ -344,42 +344,6 @@ namespace dcmqi {
       return 0;
     }
 
-    // AF: I could not quickly figure out how to template this function over image type - suggestions are welcomed!
-    template<class ImageSourceType>
-    static vector<vector<int> > getSliceMapForSegmentation2DerivationImage(const vector<DcmItem*> dcmDatasets,
-                                                                                       const ImageSourceType& labelImage) {
-      // Find mapping from the segmentation slice number to the derivation image
-      // Assume that orientation of the segmentation is the same as the source series
-      unsigned numLabelSlices = labelImage->GetLargestPossibleRegion().GetSize()[2];
-      vector<vector<int> > slice2derimg(numLabelSlices);
-      vector<bool> slice2derimgPresent(numLabelSlices, false);
-
-      int slicesMapped = 0;
-      for(size_t i=0;i<dcmDatasets.size();i++){
-        OFString ippStr;
-        ShortImageType::PointType ippPoint;
-        ShortImageType::IndexType ippIndex;
-        for(int j=0;j<3;j++){
-          CHECK_COND(dcmDatasets[i]->findAndGetOFString(DCM_ImagePositionPatient, ippStr, j));
-          ippPoint[j] = atof(ippStr.c_str());
-        }
-        if(!labelImage->TransformPhysicalPointToIndex(ippPoint, ippIndex)){
-          // if certain DICOM instance does not map to a label slice, just skip it
-          continue;
-        }
-        OFString sopInstanceUID;
-        CHECK_COND(dcmDatasets[i]->findAndGetOFString(DCM_SOPInstanceUID, sopInstanceUID));
-        // TODO: show the below when verbose mode is selected!
-        // cout << "SOPInstanceUID " << sopInstanceUID << " mapped" << endl;
-        slice2derimg[ippIndex[2]].push_back(i);
-        if(slice2derimgPresent[ippIndex[2]] == false)
-          slicesMapped++;
-        slice2derimgPresent[ippIndex[2]] = true;
-      }
-      cout << slicesMapped << " of " << slice2derimgPresent.size() << " slices mapped to source DICOM images" << endl;
-      return slice2derimg;
-    }
-
   };
 
 }

--- a/include/dcmqi/Itk2DicomConverter.h
+++ b/include/dcmqi/Itk2DicomConverter.h
@@ -55,9 +55,8 @@ namespace dcmqi {
      *        numbered monotonically without gaps; if n labels are not assigned uniquely to
      *        label IDs 1..n in the input, the conversion will fail. For labelmap output
      *        (outputLabelMap=true) any set of unique positive label IDs is allowed, including
-     *        gaps, since LABELMAP does not require consecutive segment numbers
-     *        (https://github.com/QIICR/dcmqi/issues/537); label IDs that are used by more
-     *        than one input segment make the conversion fail.
+     *        gaps, since LABELMAP does not require consecutive segment numbers;
+     *        label IDs that are used by more than one input segment make the conversion fail.
      *        The processing order of label IDs is not relevant, i.e. they can occur in any order in the input.
      *        If this is set to false (default), the segment numbers are assigned in the order of the
      *        labels that are being converted, i.e. the first label will receive the Segment
@@ -68,7 +67,9 @@ namespace dcmqi {
      *        are updated by this flag, compared to the default behavior (false). Of course, the
      *        resulting DICOM object is still valid, dimensions are consistent and lead to meaningful
      *        display.
-     * @param referencesGeometryCheck A boolean indicating whether the conversion process should attempt checking if the geometry of the referenced DICOM images is consistent with the corresponding slices of the segmentation.
+     * @param referencesGeometryCheck A boolean indicating whether the conversion process should attempt
+     *        checking if the geometry of the referenced DICOM images is consistent with the corresponding
+     *        slices of the segmentation.
      *        By default, this check is enabled. If disabled, all of the references will be
      *        added in the SharedFunctionalGroupsSequence without any geometry checks.
      * @param doDicomValueChecks A boolean indicating whether to check the values of DICOM attributes
@@ -78,7 +79,7 @@ namespace dcmqi {
      *       (e.g., VR of Patients'Name is violated, wrong value multiplicity, etc.).
      *       However, the resulting DICOM object may not be compliant with the DICOM standard in this case.
      * @param outputLabelMap If true, create a DICOM Labelmap Segmentation object
-     *       (SOP Class UID 1.2.840.10008.5.1.4.1.1.66.7, per Sup 243) directly
+     *       (SOP Class UID 1.2.840.10008.5.1.4.1.1.66.7) directly
      *       instead of a binary DICOM Segmentation object. Behavioral
      *       differences when set to true:
      *       - Output uses MONOCHROME2 photometric interpretation. Bit depth is

--- a/include/dcmqi/SourceImageIndex.h
+++ b/include/dcmqi/SourceImageIndex.h
@@ -1,0 +1,156 @@
+#ifndef DCMQI_SOURCEIMAGEINDEX_H
+#define DCMQI_SOURCEIMAGEINDEX_H
+
+// STD includes
+#include <set>
+#include <string>
+#include <vector>
+
+// DCMTK includes
+#include <dcmtk/config/osconfig.h>
+#include <dcmtk/dcmdata/dcitem.h>
+#include <dcmtk/dcmfg/fgderimg.h>
+#include <dcmtk/dcmiod/iodmacro.h>
+#include <dcmtk/dcmiod/modcommoninstanceref.h>
+
+// ITK includes
+#include <itkImageBase.h>
+
+using namespace std;
+
+namespace dcmqi {
+
+  /**
+   * @brief Inventory of the source DICOM images a derived object (SEG, PM) was created from.
+   *
+   * Normalizes the source datasets into a flat list of referenceable "source
+   * frames" (a classic single-frame instance contributes one frame), maps the
+   * slices of the ITK image being converted to those frames by geometry, and
+   * creates the DICOM references derived from that mapping:
+   * - Derivation Image functional group items with their Source Image Sequence,
+   * - the Referenced Series Sequence of the Common Instance Reference module,
+   *   fed by the instances referenced through the derivation items.
+   *
+   * Factored out of the SEG and PM converters
+   * (https://github.com/QIICR/dcmqi/issues/192).
+   */
+  class SourceImageIndex {
+
+  public:
+
+    /**
+     * @brief One referenceable entity of the source data.
+     *
+     * Either a classic single-frame instance, or a single frame of a
+     * multiframe instance.
+     */
+    struct SourceFrame {
+      size_t datasetIndex; ///< index into the dataset vector passed to the constructor
+      Uint32 frameNumber;  ///< 1-based DICOM frame number; 0 for single-frame instances
+      double position[3];  ///< ImagePositionPatient of the slice/frame
+      bool hasPosition;    ///< whether the position could be determined
+    };
+
+    /**
+     * @brief Build the frame inventory for the given source datasets.
+     *
+     * Datasets without usable position information are kept (they can still be
+     * referenced as whole instances) but their frames are excluded from the
+     * geometric slice mapping, with a warning.
+     *
+     * @param datasets Source image datasets. Not owned; must outlive this object.
+     */
+    explicit SourceImageIndex(const vector<DcmItem*>& datasets);
+
+    /**
+     * @brief Map each slice of the given image geometry to the source frames located on it.
+     *
+     * A source frame is assigned to the slice its ImagePositionPatient falls
+     * into; frames mapping outside the image are skipped. Assumes the source
+     * images have the same orientation as the image being converted.
+     *
+     * @param geometry Geometry of the ITK image being converted.
+     * @return Per slice, the indices (into getFrames()) of the source frames on that slice.
+     */
+    vector<vector<size_t> > mapSlicesToFrames(const itk::ImageBase<3>& geometry) const;
+
+    /**
+     * @brief Add a Derivation Image item referencing the given source frames.
+     *
+     * Creates one Source Image Sequence item per referenced instance and
+     * records the instances for populateCommonInstanceReference().
+     *
+     * @param fgder Derivation Image functional group to add the item to.
+     * @param frameIds Indices (into getFrames()) of the source frames to reference,
+     *        e.g. one slice entry of mapSlicesToFrames(). No-op if empty.
+     * @param derivationCode Code describing the derivation (CID 7203).
+     * @param derivationDescription Free-text description of the derivation, may be empty.
+     * @param purposeOfReference Purpose of reference code (CID 7202).
+     * @return EC_Normal on success, error otherwise.
+     */
+    OFCondition addDerivationImageItem(FGDerivationImage& fgder,
+                                       const vector<size_t>& frameIds,
+                                       const CodeSequenceMacro& derivationCode,
+                                       const string& derivationDescription,
+                                       const CodeSequenceMacro& purposeOfReference);
+
+    /**
+     * @brief Add a Derivation Image item referencing all source instances as a whole.
+     *
+     * No frame-level bookkeeping is performed (a reference without frame
+     * numbers applies to all frames of an instance). Used when the geometric
+     * mapping is bypassed. Instances are recorded for
+     * populateCommonInstanceReference(); datasets that cannot be referenced
+     * (e.g. missing SOP Class/Instance UID) are skipped.
+     *
+     * @param fgder Derivation Image functional group to add the item to.
+     * @param derivationCode Code describing the derivation (CID 7203).
+     * @param derivationDescription Free-text description of the derivation, may be empty.
+     * @param purposeOfReference Purpose of reference code (CID 7202).
+     * @return EC_Normal on success, error otherwise.
+     */
+    OFCondition addWholeInstanceDerivationImageItem(FGDerivationImage& fgder,
+                                                    const CodeSequenceMacro& derivationCode,
+                                                    const string& derivationDescription,
+                                                    const CodeSequenceMacro& purposeOfReference);
+
+    /**
+     * @brief Populate the Referenced Series Sequence of the given Common Instance
+     * Reference module with the instances referenced so far.
+     *
+     * Instances are grouped by their Series Instance UID, in order of first
+     * reference. No-op if no instance has been referenced.
+     *
+     * @param commref Common Instance Reference module of the target object.
+     * @return EC_Normal on success, error otherwise.
+     */
+    OFCondition populateCommonInstanceReference(IODCommonInstanceReferenceModule& commref) const;
+
+    /**
+     * @brief Access the frame inventory (indexed by the ids used in the mapping methods).
+     */
+    const vector<SourceFrame>& getFrames() const;
+
+  private:
+
+    /// Cached per-dataset identification, parallel to m_datasets
+    struct InstanceInfo {
+      OFString seriesInstanceUID;
+      OFString sopClassUID;
+      OFString sopInstanceUID;
+      Uint32 numberOfFrames; ///< NumberOfFrames value; 0 for single-frame instances
+    };
+
+    /// Remember that an instance is referenced (deduplicated by dataset index)
+    void recordReferencedInstance(size_t datasetIndex);
+
+    vector<DcmItem*> m_datasets;
+    vector<InstanceInfo> m_instances;
+    vector<SourceFrame> m_frames;
+    vector<size_t> m_referencedDatasets; ///< in order of first reference
+    set<size_t> m_referencedDatasetSet;
+  };
+
+}
+
+#endif // DCMQI_SOURCEIMAGEINDEX_H

--- a/libsrc/CMakeLists.txt
+++ b/libsrc/CMakeLists.txt
@@ -23,6 +23,7 @@ set(HDRS
   ${INCLUDE_DIR}/JSONParametricMapMetaInformationHandler.h
   ${INCLUDE_DIR}/JSONSegmentationMetaInformationHandler.h
   ${INCLUDE_DIR}/SegmentAttributes.h
+  ${INCLUDE_DIR}/SourceImageIndex.h
   ${INCLUDE_DIR}/TID1500Reader.h
   )
 
@@ -40,6 +41,7 @@ set(SRCS
   JSONParametricMapMetaInformationHandler.cpp
   JSONSegmentationMetaInformationHandler.cpp
   SegmentAttributes.cpp
+  SourceImageIndex.cpp
   TID1500Reader.cpp
   )
 

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -230,6 +230,74 @@ namespace dcmqi {
       return segment;
     }
 
+    /** Owns the functional groups that are re-filled for every frame of the
+     *  output, and enforces the protocol they have to be used with:
+     *  beginFrame() before filling them, get() when handing them to
+     *  DcmSegmentation::addFrame(), endFrame() afterwards.
+     *
+     *  Plane Position (Patient) and Frame Content apply to every frame, while
+     *  the Derivation Image group is only part of a frame that actually
+     *  references source images (an empty Derivation Image Sequence would be
+     *  invalid). Its content is per-frame state that must be cleared once the
+     *  frame has been added, otherwise the next frame inherits the references
+     *  of its predecessor - endFrame() takes care of that.
+     */
+    class PerFrameFunctionalGroups {
+
+    public:
+
+      PerFrameFunctionalGroups()
+        : m_planePosition(FGPlanePosPatient::createMinimal("1","1","1")),
+          m_frameContent(new FGFrameContent()),
+          m_derivationImage(new FGDerivationImage()),
+          m_derivationImageUsed(false)
+      {
+      }
+
+      /** Start a new frame: drop what the previous frame collected */
+      void beginFrame() {
+        m_functionalGroups.clear();
+        m_functionalGroups.push_back(m_planePosition.get());
+        m_functionalGroups.push_back(m_frameContent.get());
+        m_derivationImageUsed = false;
+      }
+
+      FGPlanePosPatient& planePosition() { return *m_planePosition; }
+
+      FGFrameContent& frameContent() { return *m_frameContent; }
+
+      /** Access the Derivation Image group and add it to this frame. Adding it
+       *  more than once per frame is a no-op, so several source image items can
+       *  be collected into the same group. */
+      FGDerivationImage& derivationImage() {
+        if(!m_derivationImageUsed){
+          m_functionalGroups.push_back(m_derivationImage.get());
+          m_derivationImageUsed = true;
+        }
+        return *m_derivationImage;
+      }
+
+      /** The groups of the current frame, for DcmSegmentation::addFrame() */
+      const OFVector<FGBase*>& get() const { return m_functionalGroups; }
+
+      /** Finish the frame: release the per-frame content of the Derivation
+       *  Image group so it does not leak into the next frame */
+      void endFrame() {
+        if(m_derivationImageUsed){
+          m_derivationImage->clearData();
+          m_derivationImageUsed = false;
+        }
+      }
+
+    private:
+
+      std::unique_ptr<FGPlanePosPatient> m_planePosition;
+      std::unique_ptr<FGFrameContent> m_frameContent;
+      std::unique_ptr<FGDerivationImage> m_derivationImage;
+      OFVector<FGBase*> m_functionalGroups;
+      bool m_derivationImageUsed;
+    };
+
     /** Set the Image Position (Patient) of the given plane position FG to the
      *  origin of the given slice of the image */
     void setPlanePositionToSlice(FGPlanePosPatient& fgppp, const itk::ImageBase<3>& image, const unsigned sliceNumber) {
@@ -461,6 +529,9 @@ namespace dcmqi {
       return NULL;
     };
 
+    // Get equipment and content identification information from the metadata handler.
+    // Contains constant dcmqi defaults for equipment and content identification.
+    // These are used to create the DICOM Segmentation object.
     IODGeneralEquipmentModule::EquipmentInfo eq = getEquipmentInfo();
     ContentIdentificationMacro ident = createContentIdentificationInformation(metaInfo);
     CHECK_COND(ident.setInstanceNumber(metaInfo.getInstanceNumber().c_str()));
@@ -529,10 +600,7 @@ namespace dcmqi {
       }
     }
 
-    std::unique_ptr<FGPlanePosPatient> fgppp(FGPlanePosPatient::createMinimal("1","1","1"));
-    std::unique_ptr<FGFrameContent> fgfc(new FGFrameContent());
-    std::unique_ptr<FGDerivationImage> fgder(new FGDerivationImage());
-    OFVector<FGBase*> perFrameFGs;
+    PerFrameFunctionalGroups perFrameFGs;
     unsigned framesAdded = 0;
 
     // Iterate over the files and labels available in each file, create a segment for each label,
@@ -627,39 +695,30 @@ namespace dcmqi {
         // iterate over slices for an individual label and populate output frames
         for(unsigned sliceNumber=firstSlice;sliceNumber<lastSlice;sliceNumber++){
 
+          perFrameFGs.beginFrame();
+
           // PerFrame FG: FrameContentSequence
-          CHECK_COND(fgfc->setDimensionIndexValues(segmentNumber, 0));
-          CHECK_COND(fgfc->setDimensionIndexValues(sliceNumber-firstSlice+1, 1));
+          CHECK_COND(perFrameFGs.frameContent().setDimensionIndexValues(segmentNumber, 0));
+          CHECK_COND(perFrameFGs.frameContent().setDimensionIndexValues(sliceNumber-firstSlice+1, 1));
 
           // PerFrame FG: PlanePositionSequence
-          setPlanePositionToSlice(*fgppp, *segmentations[segFileNumber], sliceNumber);
-
-          /* Add frame that references this segment */
-          vector<Uint8> frameData = extractBinaryFrame(*segmentations[segFileNumber], label, sliceNumber, frameSize);
-
-          perFrameFGs.clear();
-          perFrameFGs.push_back(fgppp.get());
-          perFrameFGs.push_back(fgfc.get());
+          setPlanePositionToSlice(perFrameFGs.planePosition(), *segmentations[segFileNumber], sliceNumber);
 
           // PerFrame FG: DerivationImageSequence, references the source frames
           // this slice was derived from
-          bool frameHasReferences = false;
           if(referencesGeometryCheck && !slice2framesPerFile[segFileNumber][sliceNumber].empty()){
-            CHECK_COND(sourceIndex.addDerivationImageItem(*fgder, slice2framesPerFile[segFileNumber][sliceNumber],
+            CHECK_COND(sourceIndex.addDerivationImageItem(perFrameFGs.derivationImage(),
+                slice2framesPerFile[segFileNumber][sliceNumber],
                 segmentationDerivationCode(), "", sourceImagePurposeOfReferenceCode()));
-            perFrameFGs.push_back(fgder.get());
-            frameHasReferences = true;
           }
 
-          OFCondition frameAdded = segdoc->addFrame(frameData.data(), segmentNumber, perFrameFGs);
+          /* Add frame that references this segment */
+          vector<Uint8> frameData = extractBinaryFrame(*segmentations[segFileNumber], label, sliceNumber, frameSize);
+          OFCondition frameAdded = segdoc->addFrame(frameData.data(), segmentNumber, perFrameFGs.get());
           if(frameAdded.good()){
             framesAdded++;
           }
-
-          // clean up the derivation image FG for the next frame, only if applicable!
-          if(frameHasReferences){
-            fgder->clearData();
-          }
+          perFrameFGs.endFrame();
         }
       }
     }
@@ -670,7 +729,7 @@ namespace dcmqi {
 
       // Stack ID is invariant across all labelmap frames; set it once on the
       // reused FGFrameContent instance.
-      CHECK_COND(fgfc->setStackID("Frame Position"));
+      CHECK_COND(perFrameFGs.frameContent().setStackID("Frame Position"));
 
       for (unsigned sliceNumber = 0; sliceNumber < inputSize[2]; sliceNumber++)
       {
@@ -684,19 +743,16 @@ namespace dcmqi {
         if (skipEmptySlices && !frameHasForeground)
           continue;
 
-        CHECK_COND(fgfc->setInStackPositionNumber(outputFrameNumber));
-        CHECK_COND(fgfc->setDimensionIndexValues(1, 0));
-        CHECK_COND(fgfc->setDimensionIndexValues(outputFrameNumber, 1));
+        perFrameFGs.beginFrame();
 
-        setPlanePositionToSlice(*fgppp, *segmentations[0], sliceNumber);
+        CHECK_COND(perFrameFGs.frameContent().setInStackPositionNumber(outputFrameNumber));
+        CHECK_COND(perFrameFGs.frameContent().setDimensionIndexValues(1, 0));
+        CHECK_COND(perFrameFGs.frameContent().setDimensionIndexValues(outputFrameNumber, 1));
 
-        perFrameFGs.clear();
-        perFrameFGs.push_back(fgppp.get());
-        perFrameFGs.push_back(fgfc.get());
+        setPlanePositionToSlice(perFrameFGs.planePosition(), *segmentations[0], sliceNumber);
 
         // PerFrame FG: DerivationImageSequence, references the source frames of
         // this slice across all segmentation files
-        bool frameHasReferences = false;
         if (referencesGeometryCheck && hasDerivationImagesAny && !slice2framesPerFile.empty())
         {
           std::set<size_t> referencedFrameIds;
@@ -711,26 +767,20 @@ namespace dcmqi {
           if (!referencedFrameIds.empty())
           {
             vector<size_t> frameIds(referencedFrameIds.begin(), referencedFrameIds.end());
-            CHECK_COND(sourceIndex.addDerivationImageItem(*fgder, frameIds,
+            CHECK_COND(sourceIndex.addDerivationImageItem(perFrameFGs.derivationImage(), frameIds,
                 segmentationDerivationCode(), "", sourceImagePurposeOfReferenceCode()));
-            perFrameFGs.push_back(fgder.get());
-            frameHasReferences = true;
           }
         }
 
         OFCondition frameAdded = labelmapUse16Bit
-            ? segdoc->addFrame(frameData16.data(), 0, perFrameFGs)
-            : segdoc->addFrame(frameData8.data(), 0, perFrameFGs);
+            ? segdoc->addFrame(frameData16.data(), 0, perFrameFGs.get())
+            : segdoc->addFrame(frameData8.data(), 0, perFrameFGs.get());
         if (frameAdded.good())
         {
           framesAdded++;
           outputFrameNumber++;
         }
-
-        if (frameHasReferences)
-        {
-          fgder->clearData();
-        }
+        perFrameFGs.endFrame();
       }
     }
 

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -36,48 +36,145 @@ namespace dcmqi {
       return CodeSequenceMacro(code.CodeValue, code.CodingSchemeDesignator, code.CodeMeaning);
     }
 
-    /** Create the DICOM Segmentation document (binary or labelmap).
-     *  For labelmap output, determines the required bit depth from the highest
-     *  segment number that will be assigned and returns it in labelmapUse16Bit.
-     *  Returns NULL if the document cannot be created.
+    /** Assigns the Segment Numbers that are written to DICOM and keeps the
+     *  mappings derived from them.
+     *
+     *  Two numbering schemes exist: sequential (1..N, in the order the labels
+     *  are processed) and the label IDs of the input images used directly.
+     *  The rules of the latter differ between the two output flavors, and the
+     *  resulting numbers are needed in three more places - to size the pixel
+     *  bit depth of a labelmap, to translate input labels into pixel values
+     *  while composing labelmap frames, and to re-map the numbers back to
+     *  label IDs after a binary segmentation was written. Keeping the scheme
+     *  and its three mappings together avoids restating the rules at each of
+     *  those places.
      */
-    DcmSegmentation* createSegmentationDocument(JSONSegmentationMetaInformationHandler& metaInfo,
-                                                const Uint16 rows, const Uint16 columns,
-                                                const bool useLabelIDAsSegmentNumber,
-                                                const bool outputLabelMap,
-                                                IODGeneralEquipmentModule::EquipmentInfo& eq,
-                                                ContentIdentificationMacro& ident,
-                                                bool& labelmapUse16Bit) {
-      DcmSegmentation* segdoc = NULL;
-      labelmapUse16Bit = false;
+    class SegmentNumberAssigner {
 
-      if (outputLabelMap)
+    public:
+
+      SegmentNumberAssigner(const bool useLabelIDAsSegmentNumber,
+                            const bool outputLabelMap,
+                            const size_t numSegmentationFiles)
+        : m_useLabelIDAsSegmentNumber(useLabelIDAsSegmentNumber),
+          m_outputLabelMap(outputLabelMap),
+          m_nextSegmentNumber(1),
+          m_fileLabelToSegmentNumber(numSegmentationFiles)
       {
-        // Pixel values in the output equal the segment numbers, so the bit depth
-        // must accommodate the largest segment number that will be assigned:
-        // the highest label ID if label IDs are used as segment numbers (which
-        // may contain gaps), the number of segments otherwise (sequential 1..N).
+      }
+
+      /** Determine whether labelmap pixel data needs 16 instead of 8 bit.
+       *  Pixel values equal the segment numbers, so the bit depth follows from
+       *  the largest number that will be assigned: the highest label ID if
+       *  label IDs are used (they may contain gaps), the number of segments
+       *  otherwise.
+       *  @param  metaInfo    Metadata describing the segments to be created.
+       *  @param  use16Bit    Set to true if 16 bit pixel data is required.
+       *  @return true on success, false if the required number of segments
+       *          exceeds the 16 bit pixel value range.
+       */
+      bool determineLabelmapBitDepth(JSONSegmentationMetaInformationHandler& metaInfo, bool& use16Bit) const {
         size_t maxSegmentNumber = 0;
         size_t numSegmentsMetadata = 0;
         for (size_t segFileNumber = 0; segFileNumber < metaInfo.segmentsAttributesMappingList.size(); segFileNumber++)
         {
           const map<unsigned, SegmentAttributes*>& fileAttributes = metaInfo.segmentsAttributesMappingList[segFileNumber];
           numSegmentsMetadata += fileAttributes.size();
-          if (useLabelIDAsSegmentNumber && !fileAttributes.empty())
+          if (m_useLabelIDAsSegmentNumber && !fileAttributes.empty())
           {
             // map is ordered by key, so the last entry holds the highest label ID
             maxSegmentNumber = std::max(maxSegmentNumber, static_cast<size_t>(fileAttributes.rbegin()->first));
           }
         }
-        if (!useLabelIDAsSegmentNumber)
+        if (!m_useLabelIDAsSegmentNumber)
           maxSegmentNumber = numSegmentsMetadata;
         if (maxSegmentNumber > 65535)
         {
           cerr << "ERROR: Cannot create labelmap SEG: maximum segment number " << maxSegmentNumber
                << " exceeds the 16 bit pixel value range!" << endl;
-          return NULL;
+          return false;
         }
-        labelmapUse16Bit = maxSegmentNumber > 255;
+        use16Bit = maxSegmentNumber > 255;
+        return true;
+      }
+
+      /** Propose the Segment Number to be used for the given label. The number
+       *  is only recorded once the segment has actually been added, see
+       *  recordSegment().
+       *  @param  label          Label ID from the input image.
+       *  @param  segmentNumber  Set to the proposed Segment Number.
+       *  @return true on success, false (with an error message) if the label ID
+       *          cannot serve as a Segment Number.
+       */
+      bool proposeSegmentNumber(const short label, Uint16& segmentNumber) {
+        if (!m_useLabelIDAsSegmentNumber)
+        {
+          segmentNumber = m_nextSegmentNumber++;
+          return true;
+        }
+        if (label < 0)
+        {
+          cerr << "ERROR: Cannot use label ID " << label << " as segment number: label IDs must be positive!" << endl;
+          return false;
+        }
+        segmentNumber = static_cast<Uint16>(label);
+        // For labelmap output the label IDs become segment numbers directly, and
+        // DcmSegmentation::addSegment() replaces an existing labelmap segment with
+        // the same number (upsert), so a collision across input files would
+        // silently drop a segment. Reject it here. (The binary path detects
+        // collisions later via checkLabelNumbering().)
+        if (m_outputLabelMap && m_segmentToLabel.find(segmentNumber) != m_segmentToLabel.end())
+        {
+          cerr << "ERROR: Label ID " << label << " is used by more than one input segment; "
+               << "cannot use label IDs as segment numbers!" << endl;
+          return false;
+        }
+        return true;
+      }
+
+      /** Record the Segment Number a segment was actually added with (which may
+       *  differ from the proposed one). */
+      void recordSegment(const size_t segFileNumber, const short label, const Uint16 segmentNumber) {
+        m_segmentToLabel.insert(make_pair(segmentNumber, label));
+        if (m_outputLabelMap)
+          m_fileLabelToSegmentNumber[segFileNumber][label] = segmentNumber;
+      }
+
+      /** Segment Number to use as the labelmap pixel value for the given input label.
+       *  @return true if the label belongs to a recorded segment. */
+      bool pixelValueFor(const size_t segFileNumber, const short label, Uint16& segmentNumber) const {
+        map<short, Uint16>::const_iterator it = m_fileLabelToSegmentNumber[segFileNumber].find(label);
+        if (it == m_fileLabelToSegmentNumber[segFileNumber].end())
+          return false;
+        segmentNumber = it->second;
+        return true;
+      }
+
+      /** Mapping from assigned Segment Number to the label ID it came from */
+      const map<Uint16, Uint16>& segmentToLabel() const { return m_segmentToLabel; }
+
+    private:
+
+      const bool m_useLabelIDAsSegmentNumber;
+      const bool m_outputLabelMap;
+      Uint16 m_nextSegmentNumber;
+      map<Uint16, Uint16> m_segmentToLabel;
+      /// per input file, the Segment Number each label was assigned (labelmap output)
+      vector<map<short, Uint16> > m_fileLabelToSegmentNumber;
+    };
+
+    /** Create the DICOM Segmentation document (binary or labelmap).
+     *  Returns NULL if the document cannot be created.
+     */
+    DcmSegmentation* createSegmentationDocument(const Uint16 rows, const Uint16 columns,
+                                                const bool outputLabelMap,
+                                                const bool labelmapUse16Bit,
+                                                IODGeneralEquipmentModule::EquipmentInfo& eq,
+                                                ContentIdentificationMacro& ident) {
+      DcmSegmentation* segdoc = NULL;
+
+      if (outputLabelMap)
+      {
         CHECK_COND(DcmSegmentation::createLabelmapSegmentation(
             segdoc,
             rows,
@@ -352,7 +449,7 @@ namespace dcmqi {
      */
     template<class ImageSourceType>
     bool composeLabelmapFrame(const vector<itk::SmartPointer<const ImageSourceType>>& segmentations,
-                              const vector<map<short, Uint16> >& fileLabelToSegmentNumber,
+                              const SegmentNumberAssigner& segmentNumbers,
                               const unsigned sliceNumber, const unsigned frameSize,
                               const bool use16Bit,
                               vector<Uint8>& frameData8, vector<Uint16>& frameData16,
@@ -391,14 +488,13 @@ namespace dcmqi {
           if (inputLabel == 0)
             continue;
 
-          typename map<short, Uint16>::const_iterator mappingIt = fileLabelToSegmentNumber[segFileNumber].find(inputLabel);
-          if (mappingIt == fileLabelToSegmentNumber[segFileNumber].end())
+          Uint16 segmentValue = 0;
+          if (!segmentNumbers.pixelValueFor(segFileNumber, inputLabel, segmentValue))
           {
             cerr << "ERROR: Failed to map input label " << inputLabel << " to output segment number!" << endl;
             return false;
           }
 
-          Uint16 segmentValue = mappingIt->second;
           if (use16Bit)
           {
             Uint16 currentValue = frameData16[framePixelCnt];
@@ -536,27 +632,21 @@ namespace dcmqi {
     ContentIdentificationMacro ident = createContentIdentificationInformation(metaInfo);
     CHECK_COND(ident.setInstanceNumber(metaInfo.getInstanceNumber().c_str()));
 
-    // Map that will hold the mapping from segment number (as written to DICOM) and label ID
-    // as it is found in the input image. This can be used later to re-map the segment numbers
-    // to their original label IDs (see mapLabelIDsToSegmentNumbers() method).
-    // Segment numbers always start at 1; pixel value 0 in labelmap output is reserved for
-    // background per Sup 243, and a background segment with number 0 (designated via
-    // Pixel Padding Value) is added later if needed.
-    map<Uint16,Uint16> segNum2Label;
-    Uint16 nextSegmentNumber = 1;
-
-    // For labelmap output, this map stores for every input file and label ID
-    // the resulting Segment Number used in output pixel data.
-    vector<map<short, Uint16> > fileLabelToSegmentNumber;
-    if (outputLabelMap)
-      fileLabelToSegmentNumber.resize(segmentations.size());
+    // Assigns the Segment Numbers written to DICOM and keeps the mappings
+    // derived from them (label ID per segment number for the re-mapping after
+    // writing, and the labelmap pixel value per input label).
+    // Segment numbers always start at 1; pixel value 0 in labelmap output is
+    // reserved for background per Sup 243, and a background segment with number
+    // 0 (designated via Pixel Padding Value) is added later if needed.
+    SegmentNumberAssigner segmentNumbers(useLabelIDAsSegmentNumber, outputLabelMap, segmentations.size());
 
     /* Create new segmentation document */
     bool labelmapUse16Bit = false;
+    if (outputLabelMap && !segmentNumbers.determineLabelmapBitDepth(metaInfo, labelmapUse16Bit))
+      return NULL;
     std::unique_ptr<DcmSegmentation> segdoc(
-        createSegmentationDocument(metaInfo, inputSize[1], inputSize[0],
-                                   useLabelIDAsSegmentNumber, outputLabelMap,
-                                   eq, ident, labelmapUse16Bit));
+        createSegmentationDocument(inputSize[1], inputSize[0], outputLabelMap,
+                                   labelmapUse16Bit, eq, ident));
     if (!segdoc)
       return NULL;
 
@@ -659,36 +749,16 @@ namespace dcmqi {
           return NULL;
 
         Uint16 segmentNumber = 0;
-        if (useLabelIDAsSegmentNumber)
+        if (!segmentNumbers.proposeSegmentNumber(label, segmentNumber))
         {
-          if (label < 0)
-          {
-            cerr << "ERROR: Cannot use label ID " << label << " as segment number: label IDs must be positive!" << endl;
-            delete segment;
-            return NULL;
-          }
-          segmentNumber = static_cast<Uint16>(label);
-          // For labelmap output the label IDs become segment numbers directly, and
-          // DcmSegmentation::addSegment() replaces an existing labelmap segment with
-          // the same number (upsert), so a collision across input files would
-          // silently drop a segment. Reject it here. (The binary path detects
-          // collisions later via checkLabelNumbering().)
-          if (outputLabelMap && segNum2Label.find(segmentNumber) != segNum2Label.end())
-          {
-            cerr << "ERROR: Label ID " << label << " is used by more than one input segment; "
-                 << "cannot use label IDs as segment numbers!" << endl;
-            delete segment;
-            return NULL;
-          }
+          delete segment;
+          return NULL;
         }
-        else
-          segmentNumber = nextSegmentNumber++;
         CHECK_COND(segdoc->addSegment(segment, segmentNumber /* returns logical segment number */));
-        segNum2Label.insert(make_pair(segmentNumber, label));
+        segmentNumbers.recordSegment(segFileNumber, label, segmentNumber);
 
         if (outputLabelMap)
         {
-          fileLabelToSegmentNumber[segFileNumber][label] = segmentNumber;
           continue;
         }
 
@@ -736,7 +806,7 @@ namespace dcmqi {
         std::vector<Uint8> frameData8;
         std::vector<Uint16> frameData16;
         bool frameHasForeground = false;
-        if (!composeLabelmapFrame(segmentations, fileLabelToSegmentNumber, sliceNumber, frameSize,
+        if (!composeLabelmapFrame(segmentations, segmentNumbers, sliceNumber, frameSize,
                                   labelmapUse16Bit, frameData8, frameData16, frameHasForeground))
           return NULL;
 
@@ -838,11 +908,11 @@ namespace dcmqi {
       // Binary segmentations require Segment Numbers to start at 1 and increase
       // monotonically by 1, so re-mapping to label IDs only works for label IDs
       // that satisfy the same constraint.
-      if (!checkLabelNumbering(segNum2Label))
+      if (!checkLabelNumbering(segmentNumbers.segmentToLabel()))
       {
         return NULL;
       }
-      mapLabelIDsToSegmentNumbers(segdocDataset.get(), segNum2Label);
+      mapLabelIDsToSegmentNumbers(segdocDataset.get(), segmentNumbers.segmentToLabel());
     }
     // For labelmap output the label IDs were used as segment numbers directly when
     // the segments were added. LABELMAP only requires segment numbers to be unique

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -577,6 +577,400 @@ namespace dcmqi {
       }
     }
 
+    /** Turns a set of ITK segmentation images into a DICOM Segmentation object.
+     *
+     *  Written as a class rather than a function because the individual steps
+     *  of the conversion share a substantial amount of state - the document
+     *  being built, the source image inventory and the mapping derived from it,
+     *  the segment numbering, the functional groups reused for every frame -
+     *  which as plain locals would have to be threaded through every step as a
+     *  dozen or more parameters. As members, each step reduces to what it
+     *  actually does.
+     *
+     *  Derives privately from ConverterBase only to reach its protected
+     *  helpers for the equipment and content identification defaults.
+     */
+    template<class ImageSourceType>
+    class SegmentationEncoder : private ConverterBase {
+
+    public:
+
+      /** The conversion flags of itkimage2dcmSegmentation(), see there for
+       *  their documentation */
+      struct Options {
+        bool skipEmptySlices;
+        bool useLabelIDAsSegmentNumber;
+        bool referencesGeometryCheck;
+        bool doDicomValueChecks;
+        bool outputLabelMap;
+      };
+
+      /** @param dcmDatasets   Source images the segmentation is based on.
+       *  @param segmentations The segmentation images to convert.
+       *  @param metaInfo      Metadata describing the segments.
+       *  @param options       Conversion flags.
+       *  The referenced objects must outlive this encoder.
+       */
+      SegmentationEncoder(const vector<DcmItem*>& dcmDatasets,
+                          const vector<itk::SmartPointer<const ImageSourceType> >& segmentations,
+                          JSONSegmentationMetaInformationHandler& metaInfo,
+                          const Options& options)
+        : m_dcmDatasets(dcmDatasets),
+          m_segmentations(segmentations),
+          m_metaInfo(metaInfo),
+          m_options(options),
+          m_inputSize(segmentations[0]->GetBufferedRegion().GetSize()),
+          m_frameSize(m_inputSize[0] * m_inputSize[1]),
+          m_labelmapUse16Bit(false),
+          // Inventory of the source images, used to map slices of the
+          // segmentation to the source frames and to create the references
+          // derived from that mapping
+          m_sourceIndex(dcmDatasets),
+          // Assigns the Segment Numbers written to DICOM and keeps the mappings
+          // derived from them (label ID per segment number for the re-mapping
+          // after writing, and the labelmap pixel value per input label).
+          // Segment numbers always start at 1; pixel value 0 in labelmap output
+          // is reserved for background per Sup 243, and a background segment
+          // with number 0 (designated via Pixel Padding Value) is added later
+          // if needed.
+          m_segmentNumbers(options.useLabelIDAsSegmentNumber, options.outputLabelMap, segmentations.size()),
+          m_hasDerivationImagesAny(false),
+          m_framesAdded(0)
+      {
+      }
+
+      /** Run the conversion.
+       *  @return The resulting dataset, which the caller owns, or NULL on failure.
+       */
+      DcmDataset* encode() {
+        if(m_metaInfo.segmentsAttributesMappingList.size() != m_segmentations.size()){
+          cerr << "Mismatch between the number of input segmentation files and the size of metainfo list!" << endl;
+          return NULL;
+        }
+
+        if(!createDocument())
+          return NULL;
+        addSharedFunctionalGroups();
+        mapSourceFrames();
+
+        if(!encodeSegments())
+          return NULL;
+        if(m_options.outputLabelMap)
+        {
+          if(!encodeLabelmapFrames())
+            return NULL;
+          // designate pixel value 0 as background (Background segment plus
+          // Pixel Padding Value) if it occurs in any frame
+          CHECK_COND(addBackgroundSegmentIfNeeded(m_segdoc.get()));
+        }
+
+        if(m_framesAdded == 0){
+          cerr << "FATAL ERROR: No input labels found - input segmentation is empty!" << endl;
+          cerr << "If you would like to encode background label, please see https://github.com/QIICR/dcmqi/issues/490" << endl;
+          return NULL;
+        }
+
+        return writeDocument();
+      }
+
+      /** Mapping from assigned Segment Number to the label ID it came from,
+       *  for the caller-side re-mapping of binary segmentations */
+      const map<Uint16, Uint16>& segmentToLabel() const { return m_segmentNumbers.segmentToLabel(); }
+
+    private:
+
+      /** Create the segmentation document and initialize what it inherits from
+       *  the source images and the metadata */
+      bool createDocument() {
+        // Get equipment and content identification information from the metadata handler.
+        // Contains constant dcmqi defaults for equipment and content identification.
+        // These are used to create the DICOM Segmentation object.
+        IODGeneralEquipmentModule::EquipmentInfo eq = getEquipmentInfo();
+        ContentIdentificationMacro ident = createContentIdentificationInformation(m_metaInfo);
+        CHECK_COND(ident.setInstanceNumber(m_metaInfo.getInstanceNumber().c_str()));
+
+        if(m_options.outputLabelMap && !m_segmentNumbers.determineLabelmapBitDepth(m_metaInfo, m_labelmapUse16Bit))
+          return false;
+        m_segdoc.reset(createSegmentationDocument(m_inputSize[1], m_inputSize[0], m_options.outputLabelMap,
+                                                  m_labelmapUse16Bit, eq, ident));
+        if(!m_segdoc)
+          return false;
+
+        // import Patient, Study and Frame of Reference; do not import Series
+        // attributes
+        CHECK_COND(m_segdoc->importHierarchy(*m_dcmDatasets[0], OFTrue, OFTrue, OFTrue, OFFalse));
+
+        initializeDimensions(*m_segdoc, m_options.outputLabelMap);
+        return true;
+      }
+
+      /** Initialize the functional groups that apply to every frame */
+      void addSharedFunctionalGroups() {
+        addGeometrySharedFGs(*m_segdoc, *m_segmentations[0]);
+
+        // Shared FGs: DerivationImageSequence
+        // When geometry checks are disabled, all source images are referenced as
+        // whole instances by all frames.
+        if(!m_options.referencesGeometryCheck && m_dcmDatasets.size() > 1){
+          FGDerivationImage fgderShared;
+          CHECK_COND(m_sourceIndex.addWholeInstanceDerivationImageItem(fgderShared,
+              segmentationDerivationCode(), "", segmentationDerivationCode()));
+          CHECK_COND(m_segdoc->addForAllFrames(fgderShared));
+        }
+      }
+
+      /** Map the slices of each segmentation file to the source frames located on them */
+      void mapSourceFrames() {
+        if(!m_options.referencesGeometryCheck)
+          return;
+        m_slice2framesPerFile.resize(m_segmentations.size());
+        for (size_t segFileNumber = 0; segFileNumber < m_segmentations.size(); segFileNumber++)
+        {
+          m_slice2framesPerFile[segFileNumber] = m_sourceIndex.mapSlicesToFrames(*m_segmentations[segFileNumber]);
+          for (vector<vector<size_t> >::const_iterator vI = m_slice2framesPerFile[segFileNumber].begin();
+               vI != m_slice2framesPerFile[segFileNumber].end(); ++vI)
+            if ((*vI).size() > 0)
+              m_hasDerivationImagesAny = true;
+        }
+      }
+
+      /** Iterate over the files and the labels available in each file and create
+       *  a segment for every label. For binary output the frames of a segment
+       *  are written right away; labelmap output composes its frames from all
+       *  segments afterwards, see encodeLabelmapFrames().
+       */
+      bool encodeSegments() {
+        for(size_t segFileNumber=0; segFileNumber<m_segmentations.size(); segFileNumber++){
+
+          // note that labels are the same in the input and output image produced
+          // by this filter, see https://itk.org/Doxygen/html/classitk_1_1LabelImageToLabelMapFilter.html
+          using LabelToLabelMapFilterType2 = itk::LabelImageToLabelMapFilter<ImageSourceType>;
+          typename LabelToLabelMapFilterType2::Pointer l2lm = LabelToLabelMapFilterType2::New();
+          l2lm->SetInput(m_segmentations[segFileNumber]);
+          l2lm->Update();
+
+          typedef typename LabelToLabelMapFilterType2::OutputImageType::LabelObjectType LabelType;
+          typedef itk::LabelStatisticsImageFilter<ImageSourceType,ImageSourceType> LabelStatisticsType;
+
+          typename LabelStatisticsType::Pointer labelStats = LabelStatisticsType::New();
+
+          cout << "Found " << l2lm->GetOutput()->GetNumberOfLabelObjects() << " label(s)" << endl;
+          labelStats->SetInput(m_segmentations[segFileNumber]);
+          labelStats->SetLabelInput(m_segmentations[segFileNumber]);
+          labelStats->Update();
+
+          for(unsigned segLabelNumber=0 ; segLabelNumber<l2lm->GetOutput()->GetNumberOfLabelObjects();segLabelNumber++){
+            LabelType* labelObject = l2lm->GetOutput()->GetNthLabelObject(segLabelNumber);
+            short label = labelObject->GetLabel();
+
+            if(!label){
+              continue;
+            }
+
+            cout << "Processing label " << label << endl;
+
+            auto bbox = labelStats->GetBoundingBox(label);
+            unsigned firstSlice, lastSlice;
+            if(m_options.skipEmptySlices){
+              firstSlice = bbox[4];
+              lastSlice = bbox[5]+1;
+            } else {
+              firstSlice = 0;
+              lastSlice = m_inputSize[2];
+            }
+
+            cout << "Total non-empty slices that will be encoded in SEG for label " <<
+            label << " is " << lastSlice-firstSlice+1 << endl <<
+            " (inclusive from " << firstSlice << " to " <<
+            lastSlice << ")" << endl;
+
+            if(m_metaInfo.segmentsAttributesMappingList[segFileNumber].find(label) == m_metaInfo.segmentsAttributesMappingList[segFileNumber].end()){
+              cerr << "ERROR: Failed to match label from image to the segment metadata!" << endl;
+              return false;
+            }
+
+            DcmSegment* segment = createSegmentFromAttributes(*m_metaInfo.segmentsAttributesMappingList[segFileNumber][label]);
+            if(!segment)
+              return false;
+
+            Uint16 segmentNumber = 0;
+            if (!m_segmentNumbers.proposeSegmentNumber(label, segmentNumber))
+            {
+              delete segment;
+              return false;
+            }
+            CHECK_COND(m_segdoc->addSegment(segment, segmentNumber /* returns logical segment number */));
+            m_segmentNumbers.recordSegment(segFileNumber, label, segmentNumber);
+
+            if (!m_options.outputLabelMap)
+              addBinaryFrames(segFileNumber, label, segmentNumber, firstSlice, lastSlice);
+          }
+        }
+        return true;
+      }
+
+      /** Write the frames of one segment of a binary segmentation, one per slice
+       *  of the given range */
+      void addBinaryFrames(const size_t segFileNumber, const short label, const Uint16 segmentNumber,
+                           const unsigned firstSlice, const unsigned lastSlice) {
+        for(unsigned sliceNumber=firstSlice;sliceNumber<lastSlice;sliceNumber++){
+
+          m_perFrameFGs.beginFrame();
+
+          // PerFrame FG: FrameContentSequence
+          CHECK_COND(m_perFrameFGs.frameContent().setDimensionIndexValues(segmentNumber, 0));
+          CHECK_COND(m_perFrameFGs.frameContent().setDimensionIndexValues(sliceNumber-firstSlice+1, 1));
+
+          // PerFrame FG: PlanePositionSequence
+          setPlanePositionToSlice(m_perFrameFGs.planePosition(), *m_segmentations[segFileNumber], sliceNumber);
+
+          // PerFrame FG: DerivationImageSequence, references the source frames
+          // this slice was derived from
+          if(m_options.referencesGeometryCheck && !m_slice2framesPerFile[segFileNumber][sliceNumber].empty()){
+            CHECK_COND(m_sourceIndex.addDerivationImageItem(m_perFrameFGs.derivationImage(),
+                m_slice2framesPerFile[segFileNumber][sliceNumber],
+                segmentationDerivationCode(), "", sourceImagePurposeOfReferenceCode()));
+          }
+
+          /* Add frame that references this segment */
+          vector<Uint8> frameData = extractBinaryFrame(*m_segmentations[segFileNumber], label, sliceNumber, m_frameSize);
+          OFCondition frameAdded = m_segdoc->addFrame(frameData.data(), segmentNumber, m_perFrameFGs.get());
+          if(frameAdded.good()){
+            m_framesAdded++;
+          }
+          m_perFrameFGs.endFrame();
+        }
+      }
+
+      /** Compose and write the frames of a labelmap segmentation, one per slice,
+       *  merging the segments of all input files into a single frame */
+      bool encodeLabelmapFrames() {
+        unsigned outputFrameNumber = 1;
+
+        // Stack ID is invariant across all labelmap frames; set it once on the
+        // reused FGFrameContent instance.
+        CHECK_COND(m_perFrameFGs.frameContent().setStackID("Frame Position"));
+
+        for (unsigned sliceNumber = 0; sliceNumber < m_inputSize[2]; sliceNumber++)
+        {
+          std::vector<Uint8> frameData8;
+          std::vector<Uint16> frameData16;
+          bool frameHasForeground = false;
+          if (!composeLabelmapFrame(m_segmentations, m_segmentNumbers, sliceNumber, m_frameSize,
+                                    m_labelmapUse16Bit, frameData8, frameData16, frameHasForeground))
+            return false;
+
+          if (m_options.skipEmptySlices && !frameHasForeground)
+            continue;
+
+          m_perFrameFGs.beginFrame();
+
+          CHECK_COND(m_perFrameFGs.frameContent().setInStackPositionNumber(outputFrameNumber));
+          CHECK_COND(m_perFrameFGs.frameContent().setDimensionIndexValues(1, 0));
+          CHECK_COND(m_perFrameFGs.frameContent().setDimensionIndexValues(outputFrameNumber, 1));
+
+          setPlanePositionToSlice(m_perFrameFGs.planePosition(), *m_segmentations[0], sliceNumber);
+
+          addLabelmapFrameReferences(sliceNumber);
+
+          OFCondition frameAdded = m_labelmapUse16Bit
+              ? m_segdoc->addFrame(frameData16.data(), 0, m_perFrameFGs.get())
+              : m_segdoc->addFrame(frameData8.data(), 0, m_perFrameFGs.get());
+          if (frameAdded.good())
+          {
+            m_framesAdded++;
+            outputFrameNumber++;
+          }
+          m_perFrameFGs.endFrame();
+        }
+        return true;
+      }
+
+      /** PerFrame FG: DerivationImageSequence of a labelmap frame, referencing
+       *  the source frames of this slice across all segmentation files */
+      void addLabelmapFrameReferences(const unsigned sliceNumber) {
+        if (!m_options.referencesGeometryCheck || !m_hasDerivationImagesAny || m_slice2framesPerFile.empty())
+          return;
+
+        std::set<size_t> referencedFrameIds;
+        for (size_t segFileNumber = 0; segFileNumber < m_slice2framesPerFile.size(); segFileNumber++)
+        {
+          if (sliceNumber >= m_slice2framesPerFile[segFileNumber].size())
+            continue;
+          referencedFrameIds.insert(m_slice2framesPerFile[segFileNumber][sliceNumber].begin(),
+                                    m_slice2framesPerFile[segFileNumber][sliceNumber].end());
+        }
+        if (referencedFrameIds.empty())
+          return;
+
+        vector<size_t> frameIds(referencedFrameIds.begin(), referencedFrameIds.end());
+        CHECK_COND(m_sourceIndex.addDerivationImageItem(m_perFrameFGs.derivationImage(), frameIds,
+            segmentationDerivationCode(), "", sourceImagePurposeOfReferenceCode()));
+      }
+
+      /** Complete the document and write it out, including the attributes that
+       *  have to be patched into the written dataset */
+      DcmDataset* writeDocument() {
+        // populate the Common Instance Reference module with the references
+        // accumulated while creating the derivation image items
+        CHECK_COND(m_sourceIndex.populateCommonInstanceReference(m_segdoc->getCommonInstanceReference()));
+
+        m_segdoc->getSeries().setSeriesNumber(m_metaInfo.getSeriesNumber().c_str());
+
+        OFString frameOfRefUID;
+        if(!m_segdoc->getFrameOfReference().getFrameOfReferenceUID(frameOfRefUID).good()){
+          // TODO: add FoR UID to the metadata JSON and check that before generating one!
+          char frameOfRefUIDchar[128];
+          dcmGenerateUniqueIdentifier(frameOfRefUIDchar, QIICR_UID_ROOT);
+          CHECK_COND(m_segdoc->getFrameOfReference().setFrameOfReferenceUID(frameOfRefUIDchar));
+        }
+
+        std::cout << "Writing DICOM segmentation dataset" << std::endl;
+        // Don't check functional groups since its very time consuming and we trust
+        // ourselves to put together valid datasets
+        m_segdoc->setCheckFGOnWrite(OFFalse);
+
+        // Ensure dataset memory is cleaned up on exit, and avoid the copy on
+        // return that was performed before
+        std::unique_ptr<DcmDataset> segdocDataset(new DcmDataset());
+        std::cout << "Checking DICOM attribute values before writing: "
+                  << (m_options.doDicomValueChecks ? "enabled" : "disabled") << std::endl;
+        m_segdoc->setValueCheckOnWrite(m_options.doDicomValueChecks);
+        OFCondition writeResult = m_segdoc->writeDataset(*segdocDataset);
+        if(writeResult.bad()){
+          cerr << "FATAL ERROR: Writing of the SEG dataset failed!";
+          if (writeResult.text()){
+            cerr << " Error: " << writeResult.text() << ".";
+          }
+          cerr << " Please report the problem to the developers, ideally accompanied by a de-identified dataset allowing to reproduce the problem!" << endl;
+          return NULL;
+        }
+
+        patchDerivedAttributes(*segdocDataset, *m_segdoc, m_metaInfo, *m_dcmDatasets[0],
+                               m_options.outputLabelMap, m_segmentations.size());
+        return segdocDataset.release();
+      }
+
+      // inputs
+      const vector<DcmItem*>& m_dcmDatasets;
+      const vector<itk::SmartPointer<const ImageSourceType> >& m_segmentations;
+      JSONSegmentationMetaInformationHandler& m_metaInfo;
+      const Options m_options;
+      const itk::ImageBase<3>::SizeType m_inputSize;
+      const unsigned m_frameSize;
+
+      // conversion state
+      std::unique_ptr<DcmSegmentation> m_segdoc;
+      bool m_labelmapUse16Bit;
+      SourceImageIndex m_sourceIndex;
+      SegmentNumberAssigner m_segmentNumbers;
+      /// per input file and slice, the source frames located on that slice
+      vector<vector<vector<size_t> > > m_slice2framesPerFile;
+      bool m_hasDerivationImagesAny;
+      PerFrameFunctionalGroups m_perFrameFGs;
+      unsigned m_framesAdded;
+    };
+
   } // anonymous namespace
 
 
@@ -618,301 +1012,24 @@ namespace dcmqi {
                                                           bool doDicomValueChecks,
                                                           bool outputLabelMap) {
 
-    auto inputSize = segmentations[0]->GetBufferedRegion().GetSize();
+    const typename SegmentationEncoder<ImageSourceType>::Options options =
+        { skipEmptySlices, useLabelIDAsSegmentNumber, referencesGeometryCheck, doDicomValueChecks, outputLabelMap };
+    SegmentationEncoder<ImageSourceType> encoder(dcmDatasets, segmentations, metaInfo, options);
 
-    if(metaInfo.segmentsAttributesMappingList.size() != segmentations.size()){
-      cerr << "Mismatch between the number of input segmentation files and the size of metainfo list!" << endl;
+    std::unique_ptr<DcmDataset> segdocDataset(encoder.encode());
+    if(!segdocDataset)
       return NULL;
-    };
-
-    // Get equipment and content identification information from the metadata handler.
-    // Contains constant dcmqi defaults for equipment and content identification.
-    // These are used to create the DICOM Segmentation object.
-    IODGeneralEquipmentModule::EquipmentInfo eq = getEquipmentInfo();
-    ContentIdentificationMacro ident = createContentIdentificationInformation(metaInfo);
-    CHECK_COND(ident.setInstanceNumber(metaInfo.getInstanceNumber().c_str()));
-
-    // Assigns the Segment Numbers written to DICOM and keeps the mappings
-    // derived from them (label ID per segment number for the re-mapping after
-    // writing, and the labelmap pixel value per input label).
-    // Segment numbers always start at 1; pixel value 0 in labelmap output is
-    // reserved for background per Sup 243, and a background segment with number
-    // 0 (designated via Pixel Padding Value) is added later if needed.
-    SegmentNumberAssigner segmentNumbers(useLabelIDAsSegmentNumber, outputLabelMap, segmentations.size());
-
-    /* Create new segmentation document */
-    bool labelmapUse16Bit = false;
-    if (outputLabelMap && !segmentNumbers.determineLabelmapBitDepth(metaInfo, labelmapUse16Bit))
-      return NULL;
-    std::unique_ptr<DcmSegmentation> segdoc(
-        createSegmentationDocument(inputSize[1], inputSize[0], outputLabelMap,
-                                   labelmapUse16Bit, eq, ident));
-    if (!segdoc)
-      return NULL;
-
-    // import Patient, Study and Frame of Reference; do not import Series
-    // attributes
-    CHECK_COND(segdoc->importHierarchy(*dcmDatasets[0], OFTrue, OFTrue, OFTrue, OFFalse));
-
-    /* Initialize dimension module */
-    initializeDimensions(*segdoc, outputLabelMap);
-
-    /* Initialize shared functional groups */
-    const unsigned frameSize = inputSize[0] * inputSize[1];
-    addGeometrySharedFGs(*segdoc, *segmentations[0]);
-
-    // Inventory of the source images, used to map slices of the segmentation to
-    // the source frames and to create the references derived from that mapping
-    SourceImageIndex sourceIndex(dcmDatasets);
-
-    // Shared FGs: DerivationImageSequence
-    // When geometry checks are disabled, all source images are referenced as
-    // whole instances by all frames.
-    if(!referencesGeometryCheck && dcmDatasets.size() > 1){
-      FGDerivationImage fgderShared;
-      CHECK_COND(sourceIndex.addWholeInstanceDerivationImageItem(fgderShared,
-          segmentationDerivationCode(), "", segmentationDerivationCode()));
-      CHECK_COND(segdoc->addForAllFrames(fgderShared));
-    }
-
-    // Map the slices of each segmentation file to the source frames located on them
-    vector<vector<vector<size_t> > > slice2framesPerFile;
-    bool hasDerivationImagesAny = false;
-    if (referencesGeometryCheck)
-    {
-      slice2framesPerFile.resize(segmentations.size());
-      for (size_t segFileNumber = 0; segFileNumber < segmentations.size(); segFileNumber++)
-      {
-        slice2framesPerFile[segFileNumber] = sourceIndex.mapSlicesToFrames(*segmentations[segFileNumber]);
-        for (vector<vector<size_t> >::const_iterator vI = slice2framesPerFile[segFileNumber].begin(); vI != slice2framesPerFile[segFileNumber].end(); ++vI)
-          if ((*vI).size() > 0)
-            hasDerivationImagesAny = true;
-      }
-    }
-
-    PerFrameFunctionalGroups perFrameFGs;
-    unsigned framesAdded = 0;
-
-    // Iterate over the files and labels available in each file, create a segment for each label,
-    // initialize segment frames and add to the document
-    for(size_t segFileNumber=0; segFileNumber<segmentations.size(); segFileNumber++){
-
-      // note that labels are the same in the input and output image produced
-      // by this filter, see https://itk.org/Doxygen/html/classitk_1_1LabelImageToLabelMapFilter.html
-      using LabelToLabelMapFilterType2 = itk::LabelImageToLabelMapFilter<ImageSourceType>;
-      typename LabelToLabelMapFilterType2::Pointer l2lm = LabelToLabelMapFilterType2::New();
-      l2lm->SetInput(segmentations[segFileNumber]);
-      l2lm->Update();
-
-      typedef typename LabelToLabelMapFilterType2::OutputImageType::LabelObjectType LabelType;
-      typedef itk::LabelStatisticsImageFilter<ImageSourceType,ImageSourceType> LabelStatisticsType;
-
-      typename LabelStatisticsType::Pointer labelStats = LabelStatisticsType::New();
-
-      cout << "Found " << l2lm->GetOutput()->GetNumberOfLabelObjects() << " label(s)" << endl;
-      labelStats->SetInput(segmentations[segFileNumber]);
-      labelStats->SetLabelInput(segmentations[segFileNumber]);
-      labelStats->Update();
-
-      for(unsigned segLabelNumber=0 ; segLabelNumber<l2lm->GetOutput()->GetNumberOfLabelObjects();segLabelNumber++){
-        LabelType* labelObject = l2lm->GetOutput()->GetNthLabelObject(segLabelNumber);
-        short label = labelObject->GetLabel();
-
-        if(!label){
-          continue;
-        }
-
-        cout << "Processing label " << label << endl;
-
-        auto bbox = labelStats->GetBoundingBox(label);
-        unsigned firstSlice, lastSlice;
-        if(skipEmptySlices){
-          firstSlice = bbox[4];
-          lastSlice = bbox[5]+1;
-        } else {
-          firstSlice = 0;
-          lastSlice = inputSize[2];
-        }
-
-        cout << "Total non-empty slices that will be encoded in SEG for label " <<
-        label << " is " << lastSlice-firstSlice+1 << endl <<
-        " (inclusive from " << firstSlice << " to " <<
-        lastSlice << ")" << endl;
-
-        if(metaInfo.segmentsAttributesMappingList[segFileNumber].find(label) == metaInfo.segmentsAttributesMappingList[segFileNumber].end()){
-          cerr << "ERROR: Failed to match label from image to the segment metadata!" << endl;
-          return NULL;
-        }
-
-        DcmSegment* segment = createSegmentFromAttributes(*metaInfo.segmentsAttributesMappingList[segFileNumber][label]);
-        if(!segment)
-          return NULL;
-
-        Uint16 segmentNumber = 0;
-        if (!segmentNumbers.proposeSegmentNumber(label, segmentNumber))
-        {
-          delete segment;
-          return NULL;
-        }
-        CHECK_COND(segdoc->addSegment(segment, segmentNumber /* returns logical segment number */));
-        segmentNumbers.recordSegment(segFileNumber, label, segmentNumber);
-
-        if (outputLabelMap)
-        {
-          continue;
-        }
-
-        // iterate over slices for an individual label and populate output frames
-        for(unsigned sliceNumber=firstSlice;sliceNumber<lastSlice;sliceNumber++){
-
-          perFrameFGs.beginFrame();
-
-          // PerFrame FG: FrameContentSequence
-          CHECK_COND(perFrameFGs.frameContent().setDimensionIndexValues(segmentNumber, 0));
-          CHECK_COND(perFrameFGs.frameContent().setDimensionIndexValues(sliceNumber-firstSlice+1, 1));
-
-          // PerFrame FG: PlanePositionSequence
-          setPlanePositionToSlice(perFrameFGs.planePosition(), *segmentations[segFileNumber], sliceNumber);
-
-          // PerFrame FG: DerivationImageSequence, references the source frames
-          // this slice was derived from
-          if(referencesGeometryCheck && !slice2framesPerFile[segFileNumber][sliceNumber].empty()){
-            CHECK_COND(sourceIndex.addDerivationImageItem(perFrameFGs.derivationImage(),
-                slice2framesPerFile[segFileNumber][sliceNumber],
-                segmentationDerivationCode(), "", sourceImagePurposeOfReferenceCode()));
-          }
-
-          /* Add frame that references this segment */
-          vector<Uint8> frameData = extractBinaryFrame(*segmentations[segFileNumber], label, sliceNumber, frameSize);
-          OFCondition frameAdded = segdoc->addFrame(frameData.data(), segmentNumber, perFrameFGs.get());
-          if(frameAdded.good()){
-            framesAdded++;
-          }
-          perFrameFGs.endFrame();
-        }
-      }
-    }
-
-    if (outputLabelMap)
-    {
-      unsigned outputFrameNumber = 1;
-
-      // Stack ID is invariant across all labelmap frames; set it once on the
-      // reused FGFrameContent instance.
-      CHECK_COND(perFrameFGs.frameContent().setStackID("Frame Position"));
-
-      for (unsigned sliceNumber = 0; sliceNumber < inputSize[2]; sliceNumber++)
-      {
-        std::vector<Uint8> frameData8;
-        std::vector<Uint16> frameData16;
-        bool frameHasForeground = false;
-        if (!composeLabelmapFrame(segmentations, segmentNumbers, sliceNumber, frameSize,
-                                  labelmapUse16Bit, frameData8, frameData16, frameHasForeground))
-          return NULL;
-
-        if (skipEmptySlices && !frameHasForeground)
-          continue;
-
-        perFrameFGs.beginFrame();
-
-        CHECK_COND(perFrameFGs.frameContent().setInStackPositionNumber(outputFrameNumber));
-        CHECK_COND(perFrameFGs.frameContent().setDimensionIndexValues(1, 0));
-        CHECK_COND(perFrameFGs.frameContent().setDimensionIndexValues(outputFrameNumber, 1));
-
-        setPlanePositionToSlice(perFrameFGs.planePosition(), *segmentations[0], sliceNumber);
-
-        // PerFrame FG: DerivationImageSequence, references the source frames of
-        // this slice across all segmentation files
-        if (referencesGeometryCheck && hasDerivationImagesAny && !slice2framesPerFile.empty())
-        {
-          std::set<size_t> referencedFrameIds;
-          for (size_t segFileNumber = 0; segFileNumber < slice2framesPerFile.size(); segFileNumber++)
-          {
-            if (sliceNumber >= slice2framesPerFile[segFileNumber].size())
-              continue;
-            referencedFrameIds.insert(slice2framesPerFile[segFileNumber][sliceNumber].begin(),
-                                      slice2framesPerFile[segFileNumber][sliceNumber].end());
-          }
-
-          if (!referencedFrameIds.empty())
-          {
-            vector<size_t> frameIds(referencedFrameIds.begin(), referencedFrameIds.end());
-            CHECK_COND(sourceIndex.addDerivationImageItem(perFrameFGs.derivationImage(), frameIds,
-                segmentationDerivationCode(), "", sourceImagePurposeOfReferenceCode()));
-          }
-        }
-
-        OFCondition frameAdded = labelmapUse16Bit
-            ? segdoc->addFrame(frameData16.data(), 0, perFrameFGs.get())
-            : segdoc->addFrame(frameData8.data(), 0, perFrameFGs.get());
-        if (frameAdded.good())
-        {
-          framesAdded++;
-          outputFrameNumber++;
-        }
-        perFrameFGs.endFrame();
-      }
-    }
-
-    // For labelmap output, designate pixel value 0 as background (Background
-    // segment plus Pixel Padding Value) if it occurs in any frame
-    if (outputLabelMap)
-    {
-      CHECK_COND(addBackgroundSegmentIfNeeded(segdoc.get()));
-    }
-
-    if(framesAdded == 0){
-      cerr << "FATAL ERROR: No input labels found - input segmentation is empty!" << endl;
-      cerr << "If you would like to encode background label, please see https://github.com/QIICR/dcmqi/issues/490" << endl;
-      return NULL;
-    }
-
-    // populate the Common Instance Reference module with the references
-    // accumulated while creating the derivation image items
-    CHECK_COND(sourceIndex.populateCommonInstanceReference(segdoc->getCommonInstanceReference()));
-
-    segdoc->getSeries().setSeriesNumber(metaInfo.getSeriesNumber().c_str());
-
-    OFString frameOfRefUID;
-    if(!segdoc->getFrameOfReference().getFrameOfReferenceUID(frameOfRefUID).good()){
-      // TODO: add FoR UID to the metadata JSON and check that before generating one!
-      char frameOfRefUIDchar[128];
-      dcmGenerateUniqueIdentifier(frameOfRefUIDchar, QIICR_UID_ROOT);
-      CHECK_COND(segdoc->getFrameOfReference().setFrameOfReferenceUID(frameOfRefUIDchar));
-    }
-
-    std::cout << "Writing DICOM segmentation dataset" << std::endl;
-    // Don't check functional groups since its very time consuming and we trust
-    // ourselves to put together valid datasets
-    segdoc->setCheckFGOnWrite(OFFalse);
-
-    // Ensure dataset memory is cleaned up on exit, and avoid the copy on
-    // return that was performed before
-    std::unique_ptr<DcmDataset> segdocDataset(new DcmDataset());
-    std::cout << "Checking DICOM attribute values before writing: " << (doDicomValueChecks ? "enabled" : "disabled") << std::endl;
-    segdoc->setValueCheckOnWrite(doDicomValueChecks);
-    OFCondition writeResult = segdoc->writeDataset(*segdocDataset);
-    if(writeResult.bad()){
-      cerr << "FATAL ERROR: Writing of the SEG dataset failed!";
-      if (writeResult.text()){
-        cerr << " Error: " << writeResult.text() << ".";
-      }
-      cerr << " Please report the problem to the developers, ideally accompanied by a de-identified dataset allowing to reproduce the problem!" << endl;
-      return NULL;
-    }
-
-    patchDerivedAttributes(*segdocDataset, *segdoc, metaInfo, *dcmDatasets[0], outputLabelMap, segmentations.size());
 
     if (useLabelIDAsSegmentNumber && !outputLabelMap)
     {
       // Binary segmentations require Segment Numbers to start at 1 and increase
       // monotonically by 1, so re-mapping to label IDs only works for label IDs
       // that satisfy the same constraint.
-      if (!checkLabelNumbering(segmentNumbers.segmentToLabel()))
+      if (!checkLabelNumbering(encoder.segmentToLabel()))
       {
         return NULL;
       }
-      mapLabelIDsToSegmentNumbers(segdocDataset.get(), segmentNumbers.segmentToLabel());
+      mapLabelIDsToSegmentNumbers(segdocDataset.get(), encoder.segmentToLabel());
     }
     // For labelmap output the label IDs were used as segment numbers directly when
     // the segments were added. LABELMAP only requires segment numbers to be unique
@@ -921,7 +1038,6 @@ namespace dcmqi {
 
     return segdocDataset.release();
   }
-
 
   bool Itk2DicomConverter::mapLabelIDsToSegmentNumbers(DcmDataset* dset, map<Uint16,Uint16> segNum2Label)
   {

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -3,6 +3,7 @@
 #include "dcmqi/Itk2DicomConverter.h"
 #include "dcmqi/ColorUtilities.h"
 #include "dcmqi/JSONSegmentationMetaInformationHandler.h"
+#include "dcmqi/SourceImageIndex.h"
 
 // DCMTK includes
 #include <dcmtk/config/osconfig.h>
@@ -16,8 +17,403 @@
 
 #include <itkVectorImageToImageAdaptor.h>
 
+#include <memory>
+
 
 namespace dcmqi {
+
+  namespace {
+
+    // Code describing how the output was derived from the source images (CID 7203)
+    CodeSequenceMacro segmentationDerivationCode() {
+      DSRBasicCodedEntry code_seg = CODE_DCM_Segmentation_113076;
+      return CodeSequenceMacro(code_seg.CodeValue, code_seg.CodingSchemeDesignator, code_seg.CodeMeaning);
+    }
+
+    // Purpose of reference for the source images (CID 7202)
+    CodeSequenceMacro sourceImagePurposeOfReferenceCode() {
+      DSRBasicCodedEntry code = CODE_DCM_SourceImageForImageProcessingOperation;
+      return CodeSequenceMacro(code.CodeValue, code.CodingSchemeDesignator, code.CodeMeaning);
+    }
+
+    /** Create the DICOM Segmentation document (binary or labelmap).
+     *  For labelmap output, determines the required bit depth from the highest
+     *  segment number that will be assigned and returns it in labelmapUse16Bit.
+     *  Returns NULL if the document cannot be created.
+     */
+    DcmSegmentation* createSegmentationDocument(JSONSegmentationMetaInformationHandler& metaInfo,
+                                                const Uint16 rows, const Uint16 columns,
+                                                const bool useLabelIDAsSegmentNumber,
+                                                const bool outputLabelMap,
+                                                IODGeneralEquipmentModule::EquipmentInfo& eq,
+                                                ContentIdentificationMacro& ident,
+                                                bool& labelmapUse16Bit) {
+      DcmSegmentation* segdoc = NULL;
+      labelmapUse16Bit = false;
+
+      if (outputLabelMap)
+      {
+        // Pixel values in the output equal the segment numbers, so the bit depth
+        // must accommodate the largest segment number that will be assigned:
+        // the highest label ID if label IDs are used as segment numbers (which
+        // may contain gaps), the number of segments otherwise (sequential 1..N).
+        size_t maxSegmentNumber = 0;
+        size_t numSegmentsMetadata = 0;
+        for (size_t segFileNumber = 0; segFileNumber < metaInfo.segmentsAttributesMappingList.size(); segFileNumber++)
+        {
+          const map<unsigned, SegmentAttributes*>& fileAttributes = metaInfo.segmentsAttributesMappingList[segFileNumber];
+          numSegmentsMetadata += fileAttributes.size();
+          if (useLabelIDAsSegmentNumber && !fileAttributes.empty())
+          {
+            // map is ordered by key, so the last entry holds the highest label ID
+            maxSegmentNumber = std::max(maxSegmentNumber, static_cast<size_t>(fileAttributes.rbegin()->first));
+          }
+        }
+        if (!useLabelIDAsSegmentNumber)
+          maxSegmentNumber = numSegmentsMetadata;
+        if (maxSegmentNumber > 65535)
+        {
+          cerr << "ERROR: Cannot create labelmap SEG: maximum segment number " << maxSegmentNumber
+               << " exceeds the 16 bit pixel value range!" << endl;
+          return NULL;
+        }
+        labelmapUse16Bit = maxSegmentNumber > 255;
+        CHECK_COND(DcmSegmentation::createLabelmapSegmentation(
+            segdoc,
+            rows,
+            columns,
+            eq,
+            ident,
+            labelmapUse16Bit,
+            DcmSegTypes::SLCM_MONOCHROME2));
+      }
+      else
+      {
+        CHECK_COND(DcmSegmentation::createBinarySegmentation(
+            segdoc,   // resulting segmentation
+            rows,
+            columns,
+            eq,       // equipment
+            ident));  // content identification
+      }
+      return segdoc;
+    }
+
+    /** Initialize the Multi-frame Dimension module of the segmentation document */
+    void initializeDimensions(DcmSegmentation& segdoc, const bool outputLabelMap) {
+      char dimUID[128];
+      dcmGenerateUniqueIdentifier(dimUID, QIICR_UID_ROOT);
+      IODMultiframeDimensionModule &mfdim = segdoc.getDimensions();
+      if (outputLabelMap)
+      {
+        CHECK_COND(mfdim.addDimensionIndex(DCM_StackID, dimUID, DCM_FrameContentSequence, "Stack ID"));
+        CHECK_COND(mfdim.addDimensionIndex(DCM_InStackPositionNumber, dimUID, DCM_FrameContentSequence, "In-Stack Position Number"));
+      }
+      else
+      {
+        CHECK_COND(mfdim.addDimensionIndex(DCM_ReferencedSegmentNumber, dimUID, DCM_SegmentIdentificationSequence,
+                           DcmTag(DCM_ReferencedSegmentNumber).getTagName()));
+        CHECK_COND(mfdim.addDimensionIndex(DCM_ImagePositionPatient, dimUID, DCM_PlanePositionSequence,
+                           DcmTag(DCM_ImagePositionPatient).getTagName()));
+      }
+    }
+
+    /** Initialize the shared functional groups (Plane Orientation, Pixel Measures)
+     *  from the geometry of the image being converted */
+    void addGeometrySharedFGs(DcmSegmentation& segdoc, const itk::ImageBase<3>& geometry) {
+      // Shared FGs: PlaneOrientationPatientSequence
+      {
+        itk::ImageBase<3>::DirectionType labelDirMatrix = geometry.GetDirection();
+
+        std::unique_ptr<FGPlaneOrientationPatient> planor(
+            FGPlaneOrientationPatient::createMinimal(
+                Helper::floatToStr(labelDirMatrix[0][0]).c_str(),
+                Helper::floatToStr(labelDirMatrix[1][0]).c_str(),
+                Helper::floatToStr(labelDirMatrix[2][0]).c_str(),
+                Helper::floatToStr(labelDirMatrix[0][1]).c_str(),
+                Helper::floatToStr(labelDirMatrix[1][1]).c_str(),
+                Helper::floatToStr(labelDirMatrix[2][1]).c_str()));
+
+        CHECK_COND(segdoc.addForAllFrames(*planor));
+      }
+
+      // Shared FGs: PixelMeasuresSequence
+      {
+        FGPixelMeasures pixmsr;
+
+        itk::ImageBase<3>::SpacingType labelSpacing = geometry.GetSpacing();
+        ostringstream spacingSStream;
+        spacingSStream << scientific << labelSpacing[1] << "\\" << labelSpacing[0];
+        CHECK_COND(pixmsr.setPixelSpacing(spacingSStream.str().c_str()));
+
+        spacingSStream.clear(); spacingSStream.str("");
+        spacingSStream << scientific << labelSpacing[2];
+        CHECK_COND(pixmsr.setSpacingBetweenSlices(spacingSStream.str().c_str()));
+        CHECK_COND(pixmsr.setSliceThickness(spacingSStream.str().c_str()));
+        CHECK_COND(segdoc.addForAllFrames(pixmsr));
+      }
+    }
+
+    /** Create a segment from the JSON-provided attributes.
+     *  Returns NULL if required attributes are missing or invalid.
+     */
+    DcmSegment* createSegmentFromAttributes(SegmentAttributes& segmentAttributes) {
+      DcmSegTypes::E_SegmentAlgoType algoType = DcmSegTypes::SAT_UNKNOWN;
+      string algoName = "";
+      string algoTypeStr = segmentAttributes.getSegmentAlgorithmType();
+      if(algoTypeStr == "MANUAL"){
+        algoType = DcmSegTypes::SAT_MANUAL;
+      } else {
+        if(algoTypeStr == "AUTOMATIC")
+          algoType = DcmSegTypes::SAT_AUTOMATIC;
+        if(algoTypeStr == "SEMIAUTOMATIC")
+          algoType = DcmSegTypes::SAT_SEMIAUTOMATIC;
+
+        algoName = segmentAttributes.getSegmentAlgorithmName();
+        if(algoName == ""){
+          cerr << "ERROR: Algorithm name must be specified for non-manual algorithm types!" << endl;
+          return NULL;
+        }
+      }
+
+      CodeSequenceMacro* typeCode = segmentAttributes.getSegmentedPropertyTypeCodeSequence();
+      CodeSequenceMacro* categoryCode = segmentAttributes.getSegmentedPropertyCategoryCodeSequence();
+      assert(typeCode != NULL && categoryCode!= NULL);
+      OFString segmentLabel;
+
+      if(segmentAttributes.getSegmentLabel().length() > 0){
+        cout << "Populating segment label to " << segmentAttributes.getSegmentLabel() << endl;
+        segmentLabel = segmentAttributes.getSegmentLabel().c_str();
+      } else if(segmentAttributes.getSegmentDescription().length() > 0){
+        cout << "Populating segment label from SegmentDescription to " << segmentAttributes.getSegmentDescription() << endl;
+        segmentLabel = segmentAttributes.getSegmentDescription().c_str();
+      } else
+        CHECK_COND(typeCode->getCodeMeaning(segmentLabel));
+
+      DcmSegment* segment = NULL;
+      CHECK_COND(DcmSegment::create(segment, segmentLabel, *categoryCode, *typeCode, algoType, algoName.c_str()));
+
+      if(segmentAttributes.getSegmentDescription().length() > 0)
+        segment->setSegmentDescription(segmentAttributes.getSegmentDescription().c_str());
+
+      if(segmentAttributes.getTrackingIdentifier().length() > 0)
+        segment->setTrackingID(segmentAttributes.getTrackingIdentifier().c_str());
+
+      if(segmentAttributes.getTrackingUniqueIdentifier().length() > 0)
+        segment->setTrackingUID(segmentAttributes.getTrackingUniqueIdentifier().c_str());
+
+      // note: codes are copied into the segment, which frees them on destruction,
+      // while the attributes object keeps ownership of its own copies
+      CodeSequenceMacro* typeModifierCode = segmentAttributes.getSegmentedPropertyTypeModifierCodeSequence();
+      if (typeModifierCode != NULL) {
+        OFVector<CodeSequenceMacro*>& modifiersVector = segment->getSegmentedPropertyTypeModifierCode();
+        modifiersVector.push_back(new CodeSequenceMacro(*typeModifierCode));
+      }
+
+      GeneralAnatomyMacro &anatomyMacro = segment->getGeneralAnatomyCode();
+      if (segmentAttributes.getAnatomicRegionSequence() != NULL){
+        anatomyMacro.getAnatomicRegion() = *segmentAttributes.getAnatomicRegionSequence();
+
+        if(segmentAttributes.getAnatomicRegionModifierSequence() != NULL){
+          OFVector<CodeSequenceMacro*>& anatomyMacroModifiersVector = anatomyMacro.getAnatomicRegionModifier();
+          anatomyMacroModifiersVector.push_back(new CodeSequenceMacro(*segmentAttributes.getAnatomicRegionModifierSequence()));
+        }
+      }
+
+      unsigned* rgb = segmentAttributes.getRecommendedDisplayRGBValue();
+      int cielab[3];
+
+      ColorUtilities::getIntegerScaledCIELabPCSFromSRGB(cielab[0], cielab[1], cielab[2], rgb[0], rgb[1], rgb[2]);
+
+      CHECK_COND(segment->setRecommendedDisplayCIELabValue(cielab[0],cielab[1],cielab[2]));
+
+      return segment;
+    }
+
+    /** Set the Image Position (Patient) of the given plane position FG to the
+     *  origin of the given slice of the image */
+    void setPlanePositionToSlice(FGPlanePosPatient& fgppp, const itk::ImageBase<3>& image, const unsigned sliceNumber) {
+      itk::ImageBase<3>::PointType sliceOriginPoint;
+      itk::ImageBase<3>::IndexType sliceOriginIndex;
+      sliceOriginIndex.Fill(0);
+      sliceOriginIndex[2] = sliceNumber;
+      image.TransformIndexToPhysicalPoint(sliceOriginIndex, sliceOriginPoint);
+      fgppp.setImagePositionPatient(
+          Helper::floatToStr(sliceOriginPoint[0]).c_str(),
+          Helper::floatToStr(sliceOriginPoint[1]).c_str(),
+          Helper::floatToStr(sliceOriginPoint[2]).c_str());
+    }
+
+    /** Extract the binary frame of the given label from a slice of the segmentation image */
+    template<class ImageSourceType>
+    vector<Uint8> extractBinaryFrame(const ImageSourceType& segmentation, const short label,
+                                     const unsigned sliceNumber, const unsigned frameSize) {
+      typename ImageSourceType::RegionType sliceRegion;
+      typename ImageSourceType::IndexType sliceIndex;
+      typename ImageSourceType::SizeType sliceSize;
+
+      auto inputSize = segmentation.GetBufferedRegion().GetSize();
+
+      sliceIndex[0] = 0;
+      sliceIndex[1] = 0;
+      sliceIndex[2] = sliceNumber;
+
+      sliceSize[0] = inputSize[0];
+      sliceSize[1] = inputSize[1];
+      sliceSize[2] = 1;
+
+      sliceRegion.SetIndex(sliceIndex);
+      sliceRegion.SetSize(sliceSize);
+
+      vector<Uint8> frameData(frameSize, 0);
+      unsigned framePixelCnt = 0;
+      itk::ImageRegionConstIteratorWithIndex<ImageSourceType> sliceIterator(&segmentation, sliceRegion);
+      for(sliceIterator.GoToBegin();!sliceIterator.IsAtEnd();++sliceIterator,++framePixelCnt){
+        if(sliceIterator.Get() == label)
+          frameData[framePixelCnt] = 1;
+        else
+          frameData[framePixelCnt] = 0;
+      }
+      return frameData;
+    }
+
+    /** Compose one labelmap output frame by merging the given slice of all
+     *  segmentation files. Fails (returns false) if two foreground segments
+     *  overlap at a pixel. frameHasForeground reports whether any non-zero
+     *  pixel was written.
+     */
+    template<class ImageSourceType>
+    bool composeLabelmapFrame(const vector<itk::SmartPointer<const ImageSourceType>>& segmentations,
+                              const vector<map<short, Uint16> >& fileLabelToSegmentNumber,
+                              const unsigned sliceNumber, const unsigned frameSize,
+                              const bool use16Bit,
+                              vector<Uint8>& frameData8, vector<Uint16>& frameData16,
+                              bool& frameHasForeground) {
+      if (use16Bit)
+        frameData16.assign(frameSize, 0);
+      else
+        frameData8.assign(frameSize, 0);
+
+      frameHasForeground = false;
+
+      auto inputSize = segmentations[0]->GetBufferedRegion().GetSize();
+
+      for (size_t segFileNumber = 0; segFileNumber < segmentations.size(); segFileNumber++)
+      {
+        typename ImageSourceType::RegionType sliceRegion;
+        typename ImageSourceType::IndexType sliceIndex;
+        typename ImageSourceType::SizeType sliceSize;
+
+        sliceIndex[0] = 0;
+        sliceIndex[1] = 0;
+        sliceIndex[2] = sliceNumber;
+
+        sliceSize[0] = inputSize[0];
+        sliceSize[1] = inputSize[1];
+        sliceSize[2] = 1;
+
+        sliceRegion.SetIndex(sliceIndex);
+        sliceRegion.SetSize(sliceSize);
+
+        unsigned framePixelCnt = 0;
+        itk::ImageRegionConstIteratorWithIndex<ImageSourceType> sliceIterator(segmentations[segFileNumber], sliceRegion);
+        for (sliceIterator.GoToBegin(); !sliceIterator.IsAtEnd(); ++sliceIterator, ++framePixelCnt)
+        {
+          short inputLabel = sliceIterator.Get();
+          if (inputLabel == 0)
+            continue;
+
+          typename map<short, Uint16>::const_iterator mappingIt = fileLabelToSegmentNumber[segFileNumber].find(inputLabel);
+          if (mappingIt == fileLabelToSegmentNumber[segFileNumber].end())
+          {
+            cerr << "ERROR: Failed to map input label " << inputLabel << " to output segment number!" << endl;
+            return false;
+          }
+
+          Uint16 segmentValue = mappingIt->second;
+          if (use16Bit)
+          {
+            Uint16 currentValue = frameData16[framePixelCnt];
+            if (currentValue != 0 && currentValue != segmentValue)
+            {
+              cerr << "ERROR: Cannot write labelmap SEG due to overlapping segments at slice " << sliceNumber << "!" << endl;
+              return false;
+            }
+            frameData16[framePixelCnt] = segmentValue;
+          }
+          else
+          {
+            Uint8 segmentValue8 = static_cast<Uint8>(segmentValue);
+            Uint8 currentValue = frameData8[framePixelCnt];
+            if (currentValue != 0 && currentValue != segmentValue8)
+            {
+              cerr << "ERROR: Cannot write labelmap SEG due to overlapping segments at slice " << sliceNumber << "!" << endl;
+              return false;
+            }
+            frameData8[framePixelCnt] = segmentValue8;
+          }
+          frameHasForeground = true;
+        }
+      }
+      return true;
+    }
+
+    /** Patch attributes that are not covered by the DcmSegmentation API into the
+     *  written dataset */
+    void patchDerivedAttributes(DcmDataset& dset, DcmSegmentation& segdoc,
+                                JSONSegmentationMetaInformationHandler& metaInfo,
+                                DcmItem& firstSourceDataset, const bool outputLabelMap,
+                                const size_t numSegmentationFiles) {
+      // Set reader/session/timepoint information
+      cout << "Patching in extra meta information into DICOM dataset" << endl;
+      CHECK_COND(dset.putAndInsertString(DCM_SeriesDescription, metaInfo.getSeriesDescription().c_str()));
+      CHECK_COND(dset.putAndInsertString(DCM_ContentCreatorName, metaInfo.getContentCreatorName().c_str()));
+      CHECK_COND(dset.putAndInsertString(DCM_ClinicalTrialSeriesID, metaInfo.getClinicalTrialSeriesID().c_str()));
+      CHECK_COND(dset.putAndInsertString(DCM_ClinicalTrialTimePointID, metaInfo.getClinicalTrialTimePointID().c_str()));
+      if (metaInfo.getClinicalTrialCoordinatingCenterName().size())
+        CHECK_COND(dset.putAndInsertString(DCM_ClinicalTrialCoordinatingCenterName, metaInfo.getClinicalTrialCoordinatingCenterName().c_str()));
+
+      // populate BodyPartExamined
+      {
+        OFString bodyPartStr;
+        string bodyPartAssigned = metaInfo.getBodyPartExamined();
+
+        // inherit BodyPartExamined from the source image dataset, if available
+        if(firstSourceDataset.findAndGetOFString(DCM_BodyPartExamined, bodyPartStr).good()
+           && string(bodyPartStr.c_str()).size())
+          bodyPartAssigned = bodyPartStr.c_str();
+
+        if(bodyPartAssigned.size())
+          CHECK_COND(dset.putAndInsertString(DCM_BodyPartExamined, bodyPartAssigned.c_str()));
+      }
+
+      // StudyDate/Time should be of the series segmented, not when segmentation was made - this is initialized by DCMTK
+
+      // SeriesDate/Time should be of when segmentation was done; initialize to when it was saved
+      {
+        OFString contentDate, contentTime;
+        DcmDate::getCurrentDate(contentDate);
+        DcmTime::getCurrentTime(contentTime);
+
+        CHECK_COND(dset.putAndInsertString(DCM_SeriesDate, contentDate.c_str()));
+        CHECK_COND(dset.putAndInsertString(DCM_SeriesTime, contentTime.c_str()));
+        segdoc.getGeneralImage().setContentDate(contentDate.c_str());
+        segdoc.getGeneralImage().setContentTime(contentTime.c_str());
+      }
+
+      {
+        string segmentsOverlap;
+        if (outputLabelMap)
+          segmentsOverlap = "NO";
+        else if(numSegmentationFiles == 1)
+          segmentsOverlap = "NO";
+        else
+          segmentsOverlap = "UNDEFINED";
+        CHECK_COND(dset.putAndInsertString(DCM_SegmentsOverlap, segmentsOverlap.c_str()));
+      }
+    }
+
+  } // anonymous namespace
 
 
   Itk2DicomConverter::Itk2DicomConverter()
@@ -68,6 +464,7 @@ namespace dcmqi {
     IODGeneralEquipmentModule::EquipmentInfo eq = getEquipmentInfo();
     ContentIdentificationMacro ident = createContentIdentificationInformation(metaInfo);
     CHECK_COND(ident.setInstanceNumber(metaInfo.getInstanceNumber().c_str()));
+
     // Map that will hold the mapping from segment number (as written to DICOM) and label ID
     // as it is found in the input image. This can be used later to re-map the segment numbers
     // to their original label IDs (see mapLabelIDsToSegmentNumbers() method).
@@ -84,204 +481,63 @@ namespace dcmqi {
       fileLabelToSegmentNumber.resize(segmentations.size());
 
     /* Create new segmentation document */
-    DcmSegmentation *segdoc = NULL;
-
-    if (outputLabelMap)
-    {
-      // Pixel values in the output equal the segment numbers, so the bit depth
-      // must accommodate the largest segment number that will be assigned:
-      // the highest label ID if label IDs are used as segment numbers (which
-      // may contain gaps), the number of segments otherwise (sequential 1..N).
-      size_t maxSegmentNumber = 0;
-      size_t numSegmentsMetadata = 0;
-      for (size_t segFileNumber = 0; segFileNumber < metaInfo.segmentsAttributesMappingList.size(); segFileNumber++)
-      {
-        const map<unsigned, SegmentAttributes*>& fileAttributes = metaInfo.segmentsAttributesMappingList[segFileNumber];
-        numSegmentsMetadata += fileAttributes.size();
-        if (useLabelIDAsSegmentNumber && !fileAttributes.empty())
-        {
-          // map is ordered by key, so the last entry holds the highest label ID
-          maxSegmentNumber = std::max(maxSegmentNumber, static_cast<size_t>(fileAttributes.rbegin()->first));
-        }
-      }
-      if (!useLabelIDAsSegmentNumber)
-        maxSegmentNumber = numSegmentsMetadata;
-      if (maxSegmentNumber > 65535)
-      {
-        cerr << "ERROR: Cannot create labelmap SEG: maximum segment number " << maxSegmentNumber
-             << " exceeds the 16 bit pixel value range!" << endl;
-        return NULL;
-      }
-      const bool use16Bit = maxSegmentNumber > 255;
-      CHECK_COND(DcmSegmentation::createLabelmapSegmentation(
-          segdoc,
-          inputSize[1],
-          inputSize[0],
-          eq,
-          ident,
-          use16Bit,
-          DcmSegTypes::SLCM_MONOCHROME2));
-    }
-    else
-    {
-      CHECK_COND(DcmSegmentation::createBinarySegmentation(
-          segdoc,   // resulting segmentation
-          inputSize[1],    // rows
-          inputSize[0],    // columns
-          eq,     // equipment
-          ident));   // content identification
-    }
+    bool labelmapUse16Bit = false;
+    std::unique_ptr<DcmSegmentation> segdoc(
+        createSegmentationDocument(metaInfo, inputSize[1], inputSize[0],
+                                   useLabelIDAsSegmentNumber, outputLabelMap,
+                                   eq, ident, labelmapUse16Bit));
+    if (!segdoc)
+      return NULL;
 
     // import Patient, Study and Frame of Reference; do not import Series
     // attributes
     CHECK_COND(segdoc->importHierarchy(*dcmDatasets[0], OFTrue, OFTrue, OFTrue, OFFalse));
 
     /* Initialize dimension module */
-    char dimUID[128];
-    dcmGenerateUniqueIdentifier(dimUID, QIICR_UID_ROOT);
-    IODMultiframeDimensionModule &mfdim = segdoc->getDimensions();
-    if (outputLabelMap)
-    {
-      CHECK_COND(mfdim.addDimensionIndex(DCM_StackID, dimUID, DCM_FrameContentSequence, "Stack ID"));
-      CHECK_COND(mfdim.addDimensionIndex(DCM_InStackPositionNumber, dimUID, DCM_FrameContentSequence, "In-Stack Position Number"));
-    }
-    else
-    {
-      CHECK_COND(mfdim.addDimensionIndex(DCM_ReferencedSegmentNumber, dimUID, DCM_SegmentIdentificationSequence,
-                         DcmTag(DCM_ReferencedSegmentNumber).getTagName()));
-      CHECK_COND(mfdim.addDimensionIndex(DCM_ImagePositionPatient, dimUID, DCM_PlanePositionSequence,
-                         DcmTag(DCM_ImagePositionPatient).getTagName()));
-    }
+    initializeDimensions(*segdoc, outputLabelMap);
 
     /* Initialize shared functional groups */
     const unsigned frameSize = inputSize[0] * inputSize[1];
+    addGeometrySharedFGs(*segdoc, *segmentations[0]);
 
-    // Shared FGs: PlaneOrientationPatientSequence
-    {
-      auto labelDirMatrix = segmentations[0]->GetDirection();
-
-      FGPlaneOrientationPatient *planor =
-          FGPlaneOrientationPatient::createMinimal(
-              Helper::floatToStr(labelDirMatrix[0][0]).c_str(),
-              Helper::floatToStr(labelDirMatrix[1][0]).c_str(),
-              Helper::floatToStr(labelDirMatrix[2][0]).c_str(),
-              Helper::floatToStr(labelDirMatrix[0][1]).c_str(),
-              Helper::floatToStr(labelDirMatrix[1][1]).c_str(),
-              Helper::floatToStr(labelDirMatrix[2][1]).c_str());
-
-      CHECK_COND(segdoc->addForAllFrames(*planor));
-    }
-
-    // Shared FGs: PixelMeasuresSequence
-    {
-      FGPixelMeasures *pixmsr = new FGPixelMeasures();
-
-      auto labelSpacing = segmentations[0]->GetSpacing();
-      ostringstream spacingSStream;
-      spacingSStream << scientific << labelSpacing[1] << "\\" << labelSpacing[0];
-      CHECK_COND(pixmsr->setPixelSpacing(spacingSStream.str().c_str()));
-
-      spacingSStream.clear(); spacingSStream.str("");
-      spacingSStream << scientific << labelSpacing[2];
-      CHECK_COND(pixmsr->setSpacingBetweenSlices(spacingSStream.str().c_str()));
-      CHECK_COND(pixmsr->setSliceThickness(spacingSStream.str().c_str()));
-      CHECK_COND(segdoc->addForAllFrames(*pixmsr));
-      delete pixmsr;
-    }
-
-    // Iterate over the files and labels available in each file, create a segment for each label,
-    // initialize segment frames and add to the document
-
-    OFString seriesInstanceUID, classUID;
-    set<OFString> instanceUIDs;
-
-    IODCommonInstanceReferenceModule &commref = segdoc->getCommonInstanceReference();
-    OFVector<IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*> &refseries = commref.getReferencedSeriesItems();
-
-    IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem* refseriesItem = new IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem;
-
-    OFVector<SOPInstanceReferenceMacro*> &refinstances = refseriesItem->getReferencedInstanceItems();
-
-    CHECK_COND(dcmDatasets[0]->findAndGetOFString(DCM_SeriesInstanceUID, seriesInstanceUID));
-    CHECK_COND(refseriesItem->setSeriesInstanceUID(seriesInstanceUID));
+    // Inventory of the source images, used to map slices of the segmentation to
+    // the source frames and to create the references derived from that mapping
+    SourceImageIndex sourceIndex(dcmDatasets);
 
     // Shared FGs: DerivationImageSequence
+    // When geometry checks are disabled, all source images are referenced as
+    // whole instances by all frames.
     if(!referencesGeometryCheck && dcmDatasets.size() > 1){
-      FGDerivationImage *fgder = new FGDerivationImage();
-      DerivationImageItem *derimgItem;
-
-      DSRBasicCodedEntry code_seg=CODE_DCM_Segmentation_113076;
-      CHECK_COND(fgder->addDerivationImageItem(CodeSequenceMacro(code_seg.CodeValue,code_seg.CodingSchemeDesignator,
-			code_seg.CodeMeaning),"",derimgItem));
-
-      OFVector<SourceImageItem*> srcimgItems;
-      OFVector<DcmItem*> dcmDatasets_ofvector;
-      for (const auto& dataset : dcmDatasets) {
-        dcmDatasets_ofvector.push_back(dataset);
-      }
-      derimgItem->addSourceImageItems(dcmDatasets_ofvector,
-        CodeSequenceMacro(code_seg.CodeValue,code_seg.CodingSchemeDesignator, code_seg.CodeMeaning), srcimgItems, OFTrue /*skip file errors */);
-
-      for(size_t src_image_cnt=0;src_image_cnt<srcimgItems.size();src_image_cnt++){
-        // initialize class UID and series instance UID
-        ImageSOPInstanceReferenceMacro &instRef = srcimgItems[src_image_cnt]->getImageSOPInstanceReference();
-        OFString instanceUID;
-        CHECK_COND(instRef.getReferencedSOPClassUID(classUID));
-        CHECK_COND(instRef.getReferencedSOPInstanceUID(instanceUID));
-
-        if(instanceUIDs.find(instanceUID) == instanceUIDs.end()){
-          SOPInstanceReferenceMacro *refinstancesItem = new SOPInstanceReferenceMacro();
-          CHECK_COND(refinstancesItem->setReferencedSOPClassUID(classUID));
-          CHECK_COND(refinstancesItem->setReferencedSOPInstanceUID(instanceUID));
-          refinstances.push_back(refinstancesItem);
-          instanceUIDs.insert(instanceUID);
-        }
-      }
-      CHECK_COND(segdoc->addForAllFrames(*fgder));
-      delete fgder;
+      FGDerivationImage fgderShared;
+      CHECK_COND(sourceIndex.addWholeInstanceDerivationImageItem(fgderShared,
+          segmentationDerivationCode(), "", segmentationDerivationCode()));
+      CHECK_COND(segdoc->addForAllFrames(fgderShared));
     }
 
-    int uidfound = 0, uidnotfound = 0;
-
-    bool hasDerivationImages = false;
+    // Map the slices of each segmentation file to the source frames located on them
+    vector<vector<vector<size_t> > > slice2framesPerFile;
     bool hasDerivationImagesAny = false;
-    vector<vector<vector<int> > > slice2derimgPerFile;
     if (referencesGeometryCheck)
     {
-      slice2derimgPerFile.resize(segmentations.size());
+      slice2framesPerFile.resize(segmentations.size());
       for (size_t segFileNumber = 0; segFileNumber < segmentations.size(); segFileNumber++)
       {
-        slice2derimgPerFile[segFileNumber] = getSliceMapForSegmentation2DerivationImage(dcmDatasets, segmentations[segFileNumber]);
-        for (vector<vector<int> >::const_iterator vI = slice2derimgPerFile[segFileNumber].begin(); vI != slice2derimgPerFile[segFileNumber].end(); ++vI)
+        slice2framesPerFile[segFileNumber] = sourceIndex.mapSlicesToFrames(*segmentations[segFileNumber]);
+        for (vector<vector<size_t> >::const_iterator vI = slice2framesPerFile[segFileNumber].begin(); vI != slice2framesPerFile[segFileNumber].end(); ++vI)
           if ((*vI).size() > 0)
             hasDerivationImagesAny = true;
       }
     }
 
-    FGPlanePosPatient* fgppp = FGPlanePosPatient::createMinimal("1","1","1");
-    FGFrameContent* fgfc = new FGFrameContent();
-    FGDerivationImage* fgder = new FGDerivationImage();
+    std::unique_ptr<FGPlanePosPatient> fgppp(FGPlanePosPatient::createMinimal("1","1","1"));
+    std::unique_ptr<FGFrameContent> fgfc(new FGFrameContent());
+    std::unique_ptr<FGDerivationImage> fgder(new FGDerivationImage());
     OFVector<FGBase*> perFrameFGs;
     unsigned framesAdded = 0;
 
+    // Iterate over the files and labels available in each file, create a segment for each label,
+    // initialize segment frames and add to the document
     for(size_t segFileNumber=0; segFileNumber<segmentations.size(); segFileNumber++){
-
-      vector<vector<int> > slice2derimg;
-      if(referencesGeometryCheck){
-        slice2derimg = slice2derimgPerFile[segFileNumber];
-        hasDerivationImages = false;
-        for(vector<vector<int> >::const_iterator vI=slice2derimg.begin();vI!=slice2derimg.end();++vI)
-          if((*vI).size()>0)
-            hasDerivationImages = true;
-      } else {
-        hasDerivationImages = false;
-      }
-
-      perFrameFGs.clear();
-      perFrameFGs.push_back(fgppp);
-      perFrameFGs.push_back(fgfc);
-      if(hasDerivationImages)
-        perFrameFGs.push_back(fgder);
 
       // note that labels are the same in the input and output image produced
       // by this filter, see https://itk.org/Doxygen/html/classitk_1_1LabelImageToLabelMapFilter.html
@@ -300,33 +556,6 @@ namespace dcmqi {
       labelStats->SetLabelInput(segmentations[segFileNumber]);
       labelStats->Update();
 
-      bool cropSegmentsBBox = false;
-      if(cropSegmentsBBox){
-        cout << "WARNING: Crop operation enabled - WIP" << endl;
-        typedef itk::BinaryThresholdImageFilter<ImageSourceType,ImageSourceType> ThresholdType;
-        typename ThresholdType::Pointer thresh = ThresholdType::New();
-        thresh->SetInput(segmentations[segFileNumber]);
-        thresh->SetLowerThreshold(1);
-        thresh->SetLowerThreshold(100);
-        thresh->SetInsideValue(1);
-        thresh->Update();
-
-        typename LabelStatisticsType::Pointer threshLabelStats = LabelStatisticsType::New();
-
-        threshLabelStats->SetInput(thresh->GetOutput());
-        threshLabelStats->SetLabelInput(thresh->GetOutput());
-        threshLabelStats->Update();
-
-        auto threshBbox = threshLabelStats->GetBoundingBox(1);
-        /*
-        cout << "OVerall bounding box: " << threshBbox[0] << ", " << threshBbox[1]
-               << threshBbox[2] << ", " << threshBbox[3]
-               << threshBbox[4] << ", " << threshBbox[5]
-               << endl;
-               */
-        return NULL;
-      }
-
       for(unsigned segLabelNumber=0 ; segLabelNumber<l2lm->GetOutput()->GetNumberOfLabelObjects();segLabelNumber++){
         LabelType* labelObject = l2lm->GetOutput()->GetNthLabelObject(segLabelNumber);
         short label = labelObject->GetLabel();
@@ -339,8 +568,6 @@ namespace dcmqi {
 
         auto bbox = labelStats->GetBoundingBox(label);
         unsigned firstSlice, lastSlice;
-        //bool skipEmptySlices = true; // TODO: what to do with that line?
-        //bool skipEmptySlices = false; // TODO: what to do with that line?
         if(skipEmptySlices){
           firstSlice = bbox[4];
           lastSlice = bbox[5]+1;
@@ -354,82 +581,14 @@ namespace dcmqi {
         " (inclusive from " << firstSlice << " to " <<
         lastSlice << ")" << endl;
 
-        DcmSegment* segment = NULL;
         if(metaInfo.segmentsAttributesMappingList[segFileNumber].find(label) == metaInfo.segmentsAttributesMappingList[segFileNumber].end()){
           cerr << "ERROR: Failed to match label from image to the segment metadata!" << endl;
           return NULL;
         }
 
-        SegmentAttributes* segmentAttributes = metaInfo.segmentsAttributesMappingList[segFileNumber][label];
-
-        DcmSegTypes::E_SegmentAlgoType algoType = DcmSegTypes::SAT_UNKNOWN;
-        string algoName = "";
-        string algoTypeStr = segmentAttributes->getSegmentAlgorithmType();
-        if(algoTypeStr == "MANUAL"){
-          algoType = DcmSegTypes::SAT_MANUAL;
-        } else {
-          if(algoTypeStr == "AUTOMATIC")
-            algoType = DcmSegTypes::SAT_AUTOMATIC;
-          if(algoTypeStr == "SEMIAUTOMATIC")
-            algoType = DcmSegTypes::SAT_SEMIAUTOMATIC;
-
-          algoName = segmentAttributes->getSegmentAlgorithmName();
-          if(algoName == ""){
-            cerr << "ERROR: Algorithm name must be specified for non-manual algorithm types!" << endl;
-            return NULL;
-          }
-        }
-
-        CodeSequenceMacro* typeCode = segmentAttributes->getSegmentedPropertyTypeCodeSequence();
-        CodeSequenceMacro* categoryCode = segmentAttributes->getSegmentedPropertyCategoryCodeSequence();
-        assert(typeCode != NULL && categoryCode!= NULL);
-        OFString segmentLabel;
-
-        if(segmentAttributes->getSegmentLabel().length() > 0){
-          cout << "Populating segment label to " << segmentAttributes->getSegmentLabel() << endl;
-          segmentLabel = segmentAttributes->getSegmentLabel().c_str();
-        } else if(segmentAttributes->getSegmentDescription().length() > 0){
-          cout << "Populating segment label from SegmentDescription to " << segmentAttributes->getSegmentDescription() << endl;
-          segmentLabel = segmentAttributes->getSegmentDescription().c_str();
-        } else
-          CHECK_COND(typeCode->getCodeMeaning(segmentLabel));
-
-        CHECK_COND(DcmSegment::create(segment, segmentLabel, *categoryCode, *typeCode, algoType, algoName.c_str()));
-
-        if(segmentAttributes->getSegmentDescription().length() > 0)
-          segment->setSegmentDescription(segmentAttributes->getSegmentDescription().c_str());
-
-        if(segmentAttributes->getTrackingIdentifier().length() > 0)
-          segment->setTrackingID(segmentAttributes->getTrackingIdentifier().c_str());
-
-        if(segmentAttributes->getTrackingUniqueIdentifier().length() > 0)
-          segment->setTrackingUID(segmentAttributes->getTrackingUniqueIdentifier().c_str());
-
-        CodeSequenceMacro* typeModifierCode = segmentAttributes->getSegmentedPropertyTypeModifierCodeSequence();
-        if (typeModifierCode != NULL) {
-          OFVector<CodeSequenceMacro*>& modifiersVector = segment->getSegmentedPropertyTypeModifierCode();
-          modifiersVector.push_back(typeModifierCode);
-        }
-
-        GeneralAnatomyMacro &anatomyMacro = segment->getGeneralAnatomyCode();
-        if (segmentAttributes->getAnatomicRegionSequence() != NULL){
-          OFVector<CodeSequenceMacro*>& anatomyMacroModifiersVector = anatomyMacro.getAnatomicRegionModifier();
-          CodeSequenceMacro& anatomicRegionSequence = anatomyMacro.getAnatomicRegion();
-          anatomicRegionSequence = *segmentAttributes->getAnatomicRegionSequence();
-
-          if(segmentAttributes->getAnatomicRegionModifierSequence() != NULL){
-            CodeSequenceMacro* anatomicRegionModifierSequence = segmentAttributes->getAnatomicRegionModifierSequence();
-            anatomyMacroModifiersVector.push_back(anatomicRegionModifierSequence);
-          }
-        }
-
-        unsigned* rgb = segmentAttributes->getRecommendedDisplayRGBValue();
-        int cielab[3];
-
-        ColorUtilities::getIntegerScaledCIELabPCSFromSRGB(cielab[0], cielab[1], cielab[2], rgb[0], rgb[1], rgb[2]);
-        //IODCIELabUtil::rgb2DicomLab(cielab[0], cielab[1], cielab[2], rgb[0], rgb[1], rgb[2]);
-
-        CHECK_COND(segment->setRecommendedDisplayCIELabValue(cielab[0],cielab[1],cielab[2]));
+        DcmSegment* segment = createSegmentFromAttributes(*metaInfo.segmentsAttributesMappingList[segFileNumber][label]);
+        if(!segment)
+          return NULL;
 
         Uint16 segmentNumber = 0;
         if (useLabelIDAsSegmentNumber)
@@ -437,6 +596,7 @@ namespace dcmqi {
           if (label < 0)
           {
             cerr << "ERROR: Cannot use label ID " << label << " as segment number: label IDs must be positive!" << endl;
+            delete segment;
             return NULL;
           }
           segmentNumber = static_cast<Uint16>(label);
@@ -449,6 +609,7 @@ namespace dcmqi {
           {
             cerr << "ERROR: Label ID " << label << " is used by more than one input segment; "
                  << "cannot use label IDs as segment numbers!" << endl;
+            delete segment;
             return NULL;
           }
         }
@@ -463,120 +624,41 @@ namespace dcmqi {
           continue;
         }
 
-        // TODO: make it possible to skip empty frames (optional)
         // iterate over slices for an individual label and populate output frames
         for(unsigned sliceNumber=firstSlice;sliceNumber<lastSlice;sliceNumber++){
 
           // PerFrame FG: FrameContentSequence
-          //fracon->setStackID("1"); // all frames go into the same stack
           CHECK_COND(fgfc->setDimensionIndexValues(segmentNumber, 0));
           CHECK_COND(fgfc->setDimensionIndexValues(sliceNumber-firstSlice+1, 1));
-          //ostringstream inStackPosSStream; // StackID is not present/needed
-          //inStackPosSStream << s+1;
-          //fracon->setInStackPositionNumber(s+1);
 
           // PerFrame FG: PlanePositionSequence
-          {
-            typename ImageSourceType::PointType sliceOriginPoint;
-            typename ImageSourceType::IndexType sliceOriginIndex;
-            sliceOriginIndex.Fill(0);
-            sliceOriginIndex[2] = sliceNumber;
-            segmentations[segFileNumber]->TransformIndexToPhysicalPoint(sliceOriginIndex, sliceOriginPoint);
-            ostringstream pppSStream;
-            if(sliceNumber>0){
-              typename ImageSourceType::PointType prevOrigin;
-              typename ImageSourceType::IndexType prevIndex;
-              prevIndex.Fill(0);
-              prevIndex[2] = sliceNumber-1;
-              segmentations[segFileNumber]->TransformIndexToPhysicalPoint(prevIndex, prevOrigin);
-            }
-            fgppp->setImagePositionPatient(
-                Helper::floatToStr(sliceOriginPoint[0]).c_str(),
-                Helper::floatToStr(sliceOriginPoint[1]).c_str(),
-                Helper::floatToStr(sliceOriginPoint[2]).c_str());
-          }
+          setPlanePositionToSlice(*fgppp, *segmentations[segFileNumber], sliceNumber);
 
           /* Add frame that references this segment */
-          {
-            typename ImageSourceType::RegionType sliceRegion;
-            typename ImageSourceType::IndexType sliceIndex;
-            typename ImageSourceType::SizeType sliceSize;
+          vector<Uint8> frameData = extractBinaryFrame(*segmentations[segFileNumber], label, sliceNumber, frameSize);
 
-            sliceIndex[0] = 0;
-            sliceIndex[1] = 0;
-            sliceIndex[2] = sliceNumber;
+          perFrameFGs.clear();
+          perFrameFGs.push_back(fgppp.get());
+          perFrameFGs.push_back(fgfc.get());
 
-            sliceSize[0] = inputSize[0];
-            sliceSize[1] = inputSize[1];
-            sliceSize[2] = 1;
+          // PerFrame FG: DerivationImageSequence, references the source frames
+          // this slice was derived from
+          bool frameHasReferences = false;
+          if(referencesGeometryCheck && !slice2framesPerFile[segFileNumber][sliceNumber].empty()){
+            CHECK_COND(sourceIndex.addDerivationImageItem(*fgder, slice2framesPerFile[segFileNumber][sliceNumber],
+                segmentationDerivationCode(), "", sourceImagePurposeOfReferenceCode()));
+            perFrameFGs.push_back(fgder.get());
+            frameHasReferences = true;
+          }
 
-            sliceRegion.SetIndex(sliceIndex);
-            sliceRegion.SetSize(sliceSize);
+          OFCondition frameAdded = segdoc->addFrame(frameData.data(), segmentNumber, perFrameFGs);
+          if(frameAdded.good()){
+            framesAdded++;
+          }
 
-            std::vector<Uint8> frameData(frameSize, 0);
-            unsigned framePixelCnt = 0;
-            itk::ImageRegionConstIteratorWithIndex<ImageSourceType> sliceIterator(segmentations[segFileNumber], sliceRegion);
-            for(sliceIterator.GoToBegin();!sliceIterator.IsAtEnd();++sliceIterator,++framePixelCnt){
-              if(sliceIterator.Get() == label){
-                frameData[framePixelCnt] = 1;
-                auto idx = sliceIterator.GetIndex();
-              } else
-                frameData[framePixelCnt] = 0;
-            }
-
-            OFVector<DcmItem*> siVector;
-            if(referencesGeometryCheck){
-              for(size_t derImageInstanceNum=0;
-                  derImageInstanceNum<slice2derimg[sliceNumber].size();
-                  derImageInstanceNum++){
-                siVector.push_back(dcmDatasets[slice2derimg[sliceNumber][derImageInstanceNum]]);
-              }
-
-              if(siVector.size()>0){
-
-                DerivationImageItem *derimgItem;
-          DSRBasicCodedEntry code_seg=CODE_DCM_Segmentation_113076;
-                CHECK_COND(fgder->addDerivationImageItem(CodeSequenceMacro(code_seg.CodeValue,code_seg.CodingSchemeDesignator,
-            code_seg.CodeMeaning),"",derimgItem));
-
-          DSRBasicCodedEntry code = CODE_DCM_SourceImageForImageProcessingOperation;
-                OFVector<SourceImageItem*> srcimgItems;
-                CHECK_COND(derimgItem->addSourceImageItems(siVector,
-                                                        CodeSequenceMacro(code.CodeValue, code.CodingSchemeDesignator,
-                                code.CodeMeaning),
-                                                        srcimgItems));
-
-                {
-                  // initialize class UID and series instance UID
-                  ImageSOPInstanceReferenceMacro &instRef = srcimgItems[0]->getImageSOPInstanceReference();
-                  OFString instanceUID;
-                  CHECK_COND(instRef.getReferencedSOPClassUID(classUID));
-                  CHECK_COND(instRef.getReferencedSOPInstanceUID(instanceUID));
-
-                  if(instanceUIDs.find(instanceUID) == instanceUIDs.end()){
-                    SOPInstanceReferenceMacro *refinstancesItem = new SOPInstanceReferenceMacro();
-                    CHECK_COND(refinstancesItem->setReferencedSOPClassUID(classUID));
-                    CHECK_COND(refinstancesItem->setReferencedSOPInstanceUID(instanceUID));
-                    refinstances.push_back(refinstancesItem);
-                    instanceUIDs.insert(instanceUID);
-                    uidnotfound++;
-                  } else {
-                    uidfound++;
-                  }
-                }
-              }
-            }
-
-            OFCondition frameAdded = segdoc->addFrame(frameData.data(), segmentNumber, perFrameFGs);
-            if(frameAdded.good()){
-              framesAdded++;
-            }
-
-            // remove derivation image FG from the per-frame FGs, only if applicable!
-            if(referencesGeometryCheck && siVector.size()>0){
-              // clean up for the next frame
-              fgder->clearData();
-            }
+          // clean up the derivation image FG for the next frame, only if applicable!
+          if(frameHasReferences){
+            fgder->clearData();
           }
         }
       }
@@ -584,88 +666,20 @@ namespace dcmqi {
 
     if (outputLabelMap)
     {
-      const size_t numSegmentsMetadata = segNum2Label.size();
-      const bool labelMapUse16Bit = numSegmentsMetadata > 255;
       unsigned outputFrameNumber = 1;
 
       // Stack ID is invariant across all labelmap frames; set it once on the
       // reused FGFrameContent instance.
       CHECK_COND(fgfc->setStackID("Frame Position"));
 
-      // Releases the per-frame functional groups before bailing out on error.
-      auto releaseFGs = [&]() { delete fgfc; delete fgppp; delete fgder; fgfc = NULL; fgppp = NULL; fgder = NULL; };
-
       for (unsigned sliceNumber = 0; sliceNumber < inputSize[2]; sliceNumber++)
       {
         std::vector<Uint8> frameData8;
         std::vector<Uint16> frameData16;
-        if (labelMapUse16Bit)
-          frameData16.assign(frameSize, 0);
-        else
-          frameData8.assign(frameSize, 0);
-
         bool frameHasForeground = false;
-
-        for (size_t segFileNumber = 0; segFileNumber < segmentations.size(); segFileNumber++)
-        {
-          typename ImageSourceType::RegionType sliceRegion;
-          typename ImageSourceType::IndexType sliceIndex;
-          typename ImageSourceType::SizeType sliceSize;
-
-          sliceIndex[0] = 0;
-          sliceIndex[1] = 0;
-          sliceIndex[2] = sliceNumber;
-
-          sliceSize[0] = inputSize[0];
-          sliceSize[1] = inputSize[1];
-          sliceSize[2] = 1;
-
-          sliceRegion.SetIndex(sliceIndex);
-          sliceRegion.SetSize(sliceSize);
-
-          unsigned framePixelCnt = 0;
-          itk::ImageRegionConstIteratorWithIndex<ImageSourceType> sliceIterator(segmentations[segFileNumber], sliceRegion);
-          for (sliceIterator.GoToBegin(); !sliceIterator.IsAtEnd(); ++sliceIterator, ++framePixelCnt)
-          {
-            short inputLabel = sliceIterator.Get();
-            if (inputLabel == 0)
-              continue;
-
-            map<short, Uint16>::const_iterator mappingIt = fileLabelToSegmentNumber[segFileNumber].find(inputLabel);
-            if (mappingIt == fileLabelToSegmentNumber[segFileNumber].end())
-            {
-              cerr << "ERROR: Failed to map input label " << inputLabel << " to output segment number!" << endl;
-              releaseFGs();
-              return NULL;
-            }
-
-            Uint16 segmentValue = mappingIt->second;
-            if (labelMapUse16Bit)
-            {
-              Uint16 currentValue = frameData16[framePixelCnt];
-              if (currentValue != 0 && currentValue != segmentValue)
-              {
-                cerr << "ERROR: Cannot write labelmap SEG due to overlapping segments at slice " << sliceNumber << "!" << endl;
-                releaseFGs();
-                return NULL;
-              }
-              frameData16[framePixelCnt] = segmentValue;
-            }
-            else
-            {
-              Uint8 segmentValue8 = static_cast<Uint8>(segmentValue);
-              Uint8 currentValue = frameData8[framePixelCnt];
-              if (currentValue != 0 && currentValue != segmentValue8)
-              {
-                cerr << "ERROR: Cannot write labelmap SEG due to overlapping segments at slice " << sliceNumber << "!" << endl;
-                releaseFGs();
-                return NULL;
-              }
-              frameData8[framePixelCnt] = segmentValue8;
-            }
-            frameHasForeground = true;
-          }
-        }
+        if (!composeLabelmapFrame(segmentations, fileLabelToSegmentNumber, sliceNumber, frameSize,
+                                  labelmapUse16Bit, frameData8, frameData16, frameHasForeground))
+          return NULL;
 
         if (skipEmptySlices && !frameHasForeground)
           continue;
@@ -674,85 +688,37 @@ namespace dcmqi {
         CHECK_COND(fgfc->setDimensionIndexValues(1, 0));
         CHECK_COND(fgfc->setDimensionIndexValues(outputFrameNumber, 1));
 
-        typename ImageSourceType::PointType sliceOriginPoint;
-        typename ImageSourceType::IndexType sliceOriginIndex;
-        sliceOriginIndex.Fill(0);
-        sliceOriginIndex[2] = sliceNumber;
-        segmentations[0]->TransformIndexToPhysicalPoint(sliceOriginIndex, sliceOriginPoint);
-        fgppp->setImagePositionPatient(
-            Helper::floatToStr(sliceOriginPoint[0]).c_str(),
-            Helper::floatToStr(sliceOriginPoint[1]).c_str(),
-            Helper::floatToStr(sliceOriginPoint[2]).c_str());
+        setPlanePositionToSlice(*fgppp, *segmentations[0], sliceNumber);
 
         perFrameFGs.clear();
-        perFrameFGs.push_back(fgppp);
-        perFrameFGs.push_back(fgfc);
+        perFrameFGs.push_back(fgppp.get());
+        perFrameFGs.push_back(fgfc.get());
 
-        OFVector<DcmItem*> siVector;
-        if (referencesGeometryCheck && hasDerivationImagesAny && !slice2derimgPerFile.empty())
+        // PerFrame FG: DerivationImageSequence, references the source frames of
+        // this slice across all segmentation files
+        bool frameHasReferences = false;
+        if (referencesGeometryCheck && hasDerivationImagesAny && !slice2framesPerFile.empty())
         {
-          std::set<int> referencedDatasetIndexes;
-          for (size_t segFileNumber = 0; segFileNumber < slice2derimgPerFile.size(); segFileNumber++)
+          std::set<size_t> referencedFrameIds;
+          for (size_t segFileNumber = 0; segFileNumber < slice2framesPerFile.size(); segFileNumber++)
           {
-            if (sliceNumber >= slice2derimgPerFile[segFileNumber].size())
+            if (sliceNumber >= slice2framesPerFile[segFileNumber].size())
               continue;
-            for (size_t derImageInstanceNum = 0;
-                 derImageInstanceNum < slice2derimgPerFile[segFileNumber][sliceNumber].size();
-                 derImageInstanceNum++)
-            {
-              referencedDatasetIndexes.insert(slice2derimgPerFile[segFileNumber][sliceNumber][derImageInstanceNum]);
-            }
+            referencedFrameIds.insert(slice2framesPerFile[segFileNumber][sliceNumber].begin(),
+                                      slice2framesPerFile[segFileNumber][sliceNumber].end());
           }
 
-          for (std::set<int>::const_iterator idxIt = referencedDatasetIndexes.begin(); idxIt != referencedDatasetIndexes.end(); ++idxIt)
+          if (!referencedFrameIds.empty())
           {
-            siVector.push_back(dcmDatasets[*idxIt]);
-          }
-
-          if (siVector.size() > 0)
-          {
-            perFrameFGs.push_back(fgder);
-            DerivationImageItem* derimgItem;
-            DSRBasicCodedEntry code_seg = CODE_DCM_Segmentation_113076;
-            CHECK_COND(fgder->addDerivationImageItem(CodeSequenceMacro(code_seg.CodeValue,
-                                                                       code_seg.CodingSchemeDesignator,
-                                                                       code_seg.CodeMeaning),
-                                                     "",
-                                                     derimgItem));
-
-            DSRBasicCodedEntry code = CODE_DCM_SourceImageForImageProcessingOperation;
-            OFVector<SourceImageItem*> srcimgItems;
-            CHECK_COND(derimgItem->addSourceImageItems(siVector,
-                                                       CodeSequenceMacro(code.CodeValue,
-                                                                         code.CodingSchemeDesignator,
-                                                                         code.CodeMeaning),
-                                                       srcimgItems));
-
-            if (!srcimgItems.empty())
-            {
-              ImageSOPInstanceReferenceMacro& instRef = srcimgItems[0]->getImageSOPInstanceReference();
-              OFString instanceUID;
-              CHECK_COND(instRef.getReferencedSOPClassUID(classUID));
-              CHECK_COND(instRef.getReferencedSOPInstanceUID(instanceUID));
-
-              if (instanceUIDs.find(instanceUID) == instanceUIDs.end())
-              {
-                SOPInstanceReferenceMacro* refinstancesItem = new SOPInstanceReferenceMacro();
-                CHECK_COND(refinstancesItem->setReferencedSOPClassUID(classUID));
-                CHECK_COND(refinstancesItem->setReferencedSOPInstanceUID(instanceUID));
-                refinstances.push_back(refinstancesItem);
-                instanceUIDs.insert(instanceUID);
-                uidnotfound++;
-              }
-              else
-              {
-                uidfound++;
-              }
-            }
+            vector<size_t> frameIds(referencedFrameIds.begin(), referencedFrameIds.end());
+            CHECK_COND(sourceIndex.addDerivationImageItem(*fgder, frameIds,
+                segmentationDerivationCode(), "", sourceImagePurposeOfReferenceCode()));
+            perFrameFGs.push_back(fgder.get());
+            frameHasReferences = true;
           }
         }
 
-        OFCondition frameAdded = labelMapUse16Bit
+        OFCondition frameAdded = labelmapUse16Bit
             ? segdoc->addFrame(frameData16.data(), 0, perFrameFGs)
             : segdoc->addFrame(frameData8.data(), 0, perFrameFGs);
         if (frameAdded.good())
@@ -761,7 +727,7 @@ namespace dcmqi {
           outputFrameNumber++;
         }
 
-        if (referencesGeometryCheck && siVector.size() > 0)
+        if (frameHasReferences)
         {
           fgder->clearData();
         }
@@ -772,7 +738,7 @@ namespace dcmqi {
     // segment plus Pixel Padding Value) if it occurs in any frame
     if (outputLabelMap)
     {
-      CHECK_COND(addBackgroundSegmentIfNeeded(segdoc));
+      CHECK_COND(addBackgroundSegmentIfNeeded(segdoc.get()));
     }
 
     if(framesAdded == 0){
@@ -781,13 +747,9 @@ namespace dcmqi {
       return NULL;
     }
 
-    // add ReferencedSeriesItem only if it is not empty
-    if(refinstances.size())
-      refseries.push_back(refseriesItem);
-
-    delete fgfc;
-    delete fgppp;
-    delete fgder;
+    // populate the Common Instance Reference module with the references
+    // accumulated while creating the derivation image items
+    CHECK_COND(sourceIndex.populateCommonInstanceReference(segdoc->getCommonInstanceReference()));
 
     segdoc->getSeries().setSeriesNumber(metaInfo.getSeriesNumber().c_str());
 
@@ -819,53 +781,7 @@ namespace dcmqi {
       return NULL;
     }
 
-    // Set reader/session/timepoint information
-    std::cout << "Patching in extra meta information into DICOM dataset" << std::endl;
-    CHECK_COND(segdocDataset->putAndInsertString(DCM_SeriesDescription, metaInfo.getSeriesDescription().c_str()));
-    CHECK_COND(segdocDataset->putAndInsertString(DCM_ContentCreatorName, metaInfo.getContentCreatorName().c_str()));
-    CHECK_COND(segdocDataset->putAndInsertString(DCM_ClinicalTrialSeriesID, metaInfo.getClinicalTrialSeriesID().c_str()));
-    CHECK_COND(segdocDataset->putAndInsertString(DCM_ClinicalTrialTimePointID, metaInfo.getClinicalTrialTimePointID().c_str()));
-    if (metaInfo.getClinicalTrialCoordinatingCenterName().size())
-      CHECK_COND(segdocDataset->putAndInsertString(DCM_ClinicalTrialCoordinatingCenterName, metaInfo.getClinicalTrialCoordinatingCenterName().c_str()));
-
-    // populate BodyPartExamined
-    {
-      OFString bodyPartStr;
-      string bodyPartAssigned = metaInfo.getBodyPartExamined();
-
-      // inherit BodyPartExamined from the source image dataset, if available
-      if(dcmDatasets[0]->findAndGetOFString(DCM_BodyPartExamined, bodyPartStr).good())
-      if(string(bodyPartStr.c_str()).size())
-        bodyPartAssigned = bodyPartStr.c_str();
-
-      if(bodyPartAssigned.size())
-        CHECK_COND(segdocDataset->putAndInsertString(DCM_BodyPartExamined, bodyPartAssigned.c_str()));
-    }
-
-    // StudyDate/Time should be of the series segmented, not when segmentation was made - this is initialized by DCMTK
-
-    // SeriesDate/Time should be of when segmentation was done; initialize to when it was saved
-    {
-      OFString contentDate, contentTime;
-      DcmDate::getCurrentDate(contentDate);
-      DcmTime::getCurrentTime(contentTime);
-
-      CHECK_COND(segdocDataset->putAndInsertString(DCM_SeriesDate, contentDate.c_str()));
-      CHECK_COND(segdocDataset->putAndInsertString(DCM_SeriesTime, contentTime.c_str()));
-      segdoc->getGeneralImage().setContentDate(contentDate.c_str());
-      segdoc->getGeneralImage().setContentTime(contentTime.c_str());
-    }
-
-    {
-      string segmentsOverlap;
-      if (outputLabelMap)
-        segmentsOverlap = "NO";
-      else if(segmentations.size() == 1)
-        segmentsOverlap = "NO";
-      else
-        segmentsOverlap = "UNDEFINED";
-      CHECK_COND(segdocDataset->putAndInsertString(DCM_SegmentsOverlap, segmentsOverlap.c_str()));
-    }
+    patchDerivedAttributes(*segdocDataset, *segdoc, metaInfo, *dcmDatasets[0], outputLabelMap, segmentations.size());
 
     if (useLabelIDAsSegmentNumber && !outputLabelMap)
     {

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -1,10 +1,13 @@
 
 // ITK includes
 #include <itkImageDuplicator.h>
-#include <itkCastImageFilter.h>
 
 // DCMQI includes
 #include "dcmqi/ParaMapConverter.h"
+#include "dcmqi/SourceImageIndex.h"
+
+// STD includes
+#include <memory>
 
 // DCMTK includes
 #include <dcmtk/config/osconfig.h>
@@ -251,110 +254,50 @@ namespace dcmqi {
     CHECK_COND(pMapDoc->addForAllFrames(rwvmFG));
 
     /* Map referenced instances to the ITK parametric map slices */
-    // this is a hack - the function below needs to be factored out
-    vector<vector<int> > slice2derimg;
-    bool hasDerivationImages = false;
+    // Inventory of the source images, used to map slices of the parametric map
+    // to the source frames and to create the references derived from that mapping
+    SourceImageIndex sourceIndex(dcmDatasets);
+    vector<vector<size_t> > slice2frames = sourceIndex.mapSlicesToFrames(*parametricMapImage);
     {
-
-      typedef itk::CastImageFilter<FloatImageType,ShortImageType> CastFilterType;
-      CastFilterType::Pointer cast = CastFilterType::New();
-      cast->SetInput(parametricMapImage);
-      cast->Update();
-      slice2derimg = getSliceMapForSegmentation2DerivationImage(dcmDatasets, cast->GetOutput());
       cout << "Mapping from the ITK image slices to the DICOM instances in the input list" << endl;
-      for(size_t i=0;i<slice2derimg.size();i++){
+      for(size_t i=0;i<slice2frames.size();i++){
         cout << "  Slice " << i << ": ";
-        for(size_t j=0;j<slice2derimg[i].size();j++){
-          cout << slice2derimg[i][j] << " ";
-          hasDerivationImages = true;
+        for(size_t j=0;j<slice2frames[i].size();j++){
+          cout << slice2frames[i][j] << " ";
         }
         cout << endl;
       }
     }
 
-    // TODO: factor initialization of the referenced instances out into Common class
-    IODCommonInstanceReferenceModule &commref = pMapDoc->getCommonInstanceReference();
-    OFVector<IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*> &refseries = commref.getReferencedSeriesItems();
-
-    IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem* refseriesItem = new IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem;
-
-    OFVector<SOPInstanceReferenceMacro*> &refinstances = refseriesItem->getReferencedInstanceItems();
-
-    OFString seriesInstanceUID, classUID;
-
-    CHECK_COND(dcmDatasets[0]->findAndGetOFString(DCM_SeriesInstanceUID, seriesInstanceUID));
-    CHECK_COND(refseriesItem->setSeriesInstanceUID(seriesInstanceUID));
-
-    FGPlanePosPatient* fgppp = FGPlanePosPatient::createMinimal("1","1","1");
-    FGFrameContent* fgfc = new FGFrameContent();
-    FGDerivationImage* fgder = new FGDerivationImage();
+    std::unique_ptr<FGPlanePosPatient> fgppp(FGPlanePosPatient::createMinimal("1","1","1"));
+    std::unique_ptr<FGFrameContent> fgfc(new FGFrameContent());
+    std::unique_ptr<FGDerivationImage> fgder(new FGDerivationImage());
     OFVector<FGBase*> perFrameFGs;
-
-    perFrameFGs.push_back(fgppp);
-    perFrameFGs.push_back(fgfc);
-    if(hasDerivationImages)
-      perFrameFGs.push_back(fgder);
 
     for (unsigned long sliceNumber = 0; result.good() && (sliceNumber < inputSize[2]); sliceNumber++) {
 
-      OFVector<DcmItem*> siVector;
-      for(size_t derImageInstanceNum=0;
-          derImageInstanceNum<slice2derimg[sliceNumber].size();
-          derImageInstanceNum++){
-        siVector.push_back(dcmDatasets[slice2derimg[sliceNumber][derImageInstanceNum]]);
-      }
+      perFrameFGs.clear();
+      perFrameFGs.push_back(fgppp.get());
+      perFrameFGs.push_back(fgfc.get());
 
-      int uidfound = 0, uidnotfound = 0;
-
-      if(siVector.size()>0){
-
-        set<OFString> instanceUIDs;
-
-        DerivationImageItem *derimgItem;
-
-        // TODO: I know David will not like this ...
-		DSRBasicCodedEntry code = CODE_DCM_ImageProcessing;
-        CodeSequenceMacro derivationCode = CodeSequenceMacro(code.CodeValue, code.CodingSchemeDesignator,
-			code.CodeMeaning);
+      // PerFrame FG: DerivationImageSequence, references the source frames
+      // this slice was derived from
+      bool frameHasReferences = false;
+      if(!slice2frames[sliceNumber].empty()){
 
         // Mandatory, defined in CID 7203
         // http://dicom.nema.org/medical/dicom/current/output/chtml/part16/sect_CID_7203.html
-        if(metaInfo.getDerivationCode() != NULL) {
-          CHECK_COND(fgder->addDerivationImageItem(*metaInfo.getDerivationCode(),
-                                                   metaInfo.getDerivationDescription().c_str(),
-                                                   derimgItem));
-        } else {
+        if(metaInfo.getDerivationCode() == NULL) {
           cerr << "ERROR: DerivationCode must be specified in the input metadata!" << endl;
           throw -1;
         }
 
-        OFVector<SourceImageItem*> srcimgItems;
-		DSRBasicCodedEntry code_src_img = CODE_DCM_SourceImageForImageProcessingOperation;
-
-        CHECK_COND(derimgItem->addSourceImageItems(siVector,
-                                                 CodeSequenceMacro(code_src_img.CodeValue, code_src_img.CodingSchemeDesignator,code_src_img.CodeMeaning),
-                                                 srcimgItems));
-
-        {
-          // initialize class UID and series instance UID
-          ImageSOPInstanceReferenceMacro &instRef = srcimgItems[0]->getImageSOPInstanceReference();
-          OFString instanceUID;
-
-          CHECK_COND(instRef.getReferencedSOPClassUID(classUID));
-          CHECK_COND(instRef.getReferencedSOPInstanceUID(instanceUID));
-
-          if(instanceUIDs.find(instanceUID) == instanceUIDs.end()){
-            SOPInstanceReferenceMacro *refinstancesItem = new SOPInstanceReferenceMacro();
-            CHECK_COND(refinstancesItem->setReferencedSOPClassUID(classUID));
-            CHECK_COND(refinstancesItem->setReferencedSOPInstanceUID(instanceUID));
-            refinstances.push_back(refinstancesItem);
-            instanceUIDs.insert(instanceUID);
-            uidnotfound++;
-          } else {
-            uidfound++;
-          }
-        }
-
+        DSRBasicCodedEntry code_src_img = CODE_DCM_SourceImageForImageProcessingOperation;
+        CHECK_COND(sourceIndex.addDerivationImageItem(*fgder, slice2frames[sliceNumber],
+            *metaInfo.getDerivationCode(), metaInfo.getDerivationDescription(),
+            CodeSequenceMacro(code_src_img.CodeValue, code_src_img.CodingSchemeDesignator, code_src_img.CodeMeaning)));
+        perFrameFGs.push_back(fgder.get());
+        frameHasReferences = true;
       }
 
       // addFrame
@@ -396,32 +339,21 @@ namespace dcmqi {
         // Frame Content
         OFCondition result = fgfc->setDimensionIndexValues(sliceNumber+1 /* value within dimension */, 0 /* first dimension */);
 
-#if ADD_DERIMG
-        // Already pushed above if siVector.size > 0
-        // if(fgder)
-          // perFrameFGs.push_back(fgder);
-#endif
-
         DPMParametricMapIOD::FramesType frames = pMapDoc->getFrames();
         result = OFget<DPMParametricMapIOD::Frames<FloatPixelType> >(&frames)->addFrame(&*data.begin(), frameSize, perFrameFGs);
 
         cout << "Frame " << sliceNumber << " added" << endl;
       }
 
-      // remove derivation image FG from the per-frame FGs, only if applicable!
-      if(!siVector.empty()){
-        // clean up for next frame
+      // clean up the derivation image FG for the next frame, only if applicable!
+      if(frameHasReferences){
         fgder->clearData();
       }
     }
 
-    // add ReferencedSeriesItem only if it is not empty
-    if(refinstances.size())
-      refseries.push_back(refseriesItem);
-
-    delete fgppp;
-    delete fgfc;
-    delete fgder;
+    // populate the Common Instance Reference module with the references
+    // accumulated while creating the derivation image items
+    CHECK_COND(sourceIndex.populateCommonInstanceReference(pMapDoc->getCommonInstanceReference()));
 
     string bodyPartAssigned = metaInfo.getBodyPartExamined();
     if(srcDataset != NULL && bodyPartAssigned.empty()) {

--- a/libsrc/SourceImageIndex.cpp
+++ b/libsrc/SourceImageIndex.cpp
@@ -1,0 +1,202 @@
+
+// DCMQI includes
+#include "dcmqi/SourceImageIndex.h"
+
+// DCMTK includes
+#include <dcmtk/dcmdata/dcdeftag.h>
+
+// ITK includes
+#include <itkPoint.h>
+
+// STD includes
+#include <cstdlib>
+#include <iostream>
+#include <map>
+
+namespace dcmqi {
+
+  SourceImageIndex::SourceImageIndex(const vector<DcmItem*>& datasets)
+    : m_datasets(datasets)
+  {
+    m_instances.resize(m_datasets.size());
+    for(size_t i=0;i<m_datasets.size();i++){
+      DcmItem* dataset = m_datasets[i];
+      InstanceInfo& info = m_instances[i];
+
+      dataset->findAndGetOFString(DCM_SeriesInstanceUID, info.seriesInstanceUID);
+      dataset->findAndGetOFString(DCM_SOPClassUID, info.sopClassUID);
+      dataset->findAndGetOFString(DCM_SOPInstanceUID, info.sopInstanceUID);
+      Sint32 numberOfFrames = 0;
+      if(dataset->findAndGetSint32(DCM_NumberOfFrames, numberOfFrames).bad() || numberOfFrames < 0)
+        numberOfFrames = 0;
+      info.numberOfFrames = OFstatic_cast(Uint32, numberOfFrames);
+
+      // classic single-frame instance: one source frame, position from the
+      // top-level Image Position (Patient)
+      SourceFrame frame;
+      frame.datasetIndex = i;
+      frame.frameNumber = 0;
+      frame.hasPosition = true;
+      for(int j=0;j<3;j++){
+        OFString ippStr;
+        if(dataset->findAndGetOFString(DCM_ImagePositionPatient, ippStr, j).good()){
+          frame.position[j] = atof(ippStr.c_str());
+        } else {
+          frame.hasPosition = false;
+          break;
+        }
+      }
+      if(!frame.hasPosition)
+        cerr << "WARNING: Source image " << info.sopInstanceUID << " has no Image Position (Patient), "
+             << "it cannot be mapped to slices of the converted image" << endl;
+      m_frames.push_back(frame);
+    }
+  }
+
+  // -------------------------------------------------------------------------------------
+
+  vector<vector<size_t> > SourceImageIndex::mapSlicesToFrames(const itk::ImageBase<3>& geometry) const {
+    // Find mapping from the slice number of the converted image to the source frames.
+    // Assume that orientation of the converted image is the same as the source series.
+    const unsigned numSlices = geometry.GetLargestPossibleRegion().GetSize()[2];
+    vector<vector<size_t> > slice2frames(numSlices);
+
+    unsigned slicesMapped = 0;
+    for(size_t frameId=0;frameId<m_frames.size();frameId++){
+      const SourceFrame& frame = m_frames[frameId];
+      if(!frame.hasPosition)
+        continue;
+      itk::Point<double,3> position;
+      for(int j=0;j<3;j++)
+        position[j] = frame.position[j];
+      itk::ImageBase<3>::IndexType index;
+      if(!geometry.TransformPhysicalPointToIndex(position, index)){
+        // if a source frame does not map to a slice, just skip it
+        continue;
+      }
+      if(slice2frames[index[2]].empty())
+        slicesMapped++;
+      slice2frames[index[2]].push_back(frameId);
+    }
+    cout << slicesMapped << " of " << numSlices << " slices mapped to source DICOM images" << endl;
+    return slice2frames;
+  }
+
+  // -------------------------------------------------------------------------------------
+
+  OFCondition SourceImageIndex::addDerivationImageItem(FGDerivationImage& fgder,
+                                                       const vector<size_t>& frameIds,
+                                                       const CodeSequenceMacro& derivationCode,
+                                                       const string& derivationDescription,
+                                                       const CodeSequenceMacro& purposeOfReference)
+  {
+    if(frameIds.empty())
+      return EC_Normal;
+
+    DerivationImageItem* derimgItem = NULL;
+    OFCondition result = fgder.addDerivationImageItem(derivationCode, derivationDescription.c_str(), derimgItem);
+    if(result.bad())
+      return result;
+
+    // group the frames by the instance they belong to, in order of first appearance
+    vector<size_t> datasetOrder;
+    map<size_t, vector<Uint32> > dataset2frameNumbers;
+    for(size_t i=0;i<frameIds.size();i++){
+      const SourceFrame& frame = m_frames[frameIds[i]];
+      if(dataset2frameNumbers.find(frame.datasetIndex) == dataset2frameNumbers.end())
+        datasetOrder.push_back(frame.datasetIndex);
+      dataset2frameNumbers[frame.datasetIndex].push_back(frame.frameNumber);
+    }
+
+    for(size_t i=0;i<datasetOrder.size();i++){
+      const size_t datasetIndex = datasetOrder[i];
+      SourceImageItem* srcimgItem = NULL;
+      result = derimgItem->addSourceImageItem(m_datasets[datasetIndex], purposeOfReference, srcimgItem);
+      if(result.bad())
+        return result;
+      recordReferencedInstance(datasetIndex);
+    }
+    return EC_Normal;
+  }
+
+  // -------------------------------------------------------------------------------------
+
+  OFCondition SourceImageIndex::addWholeInstanceDerivationImageItem(FGDerivationImage& fgder,
+                                                                    const CodeSequenceMacro& derivationCode,
+                                                                    const string& derivationDescription,
+                                                                    const CodeSequenceMacro& purposeOfReference)
+  {
+    DerivationImageItem* derimgItem = NULL;
+    OFCondition result = fgder.addDerivationImageItem(derivationCode, derivationDescription.c_str(), derimgItem);
+    if(result.bad())
+      return result;
+
+    for(size_t i=0;i<m_datasets.size();i++){
+      SourceImageItem* srcimgItem = NULL;
+      if(derimgItem->addSourceImageItem(m_datasets[i], purposeOfReference, srcimgItem).bad()){
+        cerr << "WARNING: Failed to reference source image " << m_instances[i].sopInstanceUID
+             << ", skipping it" << endl;
+        continue;
+      }
+      recordReferencedInstance(i);
+    }
+    return EC_Normal;
+  }
+
+  // -------------------------------------------------------------------------------------
+
+  OFCondition SourceImageIndex::populateCommonInstanceReference(IODCommonInstanceReferenceModule& commref) const {
+    if(m_referencedDatasets.empty())
+      return EC_Normal;
+
+    OFVector<IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*>& refseries = commref.getReferencedSeriesItems();
+
+    // group the referenced instances by series, both in order of first reference;
+    // the created items are owned by the module
+    map<OFString, IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*> series2item;
+    for(size_t i=0;i<m_referencedDatasets.size();i++){
+      const InstanceInfo& info = m_instances[m_referencedDatasets[i]];
+
+      IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem* refseriesItem = NULL;
+      map<OFString, IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*>::iterator seriesIt =
+          series2item.find(info.seriesInstanceUID);
+      if(seriesIt == series2item.end()){
+        refseriesItem = new IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem();
+        OFCondition result = refseriesItem->setSeriesInstanceUID(info.seriesInstanceUID);
+        if(result.bad()){
+          delete refseriesItem;
+          return result;
+        }
+        series2item[info.seriesInstanceUID] = refseriesItem;
+        refseries.push_back(refseriesItem);
+      } else {
+        refseriesItem = seriesIt->second;
+      }
+
+      SOPInstanceReferenceMacro* refinstancesItem = new SOPInstanceReferenceMacro();
+      OFCondition result = refinstancesItem->setReferencedSOPClassUID(info.sopClassUID);
+      if(result.good())
+        result = refinstancesItem->setReferencedSOPInstanceUID(info.sopInstanceUID);
+      if(result.bad()){
+        delete refinstancesItem;
+        return result;
+      }
+      refseriesItem->getReferencedInstanceItems().push_back(refinstancesItem);
+    }
+    return EC_Normal;
+  }
+
+  // -------------------------------------------------------------------------------------
+
+  const vector<SourceImageIndex::SourceFrame>& SourceImageIndex::getFrames() const {
+    return m_frames;
+  }
+
+  // -------------------------------------------------------------------------------------
+
+  void SourceImageIndex::recordReferencedInstance(size_t datasetIndex) {
+    if(m_referencedDatasetSet.insert(datasetIndex).second)
+      m_referencedDatasets.push_back(datasetIndex);
+  }
+
+}


### PR DESCRIPTION
Refactoring of `itkimage2segimage` and `itkimage2paramap`, with no intended
change in behavior. It stands on its own, but is also the groundwork for
multiframe source support, which follows in a separate PR.

Fixes #192.

## Why

The slice-to-instance mapping and the code building the source image
references lived inline in `Itk2DicomConverter.cpp`, copy-pasted three times
within `itkimage2dcmSegmentation()` and a fourth time in `ParaMapConverter`.
That function had grown to ~840 lines, holding the whole conversion in one
body, and the duplication had started to drift apart between the copies.

## What changes

**A new `SourceImageIndex` component** (`include/dcmqi/SourceImageIndex.h`,
`libsrc/SourceImageIndex.cpp`) owns everything about the source images:
normalizing the datasets into a list of referenceable frames, mapping the
slices of the converted image onto them by geometry, and creating the
Derivation Image items plus the Common Instance Reference module from that
mapping. Both converters use it, which removes the duplication and lets the
PM converter drop its `CastImageFilter` workaround (the mapping now works on
`itk::ImageBase` geometry directly).

**Three components carved out of the SEG converter**, each with a concrete
reason rather than just moving lines:

- `PerFrameFunctionalGroups` owns the functional groups reused for every frame
  and enforces the protocol they need. The rule "clear the derivation image
  group after the frame was added, or the next frame inherits its references"
  was previously written out twice and left to caller discipline.
- `SegmentNumberAssigner` owns the segment numbering scheme and the mappings
  derived from it. The rules were restated in four places, including a second
  implementation of the labelmap bit depth inside the document creation.
- `SegmentationEncoder` turns the conversion into named steps
  (`createDocument()`, `addSharedFunctionalGroups()`, `mapSourceFrames()`,
  `encodeSegments()`, `encodeLabelmapFrames()`, `writeDocument()`). These share
  so much state that as free functions they would have needed a dozen
  parameters each; as members of one class they take none or few.

`itkimage2dcmSegmentation()` is now a 35-line wrapper. The public signatures
and the explicit template instantiations are unchanged.

## Behavior

Intended to be behavior-preserving, with four deliberate edge-case fixes in
the first commit, all in situations that previously produced questionable
output:

1. Frames whose slice has no mapped source no longer get an empty (and
   therefore invalid) `DerivationImageSequence` when other slices of the same
   input file do have references.
2. All instances referenced by a frame now reach `ReferencedSeriesSequence`;
   previously only the first one per frame did.
3. Labelmap frame bit depth now always matches the document bit depth. It
   could differ for gapped label IDs above 255.
4. Referenced instances are grouped by their actual series instead of all
   being attributed to the series of the first input dataset.

## Verification

- The existing test suite passes (76 tests).
- Each of the five commits was additionally checked by dcmdump-diffing 19
  conversion variants against a build of the preceding state: binary,
  labelmap, multiple input files, label IDs as segment numbers, gapped label
  IDs, overlapping segments, geometry check disabled, empty slices skipped and
  not skipped, and parametric maps. All byte-identical apart from UIDs and
  timestamps, including the console output.
- Because the later commits move error handling that none of those variants
  reach, the error paths were compared separately against a build of the
  original code: colliding label IDs across input files in both output
  flavors, a segment number beyond the 16 bit pixel range, and a label without
  metadata. Identical exit codes and identical messages.
- Compiles clean under `-Wall -Wextra -Wreorder`.

## Review order

The commits are meant to be read in order; each is self-contained and
individually verified. The first is the largest and carries the edge-case
fixes listed above.
