### PR TITLE
Handle cross-study source references correctly

### DIFF
--- a/apps/seg/Testing/CommonInstanceReferenceTest.cxx
+++ b/apps/seg/Testing/CommonInstanceReferenceTest.cxx
@@ -14,9 +14,11 @@
 //     Series Sequence must group instances by the series they actually belong
 //     to; previously all instances were attributed to the series of the first
 //     input dataset.
-//
-// Cross-study references (Studies Containing Other Referenced Instances
-// Sequence) are out of scope here and not supported yet.
+//  3. An instance from a different study. It must be filed under its Study
+//     Instance UID in the Studies Containing Other Referenced Instances
+//     Sequence (PS3.3 C.12.2), not in the Referenced Series Sequence, whose
+//     items implicitly belong to the study of the created object; previously
+//     it ended up there.
 
 #include "dcmqi/Itk2DicomConverter.h"
 
@@ -75,9 +77,11 @@ DcmDataset* loadDataset(const std::string& path)
 }
 
 // Copy of the given dataset with a fresh SOP Instance UID and, if requested,
-// a fresh Series Instance UID; geometry and everything else stay identical.
+// a fresh Series and/or Study Instance UID; geometry and everything else stay
+// identical.
 DcmDataset* deriveInstance(DcmDataset& original, OFString& sopInstanceUID,
-                           const bool newSeries, OFString& seriesInstanceUID)
+                           const bool newSeries, OFString& seriesInstanceUID,
+                           const bool newStudy, OFString& studyInstanceUID)
 {
   std::unique_ptr<DcmDataset> copy(OFstatic_cast(DcmDataset*, original.clone()));
   char uid[100];
@@ -91,7 +95,14 @@ DcmDataset* deriveInstance(DcmDataset& original, OFString& sopInstanceUID,
                                  dcmGenerateUniqueIdentifier(uid, SITE_SERIES_UID_ROOT)).bad())
       return nullptr;
   }
+  if (newStudy)
+  {
+    if (copy->putAndInsertString(DCM_StudyInstanceUID,
+                                 dcmGenerateUniqueIdentifier(uid, SITE_STUDY_UID_ROOT)).bad())
+      return nullptr;
+  }
   copy->findAndGetOFString(DCM_SeriesInstanceUID, seriesInstanceUID);
+  copy->findAndGetOFString(DCM_StudyInstanceUID, studyInstanceUID);
   return copy.release();
 }
 
@@ -169,21 +180,32 @@ int main(int argc, char* argv[])
     uids.push_back(uid);
   }
 
+  OFString firstStudyUID;
+  REQUIRE(OFstatic_cast(DcmDataset*, datasets[0])->findAndGetOFString(DCM_StudyInstanceUID, firstStudyUID).good());
+
   // a second instance on the plane of the first one, same series (issue #554)
-  OFString duplicateUID, duplicateSeriesUID;
+  OFString duplicateUID, duplicateSeriesUID, duplicateStudyUID;
   DcmDataset* duplicate = deriveInstance(*OFstatic_cast(DcmDataset*, datasets[0]),
-                                         duplicateUID, false, duplicateSeriesUID);
+                                         duplicateUID, false, duplicateSeriesUID, false, duplicateStudyUID);
   REQUIRE(duplicate != nullptr);
   REQUIRE(duplicateSeriesUID == firstSeriesUID);
   datasets.push_back(duplicate);
 
   // an instance on the plane of the second one, from a second series
-  OFString otherSeriesInstanceUID, otherSeriesUID;
+  OFString otherSeriesInstanceUID, otherSeriesUID, otherSeriesStudyUID;
   DcmDataset* otherSeries = deriveInstance(*OFstatic_cast(DcmDataset*, datasets[1]),
-                                           otherSeriesInstanceUID, true, otherSeriesUID);
+                                           otherSeriesInstanceUID, true, otherSeriesUID, false, otherSeriesStudyUID);
   REQUIRE(otherSeries != nullptr);
   REQUIRE(otherSeriesUID != firstSeriesUID);
   datasets.push_back(otherSeries);
+
+  // an instance on the plane of the third one, from a different study
+  OFString foreignUID, foreignSeriesUID, foreignStudyUID;
+  DcmDataset* foreign = deriveInstance(*OFstatic_cast(DcmDataset*, datasets[2]),
+                                       foreignUID, true, foreignSeriesUID, true, foreignStudyUID);
+  REQUIRE(foreign != nullptr);
+  REQUIRE(foreignStudyUID != firstStudyUID);
+  datasets.push_back(foreign);
 
   std::unique_ptr<DcmDataset> seg(
       dcmqi::Itk2DicomConverter::itkimage2dcmSegmentation(datasets, segmentations, metadata,
@@ -196,21 +218,27 @@ int main(int argc, char* argv[])
   std::set<OFString> frameUnion;
   unsigned framesWithDuplicatePair = 0;
   unsigned framesWithOtherSeriesPair = 0;
+  unsigned framesWithForeignPair = 0;
   for (const std::set<OFString>& refs : perFrame)
   {
     frameUnion.insert(refs.begin(), refs.end());
     REQUIRE(refs.count(uids[0]) == refs.count(duplicateUID));
     REQUIRE(refs.count(uids[1]) == refs.count(otherSeriesInstanceUID));
+    REQUIRE(refs.count(uids[2]) == refs.count(foreignUID));
     if (refs.count(duplicateUID))
       framesWithDuplicatePair++;
     if (refs.count(otherSeriesInstanceUID))
       framesWithOtherSeriesPair++;
+    if (refs.count(foreignUID))
+      framesWithForeignPair++;
   }
   REQUIRE(framesWithDuplicatePair > 0);
   REQUIRE(framesWithOtherSeriesPair > 0);
+  REQUIRE(framesWithForeignPair > 0);
 
-  // Common Instance Reference module: every instance referenced by any frame,
-  // grouped by the series it actually belongs to
+  // Common Instance Reference module: every same-study instance referenced by
+  // any frame, grouped by the series it actually belongs to - and nothing from
+  // a foreign study
   DcmSequenceOfItems* refSeriesSeq = nullptr;
   REQUIRE(seg->findAndGetSequence(DCM_ReferencedSeriesSequence, refSeriesSeq).good() && refSeriesSeq);
   REQUIRE(refSeriesSeq->card() == 2);
@@ -232,15 +260,41 @@ int main(int argc, char* argv[])
       cirUnion.insert(uid);
     }
   }
+  REQUIRE(cirUnion.count(foreignUID) == 0);
+
+  // the foreign-study instance goes into the Studies Containing Other
+  // Referenced Instances Sequence, under its own study and series
+  DcmSequenceOfItems* studiesSeq = nullptr;
+  REQUIRE(seg->findAndGetSequence(DCM_StudiesContainingOtherReferencedInstancesSequence, studiesSeq).good()
+          && studiesSeq);
+  REQUIRE(studiesSeq->card() == 1);
+  {
+    DcmItem* studyItem = studiesSeq->getItem(0);
+    OFString studyUID;
+    REQUIRE(studyItem->findAndGetOFString(DCM_StudyInstanceUID, studyUID).good());
+    REQUIRE(studyUID == foreignStudyUID);
+    DcmItem* seriesItem = nullptr;
+    REQUIRE(studyItem->findAndGetSequenceItem(DCM_ReferencedSeriesSequence, seriesItem, 0).good() && seriesItem);
+    OFString seriesUID;
+    REQUIRE(seriesItem->findAndGetOFString(DCM_SeriesInstanceUID, seriesUID).good());
+    REQUIRE(seriesUID == foreignSeriesUID);
+    DcmItem* instanceItem = nullptr;
+    REQUIRE(seriesItem->findAndGetSequenceItem(DCM_ReferencedInstanceSequence, instanceItem, 0).good() && instanceItem);
+    OFString uid;
+    REQUIRE(instanceItem->findAndGetOFString(DCM_ReferencedSOPInstanceUID, uid).good());
+    REQUIRE(uid == foreignUID);
+    cirUnion.insert(uid);
+  }
 
   // the actual issue-554 assertion: nothing referenced by a frame may be
   // missing from the Common Instance Reference module (and vice versa)
   REQUIRE(cirUnion == frameUnion);
   REQUIRE(cirUnion.count(duplicateUID) == 1);
 
-  // series grouping
+  // series grouping within this object's study
   std::set<OFString> expectedFirstSeries = frameUnion;
   expectedFirstSeries.erase(otherSeriesInstanceUID);
+  expectedFirstSeries.erase(foreignUID);
   REQUIRE(seriesToInstances.count(firstSeriesUID) == 1);
   REQUIRE(seriesToInstances.count(otherSeriesUID) == 1);
   REQUIRE(seriesToInstances[firstSeriesUID] == expectedFirstSeries);
@@ -249,6 +303,7 @@ int main(int argc, char* argv[])
   for (DcmItem* item : datasets) { delete item; }
 
   std::cout << "PASS: instances sharing a frame are all present in the Common Instance "
-            << "Reference module, grouped by the series they belong to." << std::endl;
+            << "Reference module, grouped by the series they belong to, and foreign-study "
+            << "instances are filed under their study." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/include/dcmqi/SourceImageIndex.h
+++ b/include/dcmqi/SourceImageIndex.h
@@ -2,6 +2,7 @@
 #define DCMQI_SOURCEIMAGEINDEX_H
 
 // STD includes
+#include <map>
 #include <set>
 #include <string>
 #include <vector>
@@ -28,8 +29,10 @@ namespace dcmqi {
    * slices of the ITK image being converted to those frames by geometry, and
    * creates the DICOM references derived from that mapping:
    * - Derivation Image functional group items with their Source Image Sequence,
-   * - the Referenced Series Sequence of the Common Instance Reference module,
-   *   fed by the instances referenced through the derivation items.
+   * - the Common Instance Reference module, fed by the instances referenced
+   *   through the derivation items: instances from the study of the created
+   *   object go into its Referenced Series Sequence, instances from other
+   *   studies into its Studies Containing Other Referenced Instances Sequence.
    *
    * Factored out of the SEG and PM converters
    * (https://github.com/QIICR/dcmqi/issues/192).
@@ -115,16 +118,26 @@ namespace dcmqi {
                                                     const CodeSequenceMacro& purposeOfReference);
 
     /**
-     * @brief Populate the Referenced Series Sequence of the given Common Instance
-     * Reference module with the instances referenced so far.
+     * @brief Populate the given Common Instance Reference module with the
+     * instances referenced so far.
      *
-     * Instances are grouped by their Series Instance UID, in order of first
-     * reference. No-op if no instance has been referenced.
+     * Instances that belong to the study of the created object go into the
+     * Referenced Series Sequence; instances from other studies are filed under
+     * their Study Instance UID in the Studies Containing Other Referenced
+     * Instances Sequence, as required by PS3.3 C.12.2. Within either, instances
+     * are grouped by their Series Instance UID, in order of first reference.
+     * No-op if no instance has been referenced.
+     *
+     * Source instances without a Study Instance UID, and all instances if
+     * objectStudyInstanceUID is empty, are treated as belonging to the study
+     * of the created object (with a warning for the former).
      *
      * @param commref Common Instance Reference module of the target object.
+     * @param objectStudyInstanceUID Study Instance UID of the object being created.
      * @return EC_Normal on success, error otherwise.
      */
-    OFCondition populateCommonInstanceReference(IODCommonInstanceReferenceModule& commref) const;
+    OFCondition populateCommonInstanceReference(IODCommonInstanceReferenceModule& commref,
+                                                const OFString& objectStudyInstanceUID) const;
 
     /**
      * @brief Access the frame inventory (indexed by the ids used in the mapping methods).
@@ -135,6 +148,7 @@ namespace dcmqi {
 
     /// Cached per-dataset identification, parallel to m_datasets
     struct InstanceInfo {
+      OFString studyInstanceUID;
       OFString seriesInstanceUID;
       OFString sopClassUID;
       OFString sopInstanceUID;
@@ -143,6 +157,13 @@ namespace dcmqi {
 
     /// Remember that an instance is referenced (deduplicated by dataset index)
     void recordReferencedInstance(size_t datasetIndex);
+
+    /// Append one instance reference to the series list, creating the series
+    /// item (tracked in series2item, owned by the list) on first use
+    static OFCondition addToSeriesLevelReferences(
+        OFVector<IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*>& refseries,
+        map<OFString, IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*>& series2item,
+        const InstanceInfo& info);
 
     vector<DcmItem*> m_datasets;
     vector<InstanceInfo> m_instances;

--- a/libsrc/Itk2DicomConverter.cpp
+++ b/libsrc/Itk2DicomConverter.cpp
@@ -912,8 +912,12 @@ namespace dcmqi {
        *  have to be patched into the written dataset */
       DcmDataset* writeDocument() {
         // populate the Common Instance Reference module with the references
-        // accumulated while creating the derivation image items
-        CHECK_COND(m_sourceIndex.populateCommonInstanceReference(m_segdoc->getCommonInstanceReference()));
+        // accumulated while creating the derivation image items; the study of
+        // this object decides which of its two sequences a reference goes into
+        OFString objectStudyInstanceUID;
+        m_segdoc->getStudy().getStudyInstanceUID(objectStudyInstanceUID);
+        CHECK_COND(m_sourceIndex.populateCommonInstanceReference(m_segdoc->getCommonInstanceReference(),
+                                                                 objectStudyInstanceUID));
 
         m_segdoc->getSeries().setSeriesNumber(m_metaInfo.getSeriesNumber().c_str());
 

--- a/libsrc/ParaMapConverter.cpp
+++ b/libsrc/ParaMapConverter.cpp
@@ -355,8 +355,12 @@ namespace dcmqi {
     }
 
     // populate the Common Instance Reference module with the references
-    // accumulated while creating the derivation image items
-    CHECK_COND(sourceIndex.populateCommonInstanceReference(pMapDoc->getCommonInstanceReference()));
+    // accumulated while creating the derivation image items; the study of
+    // this object decides which of its two sequences a reference goes into
+    OFString objectStudyInstanceUID;
+    pMapDoc->getStudy().getStudyInstanceUID(objectStudyInstanceUID);
+    CHECK_COND(sourceIndex.populateCommonInstanceReference(pMapDoc->getCommonInstanceReference(),
+                                                           objectStudyInstanceUID));
 
     string bodyPartAssigned = metaInfo.getBodyPartExamined();
     if(srcDataset != NULL && bodyPartAssigned.empty()) {

--- a/libsrc/SourceImageIndex.cpp
+++ b/libsrc/SourceImageIndex.cpp
@@ -23,6 +23,7 @@ namespace dcmqi {
       DcmItem* dataset = m_datasets[i];
       InstanceInfo& info = m_instances[i];
 
+      dataset->findAndGetOFString(DCM_StudyInstanceUID, info.studyInstanceUID);
       dataset->findAndGetOFString(DCM_SeriesInstanceUID, info.seriesInstanceUID);
       dataset->findAndGetOFString(DCM_SOPClassUID, info.sopClassUID);
       dataset->findAndGetOFString(DCM_SOPInstanceUID, info.sopInstanceUID);
@@ -145,44 +146,91 @@ namespace dcmqi {
 
   // -------------------------------------------------------------------------------------
 
-  OFCondition SourceImageIndex::populateCommonInstanceReference(IODCommonInstanceReferenceModule& commref) const {
+  OFCondition SourceImageIndex::populateCommonInstanceReference(IODCommonInstanceReferenceModule& commref,
+                                                                const OFString& objectStudyInstanceUID) const {
     if(m_referencedDatasets.empty())
       return EC_Normal;
 
-    OFVector<IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*>& refseries = commref.getReferencedSeriesItems();
-
-    // group the referenced instances by series, both in order of first reference;
-    // the created items are owned by the module
+    // instances from the study of the created object, grouped by series
     map<OFString, IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*> series2item;
+    // instances from other studies, grouped by study and, within it, by series
+    map<OFString, IODCommonInstanceReferenceModule::StudiesOtherInstancesItem*> study2item;
+    map<OFString, map<OFString, IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*> > foreignSeries2item;
+
+    // all in order of first reference; the created items are owned by the module
     for(size_t i=0;i<m_referencedDatasets.size();i++){
       const InstanceInfo& info = m_instances[m_referencedDatasets[i]];
 
-      IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem* refseriesItem = NULL;
-      map<OFString, IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*>::iterator seriesIt =
-          series2item.find(info.seriesInstanceUID);
-      if(seriesIt == series2item.end()){
-        refseriesItem = new IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem();
-        OFCondition result = refseriesItem->setSeriesInstanceUID(info.seriesInstanceUID);
-        if(result.bad()){
-          delete refseriesItem;
-          return result;
-        }
-        series2item[info.seriesInstanceUID] = refseriesItem;
-        refseries.push_back(refseriesItem);
-      } else {
-        refseriesItem = seriesIt->second;
-      }
+      if(info.studyInstanceUID.empty() && !objectStudyInstanceUID.empty())
+        cerr << "WARNING: Source image " << info.sopInstanceUID << " has no Study Instance UID, "
+             << "referencing it as part of this object's study" << endl;
 
-      SOPInstanceReferenceMacro* refinstancesItem = new SOPInstanceReferenceMacro();
-      OFCondition result = refinstancesItem->setReferencedSOPClassUID(info.sopClassUID);
-      if(result.good())
-        result = refinstancesItem->setReferencedSOPInstanceUID(info.sopInstanceUID);
+      const bool foreignStudy = !info.studyInstanceUID.empty()
+          && !objectStudyInstanceUID.empty()
+          && info.studyInstanceUID != objectStudyInstanceUID;
+
+      OFCondition result;
+      if(!foreignStudy){
+        result = addToSeriesLevelReferences(commref.getReferencedSeriesItems(), series2item, info);
+      } else {
+        // Studies Containing Other Referenced Instances Sequence (PS3.3 C.12.2):
+        // one item per foreign study, holding its own series/instance references
+        IODCommonInstanceReferenceModule::StudiesOtherInstancesItem* studyItem = NULL;
+        map<OFString, IODCommonInstanceReferenceModule::StudiesOtherInstancesItem*>::iterator studyIt =
+            study2item.find(info.studyInstanceUID);
+        if(studyIt == study2item.end()){
+          studyItem = new IODCommonInstanceReferenceModule::StudiesOtherInstancesItem();
+          result = studyItem->setStudyInstanceUID(info.studyInstanceUID);
+          if(result.bad()){
+            delete studyItem;
+            return result;
+          }
+          study2item[info.studyInstanceUID] = studyItem;
+          commref.getStudiesContainingOtherReferences().push_back(studyItem);
+        } else {
+          studyItem = studyIt->second;
+        }
+        result = addToSeriesLevelReferences(
+            studyItem->getReferencedSeriesAndInstanceReferences().getReferencedSeriesItems(),
+            foreignSeries2item[info.studyInstanceUID], info);
+      }
+      if(result.bad())
+        return result;
+    }
+    return EC_Normal;
+  }
+
+  // -------------------------------------------------------------------------------------
+
+  OFCondition SourceImageIndex::addToSeriesLevelReferences(
+      OFVector<IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*>& refseries,
+      map<OFString, IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*>& series2item,
+      const InstanceInfo& info) {
+    IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem* refseriesItem = NULL;
+    map<OFString, IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem*>::iterator seriesIt =
+        series2item.find(info.seriesInstanceUID);
+    if(seriesIt == series2item.end()){
+      refseriesItem = new IODSeriesAndInstanceReferenceMacro::ReferencedSeriesItem();
+      OFCondition result = refseriesItem->setSeriesInstanceUID(info.seriesInstanceUID);
       if(result.bad()){
-        delete refinstancesItem;
+        delete refseriesItem;
         return result;
       }
-      refseriesItem->getReferencedInstanceItems().push_back(refinstancesItem);
+      series2item[info.seriesInstanceUID] = refseriesItem;
+      refseries.push_back(refseriesItem);
+    } else {
+      refseriesItem = seriesIt->second;
     }
+
+    SOPInstanceReferenceMacro* refinstancesItem = new SOPInstanceReferenceMacro();
+    OFCondition result = refinstancesItem->setReferencedSOPClassUID(info.sopClassUID);
+    if(result.good())
+      result = refinstancesItem->setReferencedSOPInstanceUID(info.sopInstanceUID);
+    if(result.bad()){
+      delete refinstancesItem;
+      return result;
+    }
+    refseriesItem->getReferencedInstanceItems().push_back(refinstancesItem);
     return EC_Normal;
   }
 


### PR DESCRIPTION
Follow-up to the cross-study gap discussed in #554: the Common Instance
Reference module filed every referenced source instance in
`ReferencedSeriesSequence`, whose items implicitly belong to the study of the
created object. References to images from another study were therefore
misfiled — hierarchical resolution (PACS prefetch, DICOMweb) looks in the
wrong study — and the type 1C condition of
`StudiesContainingOtherReferencedInstancesSequence` was violated.

`SourceImageIndex` now records the Study Instance UID of every source dataset,
and `populateCommonInstanceReference()` takes the study of the created object:
same-study instances go into `ReferencedSeriesSequence` as before, foreign
ones are filed under their study in the studies sequence, grouped by series
within. Instances without a Study Instance UID are treated as same-study, with
a warning. Both converters pass their document's study; no DCMTK changes
needed.

Out of scope (pre-existing): with mixed-study input, the study of the created
object itself still follows the first input dataset, and the geometric mapping
does not check Frame of Reference UIDs.

**Tests:** `CommonInstanceReferenceTest` derives an in-memory instance with a
foreign Study/Series/SOP Instance UID and asserts it is referenced per frame,
absent from `ReferencedSeriesSequence`, and filed under exactly its study and
series; the assertion fails with the routing disabled. Single-study outputs
stay identical to a master build; dciodvfy accepts the cross-study output.

Note: this PR and #558 both touch `SourceImageIndex`; whichever merges second
gets a small rebase.